### PR TITLE
cursor: Allow setting cursor to custom images

### DIFF
--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -214,10 +214,10 @@
             acceptReporters: true,
             items: [
               // [x, y] where x is [0=left, 100=right] and y is [0=top, 100=bottom]
-              { text: 'top-left', value: '0,0' },
-              { text: 'top-right', value: '100,0' },
-              { text: 'bottom-left', value: '0,100' },
-              { text: 'bottom-right', value: '100,100' },
+              { text: 'top left', value: '0,0' },
+              { text: 'top right', value: '100,0' },
+              { text: 'bottom left', value: '0,100' },
+              { text: 'bottom right', value: '100,100' },
               { text: 'center', value: '50,50' },
             ]
           },

--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -33,11 +33,9 @@
 
   /**
    * @param {RenderWebGL.Skin} skin
-   * @returns {string}
+   * @returns {string} A data: URI for the skin.
    */
   const encodeSkinToURL = (skin) => {
-    // TODO: be more resilient to weird edge cases, unloaded costumes, etc.
-
     const svgSkin = /** @type {RenderWebGL.SVGSkin} */ (skin);
     if (svgSkin._svgImage) {
       // This is an SVG skin
@@ -86,11 +84,18 @@
 
     const imageURI = encodeSkinToURL(skin);
 
-    // For high DPI displays, we want the browser to be able to show it at full resolution.
+    // We wrap the encoded image in an <svg>. This lets us do some clever things:
+    //  - We can resize the image without a canvas.
+    //  - We can give the browser an image with more raw pixels than its DPI independent size
+    // The latter is important so that cursors won't look horrible on high DPI displays. For
+    // example, if the cursor will display at 32x32 in DPI independent units on a 2x high DPI
+    // display, we actually need to send a 64x64 image for it to look good. This lets us do
+    // that automatically.
     let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">`;
     svg += `<image href="${imageURI}" width="${width}" height="${height}" />`;
     svg += '</svg>';
-    const svgURI = `data:image/svg+xml;base64,${btoa(svg)}`;
+    // URI encoding usually results in smaller string than base 64 for the types of data we get here.
+    const svgURI = `data:image/svg+xml;,${encodeURIComponent(svg)}`;
 
     return {
       uri: svgURI,

--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -301,7 +301,6 @@
 
     getCur() {
       if (customCursorImageName !== null) {
-        // TODO: should we try to "decorate" this a bit more?
         return customCursorImageName;
       }
       return nativeCursor;

--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -149,7 +149,7 @@
             arguments: {
               position: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: 'top-left',
+                defaultValue: '0,0',
                 menu: 'imagePositions'
               },
               size: {
@@ -213,11 +213,12 @@
           imagePositions: {
             acceptReporters: true,
             items: [
-              { text: 'top-left', value: 'top-left' },
-              { text: 'top-right', value: 'top-right' },
-              { text: 'bottom-left', value: 'bottom-left' },
-              { text: 'bottom-right', value: 'bottom-right' },
-              { text: 'center', value: 'center' },
+              // [x, y] where x is [0=left, 100=right] and y is [0=top, 100=bottom]
+              { text: 'top-left', value: '0,0' },
+              { text: 'top-right', value: '100,0' },
+              { text: 'bottom-left', value: '0,100' },
+              { text: 'bottom-right', value: '100,100' },
+              { text: 'center', value: '50,50' },
             ]
           },
           imageSizes: {
@@ -264,21 +265,9 @@
       }
 
       if (encodedCostume) {
-        let x = 0;
-        let y = 0;
-        if (positionName === 'top-left') {
-          // initial value is already correct
-        } else if (positionName === 'top-right') {
-          x = encodedCostume.width;
-        } else if (positionName === 'bottom-left') {
-          y = encodedCostume.height;
-        } else if (positionName === 'bottom-right') {
-          x = encodedCostume.width;
-          y = encodedCostume.height;
-        } else if (positionName === 'center') {
-          x = encodedCostume.width / 2;
-          y = encodedCostume.height / 2;
-        }
+        const [percentX, percentY] = ('' + positionName).split(',');
+        const x = Math.max(0, Math.min(100, +percentX || 0)) / 100 * encodedCostume.width;
+        const y = Math.max(0, Math.min(100, +percentY || 0)) / 100 * encodedCostume.height;
 
         currentCanvasCursor = `url("${encodedCostume.uri}") ${x} ${y}, ${nativeCursor}`;
         updateCanvasCursor();

--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -218,10 +218,17 @@
           imageSizes: {
             acceptReporters: true,
             items: [
+              // Some important numbers to keep in mind:
+              // Browsers ignore cursor images >128 in any dimension (https://searchfox.org/mozilla-central/rev/43ee5e789b079e94837a21336e9ce2420658fd19/widget/gtk/nsWindow.cpp#3393-3402)
+              // Browsers may refuse to display a cursor near window borders for images >32 in any dimension
+              { text: '4x4', value: '4' },
+              { text: '8x8', value: '8' },
+              { text: '12x12', value: '12' },
               { text: '16x16', value: '16' },
               { text: '32x32', value: '32' },
               { text: '48x48 (unreliable)', value: '48' },
               { text: '64x64 (unreliable)', value: '64' },
+              { text: '128x128 (unreliable)', value: '128' },
             ]
           }
         },

--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -97,13 +97,27 @@
     };
   };
 
-  class MouseCursor {
-    constructor() {
-      this.canvas = Scratch.renderer.canvas;
-      this.intendedNativeCursor = 'default';
-      this.customCursorImageName = null;
-    }
+  /** @type {string} */
+  let nativeCursor = 'default';
+  /** @type {null|string} */
+  let customCursorImageName = null;
 
+  const canvas = Scratch.renderer.canvas;
+  /** @type {string} */
+  let currentCanvasCursor = nativeCursor;
+  const updateCanvasCursor = () => {
+    if (canvas.style.cursor !== currentCanvasCursor) {
+      canvas.style.cursor = currentCanvasCursor;
+    }
+  };
+
+  // scratch-gui will sometimes reset the cursor when resizing the window or going in/out of fullscreen
+  new MutationObserver(updateCanvasCursor).observe(canvas, {
+    attributeFilter: ['style'],
+    attributes: true
+  });
+
+  class MouseCursor {
     getInfo() {
       return {
         id: 'MouseCursor',
@@ -213,10 +227,11 @@
     }
 
     setCur(args) {
-      const cursor = args.cur;
-      this.intendedNativeCursor = cursor;
-      this.customCursorImageName = null;
-      this.canvas.style.cursor = cursor;
+      const newCursor = args.cur;
+      nativeCursor = newCursor;
+      customCursorImageName = null;
+      currentCanvasCursor = newCursor;
+      updateCanvasCursor();
     }
 
     setCursorImage(args, util) {
@@ -243,8 +258,9 @@
         y = height / 2;
       }
 
-      this.customCursorImageName = costumeName;
-      this.canvas.style.cursor = `url("${encoded}") ${x} ${y}, ${this.intendedNativeCursor}`;
+      customCursorImageName = costumeName;
+      currentCanvasCursor = `url("${encoded}") ${x} ${y}, ${nativeCursor}`;
+      updateCanvasCursor();
     }
 
     hideCur() {
@@ -254,11 +270,11 @@
     }
 
     getCur() {
-      if (this.customCursorImageName !== null) {
+      if (customCursorImageName !== null) {
         // TODO: should we try to "decorate" this a bit more?
-        return this.customCursorImageName;
+        return customCursorImageName;
       }
-      return this.intendedNativeCursor;
+      return nativeCursor;
     }
   }
 

--- a/website/index.ejs
+++ b/website/index.ejs
@@ -275,7 +275,7 @@
         <div class="extension">
           <img loading="lazy" src="images/cursor.svg" style="filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.5));">
           <h2>Cursor</h2>
-          <p>Use custom cursors or hide the cursor in your project.</p>
+          <p>Use custom cursors or hide the cursor. Also allows replacing the cursor with any costume image.</p>
           <%- url("cursor") %>
         </div>
 


### PR DESCRIPTION
Closes https://github.com/TurboWarp/extensions/issues/46

https://user-images.githubusercontent.com/33787854/209484836-f11d7b07-80df-4934-a46a-691564ee7074.mp4

Also fixes cursor being reset when scratch-gui resizes or goes in/out of fullscreen

