### PR TITLE
files: Fix "Accepted formats:" text when using plain "open a file" block 

### DIFF
--- a/extensions/files.js
+++ b/extensions/files.js
@@ -133,7 +133,8 @@
     modal.appendChild(title);
 
     const subtitle = document.createElement('div');
-    subtitle.textContent = `Accepted formats: ${accept}`;
+    const formattedAccept = accept || 'any';
+    subtitle.textContent = `Accepted formats: ${formattedAccept}`;
     modal.appendChild(subtitle);
 
     document.body.appendChild(outer);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33787854/209633632-0f465b60-c6ae-4ab9-af0a-76c70556c4da.png)
