### PR TITLE
Itch.io API - Got open window to work

### DIFF
--- a/itchio.js
+++ b/itchio.js
@@ -208,18 +208,18 @@
 				}
 			};
 		}
-        openGameWindow(args) {
-		/* Passing just args will break this in the extension manager,
-		 * probably because of explicit name collision.
-		 */
-		openGameWindow({
-			user: args.user,
-			domain: args.domain,
-			game: args.game,
-			width: args.width,
-			height: args.height
-		});
-        }
+		openGameWindow(args) {
+			/* Passing just args will break this in the extension manager,
+			 * probably because of explicit name collision.
+			 */
+			openGameWindow({
+				user: args.user,
+				domain: args.domain,
+				game: args.game,
+				width: args.width,
+				height: args.height
+			});
+		}
 		getGameData(args) {
 			getGameData({
 				user: args.user,

--- a/itchio.js
+++ b/itchio.js
@@ -84,15 +84,11 @@
 					{
 						opcode: "openGameWindow",
 						blockType: Scratch.BlockType.COMMAND,
-						text: "Open [user][domain][game] window with [width]width and [height]height",
+						text: "Open [user][game] window with [width]width and [height]height",
 						arguments: {
 							user: {
 								type: Scratch.ArgumentType.STRING,
 								defaultValue: "user" 
-							},
-							domain: {
-								type: Scratch.ArgumentType.STRING,
-								defaultValue: "itch.io"
 							},
 							game: {
 								type: Scratch.ArgumentType.STRING,
@@ -214,7 +210,6 @@
 			 */
 			openGameWindow({
 				user: args.user,
-				domain: args.domain,
 				game: args.game,
 				width: args.width,
 				height: args.height

--- a/itchio.js
+++ b/itchio.js
@@ -81,29 +81,33 @@
 				color2: "#222222",
 				color3: "#FA5C5C",
 				blocks: [
-                    {
-                        opcode: "openGameWindow",
-                        blockType: Scratch.BlockType.COMMAND,
-                        text: "Open [user][game] window with [width]width and [height]height",
-                        arguments: {
-                            user: {
-                                type: Scratch.ArgumentType.STRING,
-                                defaultValue: "user" 
-                            },
-                            game: {
-                                type: Scratch.ArgumentType.STRING,
-                                defaultValue: "game"
-                            },
-                            width: {
-                                type: Scratch.ArgumentType.NUMBER,
-                                defaultValue: "680"
-                            },
-                            height: {
-                                type: Scratch.ArgumentType.NUMBER,
-                                defaultValue: "400"
-                            }
-                        }
-                    },
+					{
+						opcode: "openGameWindow",
+						blockType: Scratch.BlockType.COMMAND,
+						text: "Open [user][domain][game] window with [width]width and [height]height",
+						arguments: {
+							user: {
+								type: Scratch.ArgumentType.STRING,
+								defaultValue: "user" 
+							},
+							domain: {
+								type: Scratch.ArgumentType.STRING,
+								defaultValue: "itch.io"
+							},
+							game: {
+								type: Scratch.ArgumentType.STRING,
+								defaultValue: "game"
+							},
+							width: {
+								type: Scratch.ArgumentType.NUMBER,
+								defaultValue: "680"
+							},
+							height: {
+								type: Scratch.ArgumentType.NUMBER,
+								defaultValue: "400"
+							}
+						}
+					},
 					{
 						opcode: "getGameData",
 						blockType: Scratch.BlockType.COMMAND,
@@ -205,15 +209,16 @@
 			};
 		}
         openGameWindow(args) {
-            /* Passing just args will break this in the extension manager,
-             * probably because of explicit name collision.
-             */
-            openGameWindow({
-                user: args.user,
-                game: args.game,
-                width: args.width,
-                height: args.height
-            });
+		/* Passing just args will break this in the extension manager,
+		 * probably because of explicit name collision.
+		 */
+		openGameWindow({
+			user: args.user,
+			domain: args.domain,
+			game: args.game,
+			width: args.width,
+			height: args.height
+		});
         }
 		getGameData(args) {
 			getGameData({

--- a/itchio.js
+++ b/itchio.js
@@ -34,6 +34,26 @@
 		return xhr.send();
 	};
 
+	var openGameWindow = opts => {
+		var domain, height, left, top, width;
+		opts = opts ?? {};
+		domain = opts.domain || "itch.io";
+		width = opts.width || 680;
+		height = opts.height || 400;
+		top = (screen.height - height) / 2;
+		left = (screen.width - width) / 2;
+		if (!opts.user) {
+		    console.error("Missing user");
+		}
+		if (!opts.game) {
+		    console.error("Missing game");
+		}
+		var w = window.open("https://" + opts.user + "." + domain + "/" + opts.game + "/purchase?popup=1", "purchase", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
+		if (typeof w.focus === "function") {
+		    w.focus();
+		}
+	};
+
 	let err = "Error.";
 
 	/**
@@ -61,6 +81,29 @@
 				color2: "#222222",
 				color3: "#FA5C5C",
 				blocks: [
+                    {
+                        opcode: "openGameWindow",
+                        blockType: Scratch.BlockType.COMMAND,
+                        text: "Open [user][game] window with [width]width and [height]height",
+                        arguments: {
+                            user: {
+                                type: Scratch.ArgumentType.STRING,
+                                defaultValue: "user" 
+                            },
+                            game: {
+                                type: Scratch.ArgumentType.STRING,
+                                defaultValue: "game"
+                            },
+                            width: {
+                                type: Scratch.ArgumentType.NUMBER,
+                                defaultValue: "680"
+                            },
+                            height: {
+                                type: Scratch.ArgumentType.NUMBER,
+                                defaultValue: "400"
+                            }
+                        }
+                    },
 					{
 						opcode: "getGameData",
 						blockType: Scratch.BlockType.COMMAND,
@@ -161,6 +204,17 @@
 				}
 			};
 		}
+        openGameWindow(args) {
+            /* Passing just args will break this in the extension manager,
+             * probably because of explicit name collision.
+             */
+            openGameWindow({
+                user: args.user,
+                game: args.game,
+                width: args.width,
+                height: args.height
+            });
+        }
 		getGameData(args) {
 			getGameData({
 				user: args.user,

--- a/itchio.js
+++ b/itchio.js
@@ -9,24 +9,16 @@
 		var domain, url, xhr;
 		opts = opts ?? {};
 		domain = opts.domain || "itch.io";
-		if (!opts.user) {
-			console.error("Missing user");
-		}
-		if (!opts.game) {
-			console.error("Missing game");
-		}
+		if (!opts.user) console.error("Missing user");
+		if (!opts.game) console.error("Missing game");
 		url = "https://" + opts.user + "." + domain + "/" + opts.game + "/data.json";
-		if (opts.secret) {
-			url = url + "?secret=" + opts.secret;
-		}
+		if (opts.secret) url = url + "?secret=" + opts.secret;
 		xhr = new XMLHttpRequest();
 		xhr.open("GET", url);
 		xhr.addEventListener("readystatechange", (_this => {
 			return e => {
 				var game;
-				if (xhr.readyState !== 4) {
-					return;
-				}
+				if (xhr.readyState !== 4) return;
 				game = JSON.parse(xhr.responseText);
 				return typeof opts.onComplete === "function" ? opts.onComplete(game) : void 0;
 			};
@@ -35,23 +27,25 @@
 	};
 
 	var openGameWindow = opts => {
-		var domain, height, left, top, width;
+		var w, domain, height, left, top, width, page;
 		opts = opts ?? {};
 		domain = opts.domain || "itch.io";
 		width = opts.width || 680;
 		height = opts.height || 400;
+		page = opts.page || "purchase_page";
 		top = (screen.height - height) / 2;
 		left = (screen.width - width) / 2;
-		if (!opts.user) {
-		    console.error("Missing user");
+		if (!opts.user) console.error("Missing user");
+		if (!opts.game) console.error("Missing game");
+		switch (page) {
+			case "page":
+				w = window.open("https://" + opts.user + "." + domain + "/" + opts.game, "", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
+				break;
+			case "purchase_page":
+				w = window.open("https://" + opts.user + "." + domain + "/" + opts.game + "/purchase", "", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
+				break;
 		}
-		if (!opts.game) {
-		    console.error("Missing game");
-		}
-		var w = window.open("https://" + opts.user + "." + domain + "/" + opts.game + "/purchase?popup=1", "purchase", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
-		if (typeof w.focus === "function") {
-		    w.focus();
-		}
+		if (typeof w.focus === "function") w.focus();
 	};
 
 	let err = "Error.";
@@ -84,7 +78,7 @@
 					{
 						opcode: "openGameWindow",
 						blockType: Scratch.BlockType.COMMAND,
-						text: "Open [user][game] window with [width]width and [height]height",
+						text: "Open [user][game][page] window with [width]width and [height]height",
 						arguments: {
 							user: {
 								type: Scratch.ArgumentType.STRING,
@@ -93,6 +87,11 @@
 							game: {
 								type: Scratch.ArgumentType.STRING,
 								defaultValue: "game"
+							},
+							page: {
+								type: Scratch.ArgumentType.STRING,
+								menu: "pageMenu",
+								defaultValue: "page"
 							},
 							width: {
 								type: Scratch.ArgumentType.NUMBER,
@@ -200,6 +199,12 @@
 							{ text: "end date", value: "end_date" },
 							{ text: "rate", value: "rate" }
 						]
+					},
+					pageMenu: {
+						items: [
+							{ text: "page", value: "page" },
+							{ text: "purchase page", value: "purchase_page" }
+						]
 					}
 				}
 			};
@@ -211,6 +216,7 @@
 			openGameWindow({
 				user: args.user,
 				game: args.game,
+				page: args.page,
 				width: args.width,
 				height: args.height
 			});

--- a/itchio.js
+++ b/itchio.js
@@ -26,25 +26,15 @@
 		return xhr.send();
 	};
 
-	var openGameWindow = opts => {
-		var w, domain, height, left, top, width, page;
+	var openItchWindow = opts => {
+		var w, domain, height, left, top, width;
 		opts = opts ?? {};
 		domain = opts.domain || "itch.io";
 		width = opts.width || 680;
 		height = opts.height || 400;
-		page = opts.page || "purchase_page";
 		top = (screen.height - height) / 2;
 		left = (screen.width - width) / 2;
-		if (!opts.user) console.error("Missing user");
-		if (!opts.game) console.error("Missing game");
-		switch (page) {
-			case "page":
-				w = window.open("https://" + opts.user + "." + domain + "/" + opts.game, "", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
-				break;
-			case "purchase_page":
-				w = window.open("https://" + opts.user + "." + domain + "/" + opts.game + "/purchase", "", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
-				break;
-		}
+		w = window.open("https://" + opts.prefix + (opts.prefix ? "." : "") + domain + "/" + opts.page, "", "scrollbars=1, resizable=no, width=" + width + ", height=" + height + ", top=" + top + ", left=" + left);
 		if (typeof w.focus === "function") w.focus();
 	};
 
@@ -76,22 +66,17 @@
 				color3: "#FA5C5C",
 				blocks: [
 					{
-						opcode: "openGameWindow",
+						opcode: "openItchWindow",
 						blockType: Scratch.BlockType.COMMAND,
-						text: "Open [user][game][page] window with [width]width and [height]height",
+						text: "Open [prefix] itch.io [page] window with [width]width and [height]height",
 						arguments: {
-							user: {
+							prefix: {
 								type: Scratch.ArgumentType.STRING,
-								defaultValue: "user" 
-							},
-							game: {
-								type: Scratch.ArgumentType.STRING,
-								defaultValue: "game"
+								defaultValue: "user"
 							},
 							page: {
 								type: Scratch.ArgumentType.STRING,
-								menu: "pageMenu",
-								defaultValue: "page"
+								defaultValue: "game"
 							},
 							width: {
 								type: Scratch.ArgumentType.NUMBER,
@@ -199,23 +184,16 @@
 							{ text: "end date", value: "end_date" },
 							{ text: "rate", value: "rate" }
 						]
-					},
-					pageMenu: {
-						items: [
-							{ text: "page", value: "page" },
-							{ text: "purchase page", value: "purchase_page" }
-						]
 					}
 				}
 			};
 		}
-		openGameWindow(args) {
+		openItchWindow(args) {
 			/* Passing just args will break this in the extension manager,
 			 * probably because of explicit name collision.
 			 */
-			openGameWindow({
-				user: args.user,
-				game: args.game,
+			openItchWindow({
+				prefix: args.prefix,
 				page: args.page,
 				width: args.width,
 				height: args.height


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/100989385/208289183-453b694e-6fb6-42bb-8b8b-0b26cfd77bdd.png)

This can be used maliciously, but the functionality of this block is limited due to it opening windows with this:
`/purchase?popup=1`

To limit this block even further we can remove the domain argument which is replaced with default itch.io, and since this is an entire new block, nothing breaks. This won't allow users to open their game purchase popup from other websites, but there is still `☁ open window` and `☁ redirect` stuff.