### PR TITLE
stretch: Don't implement stretch multiple times per target

### DIFF
--- a/extensions/stretch.js
+++ b/extensions/stretch.js
@@ -8,8 +8,14 @@
 
   /**
    * @param {VM.RenderedTarget} target
+   * @param {VM.RenderedTarget} [originalTarget] If target is a clone, the original to copy from.
    */
   const implementStretchForTarget = (target, originalTarget) => {
+    if (STRETCH_X in target) {
+      // Target already has stretch. Don't implement again.
+      return;
+    }
+
     target[STRETCH_X] = originalTarget ? originalTarget[STRETCH_X] : 100;
     target[STRETCH_Y] = originalTarget ? originalTarget[STRETCH_Y] : 100;
 


### PR DESCRIPTION
The old code was making sprites become quadratically larger instead of linearly larger and broke negative stretch in some situations.