### PR TITLE
Remove desktop app version number from the website

### DIFF
--- a/website/index.ejs
+++ b/website/index.ejs
@@ -245,7 +245,7 @@
         <% } else { %>
           <div class="infobox-title">Some extensions may not work in TurboWarp Desktop.</div>
           For compatibility, security, and offline support, each <a href="https://desktop.turbowarp.org/">TurboWarp Desktop</a> update contains an offline copy of these extensions from its release date, so some extensions may be outdated or missing.
-          Use the <a href="https://desktop.turbowarp.org/">latest update (v1.8.0)</a> for best results.
+          Use the latest update for best results.
         <% } %>
       </div>
     </div>


### PR DESCRIPTION
it's been outdated for a week, and hopefully we will be releasing these more regularly