### PR TITLE
Add memory block to navigator.js

### DIFF
--- a/extensions/navigator.js
+++ b/extensions/navigator.js
@@ -16,6 +16,11 @@
             opcode: 'getBrowser',
             blockType: Scratch.BlockType.REPORTER,
             text: 'browser'
+          },
+          {
+            opcode: 'getMemory',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'device memory'
           }
         ]
       };
@@ -49,6 +54,13 @@
         return 'Safari';
       }
       return 'Other';
+    }
+    getMemory(){
+      if (navigator.deviceMemory == undefined) {
+        return 'Unsupported';
+    } else {
+        return navigator.deviceMemory;
+    }
     }
   }
 

--- a/extensions/navigator.js
+++ b/extensions/navigator.js
@@ -20,7 +20,7 @@
           {
             opcode: 'getMemory',
             blockType: Scratch.BlockType.REPORTER,
-            text: 'device memory'
+            text: 'device memory in GB'
           }
         ]
       };
@@ -55,12 +55,15 @@
       }
       return 'Other';
     }
-    getMemory(){
+
+    getMemory () {
+      // @ts-expect-error
       if (navigator.deviceMemory == undefined) {
         return 'Unsupported';
-    } else {
+      } else {
+        // @ts-expect-error
         return navigator.deviceMemory;
-    }
+      }
     }
   }
 


### PR DESCRIPTION
 Returns the memory of the device.
This is not supported on some browsers, so it will return "Unsupported" if so.
![image](https://user-images.githubusercontent.com/68913917/230372896-985ac668-222b-4576-84b9-87f8696f4bc8.png)
