### PR TITLE
obviousAlexC/SensingPlus: Hide speech blocks

### DIFF
--- a/extensions/obviousAlexC/SensingPlus.js
+++ b/extensions/obviousAlexC/SensingPlus.js
@@ -573,18 +573,21 @@
                 menu: "toggleMenu",
               },
             },
+            hideFromPalette: true,
           },
           {
             opcode: "returnWords",
             blockType: Scratch.BlockType.REPORTER,
             text: "Recognized Words",
             blockIconURI: speechIco,
+            hideFromPalette: true,
           },
           {
             opcode: "isrecording",
             blockType: Scratch.BlockType.BOOLEAN,
             text: "Recording?",
             blockIconURI: speechIco,
+            hideFromPalette: true,
           },
           "---",
           {


### PR DESCRIPTION
hopefully temporary, but not optimistic

related to https://github.com/TurboWarp/extensions/issues/483

they don't work:

 - In the desktop app
 - In packaged electron projects
 - In Firefox
 - In most Chromium forks
 - In most WebKit forks
 - When offline

and the privacy aspect of sending audio to a remote server for transcription is slightly scary.
