### PR TITLE
LMS Utilities: Rename "Replace" block

### DIFF
--- a/extensions/LukeManiaStudios/lmsutils.js
+++ b/extensions/LukeManiaStudios/lmsutils.js
@@ -169,7 +169,7 @@
           {
             opcode: 'replaceWords',
             blockType: Scratch.BlockType.REPORTER,
-            text: 'replace [INPUTA] with [INPUTB] in [STRING]',
+            text: 'replace first [INPUTA] with [INPUTB] in [STRING]',
             disableMonitor: true,
             arguments: {
               INPUTA: {


### PR DESCRIPTION
Rename the "replace" block to better match how it functions.