### PR TITLE
Add delete sprite mechanics to Shovel's Utilities

### DIFF
--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -127,6 +127,19 @@
               }
             }
           },
+          
+          {
+          opcode: 'deleteSprite',
+          blockType: Scratch.BlockType.COMMAND,
+          text: 'Delete sprite [TEXT]',
+          arguments: {
+            SPRITE: {
+              type: Scratch.ArgumentType.STRING,
+              defaultValue: 'Sprite1',
+              }
+            }
+          },
+
           {
             opcode: 'setedtarget',
             blockType: Scratch.BlockType.COMMAND,
@@ -188,6 +201,10 @@
         .catch((error) => {
           console.log("Error", error);
         });
+    }
+    
+    deleteSprite({ TEXT }) {
+  vm.deleteSprite(vm.runtime.getSpriteTargetByName(TEXT).id);
     }
 
     importSound({ TEXT, NAME }) {

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -127,19 +127,17 @@
               }
             }
           },
-          
           {
-          opcode: 'deleteSprite',
-          blockType: Scratch.BlockType.COMMAND,
-          text: 'Delete sprite [TEXT]',
-          arguments: {
-            SPRITE: {
-              type: Scratch.ArgumentType.STRING,
-              defaultValue: 'Sprite1',
+            opcode: 'deleteSprite',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'Delete sprite [SPRITE]',
+            arguments: {
+              SPRITE: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'Sprite1',
               }
             }
           },
-
           {
             opcode: 'setedtarget',
             blockType: Scratch.BlockType.COMMAND,
@@ -202,9 +200,19 @@
           console.log("Error", error);
         });
     }
-    
-    deleteSprite({ TEXT }) {
-  vm.deleteSprite(vm.runtime.getSpriteTargetByName(TEXT).id);
+
+    deleteSprite({ SPRITE }) {
+      const target = vm.runtime.getSpriteTargetByName(SPRITE);
+      if (!target || target.isStage) {
+        return;
+      }
+      // @ts-expect-error
+      if (typeof ScratchBlocks !== 'undefined') {
+        if (!confirm(`Do you want to delete the sprite "${SPRITE}"? This cannot be undone.`)) {
+          return;
+        }
+      }
+      vm.deleteSprite(target.id);
     }
 
     importSound({ TEXT, NAME }) {


### PR DESCRIPTION
Small change, but I added deleteSprite into Shovel's Utilities as @TheShovel is currently working on another extension. First time making a PR here, anything strange you notice, please let me know.