### PR TITLE
Revise ESLint more

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-undef
 module.exports = {
   env: {
-    browser: true,
     es2021: true
   },
   extends: 'eslint:recommended',
@@ -32,7 +31,6 @@ module.exports = {
     'space-infix-ops': 'warn',
     'no-tabs': 'warn',
 
-    // Allow blocks to accept unused `util` arguments
     'no-unused-vars': 'off',
     // Allow while (true) { }
     'no-constant-condition': [
@@ -74,84 +72,6 @@ module.exports = {
     ],
     // Disallow async functions that don't need to be. This is important as a Promise and non-Promise return value
     // significantly impacts the behavior of projects.
-    'require-await': 'error',
-    // Require each extension to use strict mode
-    'strict': ['error', 'function'],
-    // Disallow APIs that are replaced by Scratch.* APIs
-    // This is not comprehensive, but it should be enough to prevent the most common ways for these to be written.
-    'no-restricted-globals': [
-      'error',
-      {
-        name: 'vm',
-        message: 'Use Scratch.vm instead of the global vm object. You also can use const vm = Scratch.vm;'
-      }
-    ],
-    'no-restricted-syntax': [
-      'error',
-      {
-        selector: 'CallExpression[callee.name=fetch]',
-        message: 'Use Scratch.fetch() instead of fetch()'
-      },
-      {
-        selector: 'CallExpression[callee.object.name=window][callee.property.name=fetch]',
-        message: 'Use Scratch.fetch() instead of window.fetch()'
-      },
-      {
-        selector: 'CallExpression[callee.name=open]',
-        message: 'Use Scratch.openWindow() instead of open()'
-      },
-      {
-        selector: 'CallExpression[callee.object.name=window][callee.property.name=open]',
-        message: 'Use Scratch.openWindow() instead of window.open()'
-      },
-      {
-        selector: 'AssignmentExpression[left.object.name=location][left.property.name=href]',
-        message: 'Use Scratch.redirect() instead of location.href = ...'
-      },
-      {
-        selector: 'AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]',
-        message: 'Use Scratch.redirect() instead of window.location.href = ...'
-      },
-      {
-        selector: 'AssignmentExpression[left.name=location]',
-        message: 'Use Scratch.redirect() instead of location = ...'
-      },
-      {
-        selector: 'AssignmentExpression[left.object.name=window][left.property.name=location]',
-        message: 'Use Scratch.redirect() instead of window.location = ...'
-      },
-      {
-        selector: 'CallExpression[callee.object.name=location][callee.property.name=assign]',
-        message: 'Use Scratch.redirect() instead of location.assign()'
-      },
-      {
-        selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]',
-        message: 'Use Scratch.redirect() instead of window.location.assign()'
-      },
-      {
-        selector: 'CallExpression[callee.object.name=location][callee.property.name=replace]',
-        message: 'Use Scratch.redirect() instead of location.replace()'
-      },
-      {
-        selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]',
-        message: 'Use Scratch.redirect() instead of window.location.replace()'
-      },
-      {
-        selector: 'NewExpression[callee.name=XMLHttpRequest]',
-        message: 'Use Scratch.fetch() instead of XMLHttpRequest'
-      },
-      {
-        selector: 'NewExpression[callee.name=WebSocket]',
-        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-      },
-      {
-        selector: 'NewExpression[callee.name=Image]',
-        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-      },
-      {
-        selector: 'NewExpression[callee.name=Audio]',
-        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-      }
-    ]
+    'require-await': 'error'
   }
 };

--- a/development/.eslintrc.js
+++ b/development/.eslintrc.js
@@ -2,8 +2,5 @@ module.exports = {
   env: {
     commonjs: true,
     node: true,
-  },
-  rules: {
-    strict: 'off'
   }
 };

--- a/development/builder.js
+++ b/development/builder.js
@@ -17,6 +17,10 @@ const IMAGE_EXTENSIONS = ['png', 'jpg', 'svg'];
 const readDirectory = (directory) => {
   const result = [];
   for (const name of fs.readdirSync(directory)) {
+    if (name.startsWith('.')) {
+      // Ignore .eslintrc.js, .DS_Store, etc.
+      continue;
+    }
     const absolutePath = pathUtil.join(directory, name);
     const stat = fs.statSync(absolutePath);
     if (stat.isDirectory()) {

--- a/extensions/.eslintrc.js
+++ b/extensions/.eslintrc.js
@@ -1,0 +1,86 @@
+// eslint-disable-next-line
+module.exports = {
+  env: {
+    browser: true
+  },
+  rules: {
+    // Require each extension to use strict mode
+    'strict': ['error', 'function'],
+    // Disallow APIs that are replaced by Scratch.* APIs
+    // This is not comprehensive, but it should be enough to prevent the most common ways for these to be written.
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'vm',
+        message: 'Use Scratch.vm instead of the global vm object. You also can use const vm = Scratch.vm;'
+      }
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'CallExpression[callee.name=fetch]',
+        message: 'Use Scratch.fetch() instead of fetch()'
+      },
+      {
+        selector: 'CallExpression[callee.object.name=window][callee.property.name=fetch]',
+        message: 'Use Scratch.fetch() instead of window.fetch()'
+      },
+      {
+        selector: 'CallExpression[callee.name=open]',
+        message: 'Use Scratch.openWindow() instead of open()'
+      },
+      {
+        selector: 'CallExpression[callee.object.name=window][callee.property.name=open]',
+        message: 'Use Scratch.openWindow() instead of window.open()'
+      },
+      {
+        selector: 'AssignmentExpression[left.object.name=location][left.property.name=href]',
+        message: 'Use Scratch.redirect() instead of location.href = ...'
+      },
+      {
+        selector: 'AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]',
+        message: 'Use Scratch.redirect() instead of window.location.href = ...'
+      },
+      {
+        selector: 'AssignmentExpression[left.name=location]',
+        message: 'Use Scratch.redirect() instead of location = ...'
+      },
+      {
+        selector: 'AssignmentExpression[left.object.name=window][left.property.name=location]',
+        message: 'Use Scratch.redirect() instead of window.location = ...'
+      },
+      {
+        selector: 'CallExpression[callee.object.name=location][callee.property.name=assign]',
+        message: 'Use Scratch.redirect() instead of location.assign()'
+      },
+      {
+        selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]',
+        message: 'Use Scratch.redirect() instead of window.location.assign()'
+      },
+      {
+        selector: 'CallExpression[callee.object.name=location][callee.property.name=replace]',
+        message: 'Use Scratch.redirect() instead of location.replace()'
+      },
+      {
+        selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]',
+        message: 'Use Scratch.redirect() instead of window.location.replace()'
+      },
+      {
+        selector: 'NewExpression[callee.name=XMLHttpRequest]',
+        message: 'Use Scratch.fetch() instead of XMLHttpRequest'
+      },
+      {
+        selector: 'NewExpression[callee.name=WebSocket]',
+        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+      },
+      {
+        selector: 'NewExpression[callee.name=Image]',
+        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+      },
+      {
+        selector: 'NewExpression[callee.name=Audio]',
+        message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+      }
+    ]
+  }
+};

--- a/extensions/.eslintrc.js
+++ b/extensions/.eslintrc.js
@@ -80,6 +80,10 @@ module.exports = {
       {
         selector: 'NewExpression[callee.name=Audio]',
         message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+      },
+      {
+        selector: 'Program > :not(ExpressionStatement[expression.type=CallExpression][expression.callee.type=/FunctionExpression/])',
+        message: 'All extension code must be within (function (Scratch) { ... })(Scratch);'
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "node development/server.js",
     "build": "node development/build-production.js",
     "validate": "node development/validate.js",
-    "lint": "eslint development extensions",
+    "lint": "eslint development extensions --max-warnings=0",
     "fix": "npm run lint -- --fix"
   },
   "repository": {


### PR DESCRIPTION
 - ESLint rules specifically for extensions are now in the extensions folder
 - Putting any extension code outside of the IIFE will now cause an error
 - Any ESLint *warning* will now cause GitHub Actions to report an error. Hopefully this will encourage people to resolve style issues so that I don't need to.