### PR TITLE
Mouse Cursor Extension

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -54,7 +54,7 @@
         }
 
         GetCur() {
-            return this.stage.style.cursor;
+            return this.stage.style.cursor || 'default';
         }
     }
 

--- a/cursor.js
+++ b/cursor.js
@@ -30,11 +30,6 @@
                         "text": "hide cursor",
                     },
                     {
-                        "opcode": "reset",
-                        "blockType": "command",
-                        "text": "reset cursor",
-                    },
-                    {
                         "opcode": "GetCur",
                         "blockType": "reporter",
                         "text": "cursor",
@@ -56,10 +51,6 @@
 
         hide() {
             this.stage.style.cursor = "none";
-        }
-
-        reset() {
-            this.stage.style.cursor = "auto";
         }
 
         GetCur() {

--- a/cursor.js
+++ b/cursor.js
@@ -8,39 +8,48 @@
 
         getInfo() {
             return {
-                "id": "MouseCursor",
-                "name": "Mouse Cursor",
-                "blocks": [
-                    {
-                        "opcode": "SwitchCur",
-                        "blockType": "command",
-                        "text": "switch cursor to [cur]",
-                        "arguments": {
-                            "cur": {
-                                "type": "string",
-                                "defaultValue": "pointer",
-                                "menu": "cursors"
-                            },
-                        },
+              id: "MouseCursor",
+              name: "Mouse Cursor",
+              blocks: [
+                {
+                  opcode: "SwitchCur",
+                  blockType: "command",
+                  text: "switch cursor to [cur]",
+                  arguments: {
+                    cur: {
+                      type: "string",
+                      defaultValue: "pointer",
+                      menu: "cursors",
                     },
-                    {
-                        "opcode": "hide",
-                        "blockType": "command",
-                        "text": "hide cursor",
-                    },
-                    {
-                        "opcode": "GetCur",
-                        "blockType": "reporter",
-                        "text": "cursor",
-                    },
-                ],
+                  },
+                },
+                {
+                  opcode: "hide",
+                  blockType: "command",
+                  text: "hide cursor",
+                },
+                {
+                  opcode: "GetCur",
+                  blockType: "reporter",
+                  text: "cursor",
+                },
+              ],
 
-                "menus": {
-                    "cursors": {
-                        acceptReporters: true,
-                        items: [{ text: "default", value: "default" }, { text: "pointer", value: "pointer" }, { text: "crosshair", value: "crosshair" }, { text: "move", value: "move" }, { text: "text", value: "text" }, { text: "wait", value: "wait" }, { text: "progress", value: "progress" }, { text: "help", value: "help" }],
-                    }
-                }
+              menus: {
+                cursors: {
+                  acceptReporters: true,
+                  items: [
+                    {text: "default", value: "default"},
+                    {text: "pointer", value: "pointer"},
+                    {text: "crosshair", value: "crosshair"},
+                    {text: "move", value: "move"},
+                    {text: "text", value: "text"},
+                    {text: "wait", value: "wait"},
+                    {text: "progress", value: "progress"},
+                    {text: "help", value: "help"},
+                  ],
+                },
+              },
             };
         }
 

--- a/cursor.js
+++ b/cursor.js
@@ -1,6 +1,10 @@
 (function (Scratch) {
   'use strict';
 
+  if (!Scratch.extensions.unsandboxed) {
+    throw new Error('MouseCursor extension must be run unsandboxed');
+  }
+
   class MouseCursor {
     constructor() {
       this.canvas = Scratch.renderer.canvas;
@@ -8,7 +12,7 @@
 
     getInfo() {
       return {
-        id: 'mouseCursor',
+        id: 'MouseCursor',
         name: 'Mouse Cursor',
         blocks: [
           {
@@ -52,8 +56,8 @@
       };
     }
 
-    setCur({ cur }) {
-      this.canvas.style.cursor = cur;
+    setCur(args) {
+      this.canvas.style.cursor = args.cur;
     }
 
     hideCur() {

--- a/cursor.js
+++ b/cursor.js
@@ -13,11 +13,11 @@
               blocks: [
                 {
                   opcode: "SwitchCur",
-                  blockType: "command",
+                  blockType: Scratch.BlockType.COMMAND,
                   text: "switch cursor to [cur]",
                   arguments: {
                     cur: {
-                      type: "string",
+                      type: Scratch.ArgumentType.STRING,
                       defaultValue: "pointer",
                       menu: "cursors",
                     },
@@ -25,12 +25,12 @@
                 },
                 {
                   opcode: "hide",
-                  blockType: "command",
+                  blockType: Scratch.BlockType.COMMAND,
                   text: "hide cursor",
                 },
                 {
                   opcode: "GetCur",
-                  blockType: "reporter",
+                  blockType: Scratch.BlockType.REPORTER,
                   text: "cursor",
                 },
               ],

--- a/cursor.js
+++ b/cursor.js
@@ -1,70 +1,69 @@
 (function (Scratch) {
-    'use strict';
+  'use strict';
 
-    class MouseCursor {
-        constructor() {
-            this.canvas = Scratch.renderer.canvas;
-        }
-
-        getInfo() {
-            return {
-              id: "MouseCursor",
-              name: "Mouse Cursor",
-              blocks: [
-                {
-                  opcode: "SwitchCur",
-                  blockType: Scratch.BlockType.COMMAND,
-                  text: "switch cursor to [cur]",
-                  arguments: {
-                    cur: {
-                      type: Scratch.ArgumentType.STRING,
-                      defaultValue: "pointer",
-                      menu: "cursors",
-                    },
-                  },
-                },
-                {
-                  opcode: "hide",
-                  blockType: Scratch.BlockType.COMMAND,
-                  text: "hide cursor",
-                },
-                {
-                  opcode: "GetCur",
-                  blockType: Scratch.BlockType.REPORTER,
-                  text: "cursor",
-                },
-              ],
-
-              menus: {
-                cursors: {
-                  acceptReporters: true,
-                  items: [
-                    {text: "default", value: "default"},
-                    {text: "pointer", value: "pointer"},
-                    {text: "crosshair", value: "crosshair"},
-                    {text: "move", value: "move"},
-                    {text: "text", value: "text"},
-                    {text: "wait", value: "wait"},
-                    {text: "progress", value: "progress"},
-                    {text: "help", value: "help"},
-                  ],
-                },
-              },
-            };
-        }
-
-        SwitchCur({ cur }) {
-            this.canvas.style.cursor = cur;
-        }
-
-        hide() {
-            this.canvas.style.cursor = "none";
-        }
-
-        GetCur() {
-            return this.canvas.style.cursor || 'default';
-        }
+  class MouseCursor {
+    constructor() {
+      this.canvas = Scratch.renderer.canvas;
     }
 
-    Scratch.extensions.register(new MouseCursor());
+    getInfo() {
+      return {
+        id: 'mouseCursor',
+        name: 'Mouse Cursor',
+        blocks: [
+          {
+            opcode: 'setCur',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'set cursor to [cur]',
+            arguments: {
+              cur: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'pointer',
+                menu: 'cursors',
+              },
+            },
+          },
+          {
+            opcode: 'hideCur',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'hide cursor',
+          },
+          {
+            opcode: 'getCur',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'cursor',
+          },
+        ],
+        menus: {
+          cursors: {
+            acceptReporters: true,
+            items: [
+              { text: 'default', value: 'default' },
+              { text: 'pointer', value: 'pointer' },
+              { text: 'crosshair', value: 'crosshair' },
+              { text: 'move', value: 'move' },
+              { text: 'text', value: 'text' },
+              { text: 'wait', value: 'wait' },
+              { text: 'progress', value: 'progress' },
+              { text: 'help', value: 'help' },
+            ],
+          },
+        },
+      };
+    }
+
+    setCur({ cur }) {
+      this.canvas.style.cursor = cur;
+    }
+
+    hideCur() {
+      this.canvas.style.cursor = 'none';
+    }
+
+    getCur() {
+      return this.canvas.style.cursor || 'default';
+    }
+  }
+
+  Scratch.extensions.register(new MouseCursor());
 })(Scratch);

--- a/cursor.js
+++ b/cursor.js
@@ -2,9 +2,8 @@
     'use strict';
 
     class MouseCursor {
-        constructor(runtime) {
-            this.runtime = runtime;
-            this.stage = document.body.querySelector(".stage_stage_1fD7k.box_box_2jjDp");
+        constructor() {
+            this.canvas = Scratch.renderer.canvas;
         }
 
         getInfo() {
@@ -46,15 +45,15 @@
         }
 
         SwitchCur({ cur }) {
-            this.stage.style.cursor = cur;
+            this.canvas.style.cursor = cur;
         }
 
         hide() {
-            this.stage.style.cursor = "none";
+            this.canvas.style.cursor = "none";
         }
 
         GetCur() {
-            return this.stage.style.cursor || 'default';
+            return this.canvas.style.cursor || 'default';
         }
     }
 

--- a/cursor.js
+++ b/cursor.js
@@ -1,0 +1,71 @@
+(function (Scratch) {
+    'use strict';
+
+    class MouseCursor {
+        constructor(runtime) {
+            this.runtime = runtime;
+            this.stage = document.body.querySelector(".stage_stage_1fD7k.box_box_2jjDp");
+        }
+
+        getInfo() {
+            return {
+                "id": "MouseCursor",
+                "name": "Mouse Cursor",
+                "blocks": [
+                    {
+                        "opcode": "SwitchCur",
+                        "blockType": "command",
+                        "text": "switch cursor to [cur]",
+                        "arguments": {
+                            "cur": {
+                                "type": "string",
+                                "defaultValue": "pointer",
+                                "menu": "cursors"
+                            },
+                        },
+                    },
+                    {
+                        "opcode": "hide",
+                        "blockType": "command",
+                        "text": "hide cursor",
+                    },
+                    {
+                        "opcode": "reset",
+                        "blockType": "command",
+                        "text": "reset cursor",
+                    },
+                    {
+                        "opcode": "GetCur",
+                        "blockType": "reporter",
+                        "text": "cursor",
+                    },
+                ],
+
+                "menus": {
+                    "cursors": {
+                        acceptReporters: true,
+                        items: [{ text: "default", value: "default" }, { text: "pointer", value: "pointer" }, { text: "crosshair", value: "crosshair" }, { text: "move", value: "move" }, { text: "text", value: "text" }, { text: "wait", value: "wait" }, { text: "progress", value: "progress" }, { text: "help", value: "help" }],
+                    }
+                }
+            };
+        }
+
+        SwitchCur({ cur }) {
+            this.stage.style.cursor = cur;
+        }
+
+        hide() {
+            this.stage.style.cursor = "none";
+        }
+
+        reset() {
+            this.stage.style.cursor = "auto";
+        }
+
+        GetCur() {
+            return this.stage.style.cursor;
+        }
+    }
+
+    Scratch.extensions.register(new MouseCursor());
+})(Scratch);


### PR DESCRIPTION
Source:  https://github.com/Samq64/scratch-extensions

It's just a test extension I made a while back and thought I would add it here in case someone finds it useful.

Tested locally, everything works except the cursor reporter is blank until running one of the other blocks.