### PR TITLE
clippingblending: Add more blending options

### DIFF
--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -92,12 +92,23 @@
     }
     switch (blendMode) {
       case 'additive':
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ONE);
+        break;
+      case 'subtract':
+        gl.blendEquation(gl.FUNC_REVERSE_SUBTRACT);
         gl.blendFunc(gl.ONE, gl.ONE);
         break;
       case 'multiply':
+        gl.blendEquation(gl.FUNC_ADD);
         gl.blendFunc(gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA);
         break;
+      case 'invert':
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE_MINUS_DST_COLOR, gl.ONE_MINUS_SRC_COLOR);
+        break;
       default:
+        gl.blendEquation(gl.FUNC_ADD);
         gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
     }
   }
@@ -345,7 +356,7 @@
           },
           blends: {
             acceptReporters: true,
-            items: ['default', 'additive', 'multiply']
+            items: ['default', 'additive', 'subtract', 'multiply', 'invert']
           },
           props: {
             acceptReporters: true,
@@ -406,7 +417,9 @@
       switch (BLENDMODE) {
         case 'default':
         case 'additive':
+        case 'subtract':
         case 'multiply':
+        case 'invert':
           newValue = BLENDMODE;
           break;
         default:


### PR DESCRIPTION
Adds 2 more blending options to the Clipping and Blending extension:
![](https://github.com/TurboWarp/extensions/assets/68464103/f1fcc52a-b961-4027-9445-fc44cf5875b6)

- `subtract`
Your standard subtract option.
![](https://github.com/TurboWarp/extensions/assets/68464103/96e44520-da26-4186-b20e-4b86d9a22116)
- `invert`
Somewhat hard to explain; inverts the sprite when on a white background, and makes it normal on a black one (I would have reversed this behavior so white is normal, but I couldn't find a way to do that). Useful for making a "black-and-white contrast thing" effect.
![](https://github.com/TurboWarp/extensions/assets/68464103/9ac4b758-7fdc-4b23-9ea6-4bf1e8751678)

https://github.com/TurboWarp/extensions/assets/68464103/587271ae-1f2e-44c8-9354-74a9b1f32491
