### PR TITLE
Temporarily unlist 0832/rxFS from the homepage

### DIFF
--- a/website/index.ejs
+++ b/website/index.ejs
@@ -543,12 +543,6 @@
         </div>
 
         <div class="extension">
-          <%- banner('0832/rxFS') %>
-          <h3>rxFS</h3>
-          <p>Blocks for interacting with a virtual in-memory filesystem. Created by 0832.</p>
-        </div>
-
-        <div class="extension">
           <%- banner('NOname-awa/graphics2d') %>
           <h3>Graphics 2D</h3>
           <p>Blocks to compute lengths, angles, and areas in two dimensions. Created by NOname-awa.</p>


### PR DESCRIPTION
Extension still works even though it's legally ambiguous.

Hope to add it back to the homepage when these concerns are addressed: https://github.com/TurboWarp/extensions/pull/319#issuecomment-1520247431