### PR TITLE
Utilities: Fix typo in the name

### DIFF
--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -35,7 +35,7 @@
     getInfo() {
       return {
         id: 'utilities',
-        name: 'Utlities',
+        name: 'Utilities',
 
         color1: '#8BC34A',
         color2: '#7CB342',


### PR DESCRIPTION
For the longest time, it's actually been called "Utlities"
![image](https://github.com/TurboWarp/extensions/assets/127533508/6a3b29d8-e6f3-430d-b5df-d38349e1710c)
