### PR TITLE
Rename the profanity remover extension and list it on the homepage

### DIFF
--- a/extensions/TheShovel/profanity.js
+++ b/extensions/TheShovel/profanity.js
@@ -227,7 +227,7 @@
     getInfo () {
       return {
         id: 'theshovelprofanity',
-        name: 'Profanity',
+        name: 'Bad Word Remover',
         color1: '#cf6a3c',
         color2: '#cf6a3c',
         color3: '#cf6a3c',
@@ -235,7 +235,7 @@
           {
             opcode: 'checkProfanity',
             blockType: Scratch.BlockType.REPORTER,
-            text: "Replace profanity from [TEXT] with [REPLACEMENT]",
+            text: 'replace bad words in [TEXT] with [REPLACEMENT]',
             arguments: {
               REPLACEMENT: {
                 type: Scratch.ArgumentType.STRING,
@@ -243,7 +243,7 @@
               },
               TEXT: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: 'Bad word here',
+                defaultValue: 'Hello!',
               }
             }
           },

--- a/website/index.ejs
+++ b/website/index.ejs
@@ -493,6 +493,12 @@
           <h3>Consoles</h3>
           <p>Blocks that interact the JavaScript console built in to your browser's developer tools. Created by -SIPC-.</p>
         </div>
+
+        <div class="extension">
+          <%- banner('TheShovel/profanity') %>
+          <h3>Bad Word Remover</h3>
+          <p>Blocks that can remove bad words from text. Not 100% accurate. Created by TheShovel.</p>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
"Bad Word Remover" is a bit more on-brand for something Scratch related, and the default value has been changed to be something nice and normal instead of something that suggests typing in a bad word

As for the image, given the Scratch Team's rules, I'd like to keep it *extremely* vague or just have it always use a placeholder image. Any image that contains words that appear to be censored is unlikely to work here