### PR TITLE
Adjust button hover and active effects

### DIFF
--- a/website/index.ejs
+++ b/website/index.ejs
@@ -157,7 +157,7 @@
         color: white;
         text-decoration: none;
         pointer-events: auto;
-        transition: 0.15s;
+        transition: filter 0.15s;
         filter: drop-shadow(0px 1px 3px #00000075);
       }
       .extension-buttons > *:hover {
@@ -165,7 +165,7 @@
         z-index: 1;
       }
       .extension-buttons *:active {
-        opacity: 0.8;
+        filter: brightness(0.85) drop-shadow(0px 1px 2px #00000075);
       }
       .extension-buttons *:disabled {
         opacity: 0.5;


### PR DESCRIPTION
- Made `transition` at line 160 only apply to `filter`. Now, when you click the button, it will instantly darken instead of fading into a darkened state over 0.15s, and when navigating using a keyboard, the focus ring won't do a weird animation anymore.
- Updated active effect on extension buttons to darken them instead of making them slightly transparent.