### PR TITLE
Clipping and blending: blend modes and pen support

### DIFF
--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -32,6 +32,7 @@
   let height = 0;
   let scratchUnitWidth = 480;
   let scratchUnitHeight = 360;
+  let penDirty = false;
 
 
   renderer._drawThese = function (drawables, drawMode, projection, opts) {
@@ -171,6 +172,9 @@
       lastBlendMode = "default";
     };
     const willDrawPenWithTarget = function(target) {
+      if (!penDirty && target == lastTarget) return;
+      penDirty = false;
+
       const clipbox = target.clipbox;
       if ((!lastClipbox ^ !clipbox) ||
           (lastBlendMode != target.blendMode) ||
@@ -357,6 +361,7 @@
         w: Math.max(X1, X2) - Math.min(X1, X2),
         h: Math.max(Y1, Y2) - Math.min(Y1, Y2)
       };
+      penDirty = true;
       target.clipbox = newClipbox;
       renderer.updateDrawableClipBox.call(renderer, target.drawableID, newClipbox);
       if (target.visible) {
@@ -370,6 +375,7 @@
     clearClipbox (args, {target}) {
       if (target.isStage) return;
       target.clipbox = null;
+      penDirty = true;
       renderer.updateDrawableClipBox.call(renderer, target.drawableID, null);
       if (target.visible) {
         renderer.dirty = true;
@@ -405,6 +411,7 @@
           return;
       }
       if (target.isStage) return;
+      penDirty = true;
       target.blendMode = newValue;
       renderer.updateDrawableBlendMode.call(renderer, target.drawableID, newValue);
       if (target.visible) {

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -77,12 +77,14 @@
   function setupModes(clipbox, blendMode, flipY) {
     if (clipbox) {
       gl.enable(gl.SCISSOR_TEST);
-      let x = (clipbox.x / scratchUnitWidth + 0.5) * width;
-      let y = (clipbox.y / scratchUnitHeight + 0.5) * height;
-      let w = (clipbox.w / scratchUnitWidth) * width;
-      let h = (clipbox.h / scratchUnitHeight) * height;
+      let x = (clipbox.x / scratchUnitWidth + 0.5) * width | 0;
+      let y = (clipbox.y / scratchUnitHeight + 0.5) * height | 0;
+      let x2 = ((clipbox.x + clipbox.w) / scratchUnitWidth + 0.5) * width | 0;
+      let y2 = ((clipbox.y + clipbox.h) / scratchUnitHeight + 0.5) * height | 0;
+      let w = x2 - x;
+      let h = y2 - y;
       if (flipY) {
-        y = (-(clipbox.y + clipbox.h) / scratchUnitHeight + 0.5) * height;
+        y = (-(clipbox.y + clipbox.h) / scratchUnitHeight + 0.5) * height | 0;
       }
       gl.scissor(x, y, w, h);
     } else {
@@ -133,17 +135,17 @@
   const regTargetStuff = function (args) {
     if (args.editingTarget) {
       vm.removeListener('targetsUpdate', regTargetStuff);
-      const proto = args.editingTarget.__proto__;
+      const proto = vm.runtime.targets[0].__proto__;
       const osa = proto.onStopAll;
       proto.onStopAll = function () {
         this.renderer.updateDrawableClipBox.call(renderer, this.drawableID, null);
-        this.renderer.updateDrawableAdditiveBlend.call(renderer, this.drawableID, false);
+        this.renderer.updateDrawableBlendMode.call(renderer, this.drawableID, null);
         osa.call(this);
       };
       const mc = proto.makeClone;
       proto.makeClone = function () {
         const newTarget = mc.call(this);
-        if (this.clipbox) {
+        if (this.clipbox || this.blendMode) {
           newTarget.clipbox = Object.assign({}, this.clipbox);
           newTarget.blendMode = this.blendMode;
           renderer.updateDrawableClipBox.call(renderer, newTarget.drawableID, this.clipbox);

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -77,14 +77,14 @@
   function setupModes(clipbox, blendMode, flipY) {
     if (clipbox) {
       gl.enable(gl.SCISSOR_TEST);
-      let x = (clipbox.x / scratchUnitWidth + 0.5) * width | 0;
-      let y = (clipbox.y / scratchUnitHeight + 0.5) * height | 0;
-      let x2 = ((clipbox.x + clipbox.w) / scratchUnitWidth + 0.5) * width | 0;
-      let y2 = ((clipbox.y + clipbox.h) / scratchUnitHeight + 0.5) * height | 0;
+      let x = (clipbox.x_min / scratchUnitWidth + 0.5) * width | 0;
+      let y = (clipbox.y_min / scratchUnitHeight + 0.5) * height | 0;
+      let x2 = (clipbox.x_max / scratchUnitWidth + 0.5) * width | 0;
+      let y2 = (clipbox.y_max / scratchUnitHeight + 0.5) * height | 0;
       let w = x2 - x;
       let h = y2 - y;
       if (flipY) {
-        y = (-(clipbox.y + clipbox.h) / scratchUnitHeight + 0.5) * height | 0;
+        y = (-(clipbox.y_max) / scratchUnitHeight + 0.5) * height | 0;
       }
       gl.scissor(x, y, w, h);
     } else {
@@ -180,17 +180,17 @@
       const clipbox = target.clipbox;
       if ((!lastClipbox ^ !clipbox) ||
           (lastBlendMode != target.blendMode) ||
-          (clipbox && (clipbox.x != lastClipbox.x || clipbox.y != lastClipbox.y || clipbox.w != lastClipbox.w || clipbox.h != lastClipbox.h))) {
+          (clipbox && (clipbox.x_min != lastClipbox.x_min || clipbox.y_min != lastClipbox.y_min || clipbox.x_max != lastClipbox.x_max || clipbox.y_max != lastClipbox.y_max))) {
         if (skin.a_lineColorIndex) {
           skin._flushLines();
         }
         lastTarget = target;
         if (clipbox) {
           lastClipbox = {
-            x: clipbox.x,
-            y: clipbox.y,
-            w: clipbox.w,
-            h: clipbox.h
+            x_min: clipbox.x_min,
+            y_min: clipbox.y_min,
+            x_max: clipbox.x_max,
+            y_max: clipbox.y_max
           };
         } else {
           lastClipbox = null;
@@ -358,10 +358,10 @@
     setClipbox ({X1, Y1, X2, Y2}, {target}) {
       if (target.isStage) return;
       const newClipbox = {
-        x: Math.min(X1, X2),
-        y: Math.min(Y1, Y2),
-        w: Math.max(X1, X2) - Math.min(X1, X2),
-        h: Math.max(Y1, Y2) - Math.min(Y1, Y2)
+        x_min: Math.min(X1, X2),
+        y_min: Math.min(Y1, Y2),
+        x_max: Math.max(X1, X2),
+        y_max: Math.max(Y1, Y2)
       };
       penDirty = true;
       target.clipbox = newClipbox;
@@ -391,12 +391,12 @@
       const clipbox = target.clipbox;
       if (!clipbox) return '';
       switch (PROP) {
-        case 'width': return clipbox.w;
-        case 'height': return clipbox.h;
-        case 'min x': return clipbox.x;
-        case 'min y': return clipbox.y;
-        case 'max x': return clipbox.x + clipbox.w;
-        case 'max y': return clipbox.y + clipbox.h;
+        case 'width': return clipbox.x_max - clipbox.x_min;
+        case 'height': return clipbox.y_max - clipbox.y_min;
+        case 'min x': return clipbox.x_min;
+        case 'min y': return clipbox.y_min;
+        case 'max x': return clipbox.x_max;
+        case 'max y': return clipbox.y_max;
         default: return '';
       }
     }


### PR DESCRIPTION
This PR:
* Deprecates and hides additive blending blocks
* Adds blocks for working with blend modes (https://github.com/TurboWarp/extensions/pull/263)
![image](https://user-images.githubusercontent.com/90340988/235323501-cce94259-d811-48a4-b3ce-50d4a2913481.png)
* Makes this extension affect pen (https://github.com/TurboWarp/extensions/issues/302)
![image](https://user-images.githubusercontent.com/90340988/235323471-251a1a3b-b094-465d-b4e2-8a6753ae5487.png)
