### PR TITLE
Update @turbowarp/types

### DIFF
--- a/extensions/-SIPC-/recording.js
+++ b/extensions/-SIPC-/recording.js
@@ -57,7 +57,6 @@
         return;
       }
       try {
-        // @ts-expect-error - not typed yet
         if (!await Scratch.canRecordAudio()) {
           throw new Error('VM denied permission');
         }

--- a/extensions/LukeManiaStudios/lmsutils.js
+++ b/extensions/LukeManiaStudios/lmsutils.js
@@ -1384,7 +1384,6 @@
 
     readClipboard(args) {
       if (navigator.clipboard && navigator.clipboard.readText) {
-        // @ts-expect-error - not typed yet
         return Scratch.canReadClipboard().then(allowed => {
           if (allowed) {
             return navigator.clipboard.readText();

--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -50,21 +50,14 @@
    */
 
   // temporary
-  // @ts-expect-error
   if (!renderer.exports || !renderer.exports.Skin || !vm.exports) {
     alert('VM is too old for animated text extension');
     throw new Error('VM is too old');
   }
 
-  /** @type {typeof RenderWebGL.Skin} */
-  // @ts-expect-error - exports not typed yet
   const Skin = renderer.exports.Skin;
-  /** @type {typeof RenderWebGL.CanvasMeasurementProvider} */
-  // @ts-expect-error - exports not typed yet
   const CanvasMeasurementProvider = renderer.exports.CanvasMeasurementProvider;
-  // @ts-expect-error - exports not typed yet
   const twgl = renderer.exports.twgl;
-  // @ts-expect-error - exports not typed yet
   const RenderedTarget = vm.exports.RenderedTarget;
 
   /**
@@ -123,7 +116,6 @@
 
   class TextCostumeSkin extends Skin {
     constructor (id, drawable) {
-      // @ts-expect-error - constructors not typed yet
       super(id, renderer);
 
       /** @type {RenderWebGL.Drawable} */
@@ -237,10 +229,8 @@
       this.ctx.font = this._getFontStyle();
 
       // need to make new ones each time to avoid caching incorrectly across fonts
-      // @ts-expect-error - constructors not typed yet
       const measurementProvider = new CanvasMeasurementProvider(this.ctx);
       /** @type {RenderWebGL.TextWrapper} */
-      // @ts-expect-error - createTextWrapper not typed yet
       const textWrapper = renderer.createTextWrapper(measurementProvider);
 
       const lines = textWrapper.wrapText(this.wrapWidth, this.text);
@@ -307,6 +297,7 @@
       }
 
       if (!this._texture) {
+        // @ts-expect-error - twgl not typed yet
         this._texture = twgl.createTexture(gl, {
           auto: false,
           wrap: gl.CLAMP_TO_EDGE
@@ -479,7 +470,6 @@
     return skin;
   };
 
-  // @ts-expect-error - not typed yet
   vm.runtime.on('BEFORE_EXECUTE', () => {
     globalFrameTime = Date.now();
 

--- a/extensions/obviousAlexC/SensingPlus.js
+++ b/extensions/obviousAlexC/SensingPlus.js
@@ -31,7 +31,6 @@
       return;
     }
 
-    // @ts-expect-error - not typed yet
     if (!await Scratch.canRecordAudio()) {
       return;
     }
@@ -780,7 +779,6 @@
 
     getClipBoard() {
       if (navigator.clipboard && navigator.clipboard.readText) {
-        // @ts-expect-error - not typed yet
         return Scratch.canReadClipboard().then(allowed => {
           if (allowed) {
             return navigator.clipboard.readText();

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,10 +125,9 @@
         "fastq": "^1.6.0"
       }
     },
-    "@turbowarp/types-tw": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@turbowarp/types-tw/-/types-tw-0.0.6.tgz",
-      "integrity": "sha512-mQxaUypyHe2D18bBsnbTYzAgRTXpM7Dz2cH1bvh8eGJbQUAWHtKxpKcO9Sz57fYye+6hzlx1XrcuaTgRlCOwiQ=="
+    "@turbowarp/types": {
+      "version": "git+https://github.com/TurboWarp/types-tw.git#2254ba017282c3f87d373f3d8646d2b7136166b2",
+      "from": "git+https://github.com/TurboWarp/types-tw.git#tw"
     },
     "accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/TurboWarp/extensions#readme",
   "dependencies": {
-    "@turbowarp/types-tw": "^0.0.6",
+    "@turbowarp/types": "git+https://github.com/TurboWarp/types-tw.git#tw",
     "chokidar": "^3.5.3",
     "ejs": "^3.1.9",
     "express": "^4.18.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,19 +6,19 @@
     "checkJs": true,
     "paths": {
       // See https://github.com/turboWarp/types#using-from-npm
-      "scratch-vm": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-render": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-svg-renderer": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-render-fonts": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-storage": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-audio": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-parser": ["./node_modules/@turbowarp/types-tw/index.d.ts"],
-      "scratch-blocks": ["./node_modules/@turbowarp/types-tw/index.d.ts"]
+      "scratch-vm": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-render": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-svg-renderer": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-render-fonts": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-storage": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-audio": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-parser": ["./node_modules/@turbowarp/types/index.d.ts"],
+      "scratch-blocks": ["./node_modules/@turbowarp/types/index.d.ts"]
     }
   },
   "include": [
-    "node_modules/@turbowarp/types-tw/types/scratch-vm-extension.d.ts",
-    "node_modules/@turbowarp/types-tw/types/scratchx-extension.d.ts",
+    "node_modules/@turbowarp/types/types/scratch-vm-extension.d.ts",
+    "node_modules/@turbowarp/types/types/scratchx-extension.d.ts",
     "extensions/**/*",
     "website/**/*"
   ]


### PR DESCRIPTION
## For development server users, you will need to run `npm ci` after pulling this

types-tw is now installed as a git repository instead of an npm package: this reduces friction for updates considerably

Many new types are added for the new APIs that now exist. Most of the weird things in lab/text are now fully type checked
