### PR TITLE
types: Add string to ExtensionMenu items

### DIFF
--- a/types/Scratch.d.ts
+++ b/types/Scratch.d.ts
@@ -75,7 +75,7 @@ declare namespace Scratch {
 
   interface ExtensionMenu {
     acceptReporters?: boolean;
-    items: Array<{
+    items: Array<string | {
       text: string;
       value: string;
     }>;


### PR DESCRIPTION
Fixes an incorrect type warning in Pen+