### PR TITLE
Add drop-shadow on buttons and more hover effects

### DIFF
--- a/website/index.ejs
+++ b/website/index.ejs
@@ -137,7 +137,7 @@
         align-items: center;
         justify-content: center;
         opacity: 0;
-        transition: opacity .2s;
+        transition: opacity .15s;
         background: rgba(0, 0, 0, 0.5);
         pointer-events: none;
       }

--- a/website/index.ejs
+++ b/website/index.ejs
@@ -144,6 +144,9 @@
       .extension:hover .extension-buttons, .extension:focus-within .extension-buttons {
         opacity: 1;
       }
+      .extension:hover .extension-buttons {
+        backdrop-filter: blur(0.6px);
+      }
       .extension-buttons > * {
         padding: 8px;
         background-color: #4c97ff;
@@ -154,6 +157,12 @@
         color: white;
         text-decoration: none;
         pointer-events: auto;
+        transition: 0.15s;
+        filter: drop-shadow(0px 1px 3px #00000075);
+      }
+      .extension-buttons > *:hover {
+        filter: drop-shadow(0px 1px 7px black);
+        z-index: 1;
       }
       .extension-buttons *:active {
         opacity: 0.8;


### PR DESCRIPTION
These changes are meant to give the "Copy URL" and "Open Extension" buttons more contrast and pop out more.

List of changes:
- The extension thumbnails now get blurred when you hover over them. Since the buttons are on top, this helps them stand out.
- The buttons now have a drop-shadow, which makes them easier to see on top of the background. This drop-shadow gets bigger when you hover over the buttons.