### PR TITLE
files: Add download URL block

### DIFF
--- a/extensions/files.js
+++ b/extensions/files.js
@@ -165,19 +165,28 @@
   });
 
   /**
-   * @param {string|Blob} data Text or blob to download
+   * @param {string} data Text to download
    * @param {string} file Name of the file
    */
-  const download = (data, file) => {
-    const blob = data instanceof Blob ? data : new Blob([data]);
+  const downloadText = (data, file) => {
+    const blob = new Blob([data]);
     const url = URL.createObjectURL(blob);
+    downloadURL(url, file);
+    URL.revokeObjectURL(url);
+  };
+
+  /**
+   * Assumes that permission to fetch the URL has already been granted.
+   * @param {string} url
+   * @param {string} file
+   */
+  const downloadURL = (url, file) => {
     const link = document.createElement('a');
     link.href = url;
     link.download = file;
     document.body.appendChild(link);
     link.click();
     link.remove();
-    URL.revokeObjectURL(url);
   };
 
   class Files {
@@ -254,9 +263,9 @@
             }
           },
           {
-            opcode: 'downloadDataUrl',
+            opcode: 'downloadURL',
             blockType: Scratch.BlockType.COMMAND,
-            text: 'download data: URL [url] as [file]',
+            text: 'download URL [url] as [file]',
             arguments: {
               url: {
                 type: Scratch.ArgumentType.STRING,
@@ -332,19 +341,11 @@
     }
 
     download (args) {
-      download(args.text, args.file);
+      downloadText(Scratch.Cast.toString(args.text), Scratch.Cast.toString(args.file));
     }
 
-    async downloadDataUrl (args) {
-      try {
-        args.url = Scratch.Cast.toString(args.url);
-        if (new URL(args.url).protocol !== "data:") return;
-        const resp = await Scratch.fetch(args.url);
-        const blob = await resp.blob();
-        download(blob, args.file);
-      } catch (e) {
-        // ignore
-      }
+    downloadURL (args) {
+      downloadURL(Scratch.Cast.toString(args.url), Scratch.Cast.toString(args.file));
     }
 
     setOpenMode (args) {

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -165,11 +165,11 @@
   });
 
   /**
-   * @param {string} text Text to download
+   * @param {string|Blob} text Text or blob to download
    * @param {string} file Name of the file
    */
   const download = (text, file) => {
-    const blob = new Blob([text]);
+    const blob = !(text instanceof Blob) ? new Blob([text]) : text;
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
@@ -254,6 +254,21 @@
             }
           },
           {
+            opcode: 'downloadDataUrl',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'download data: URL [url] as [file]',
+            arguments: {
+              url: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'data:text/plain;base64,SGVsbG8sIHdvcmxkIQ=='
+              },
+              file: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'save.txt'
+              }
+            }
+          },
+          {
             opcode: 'setOpenMode',
             blockType: Scratch.BlockType.COMMAND,
             text: 'set open file selector mode to [mode]',
@@ -315,6 +330,16 @@
 
     download (args) {
       download(args.text, args.file);
+    }
+
+    async downloadDataUrl (args) {
+      try {
+        args.url = Scratch.Cast.toString(args.url);
+        if (new URL(args.url).protocol !== "data:") return;
+        const resp = await Scratch.fetch(args.url);
+        const blob = await resp.blob();
+        download(blob, args.file);
+      } catch (e) { }
     }
 
     setOpenMode (args) {

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -268,6 +268,9 @@
               }
             }
           },
+
+          '---',
+
           {
             opcode: 'setOpenMode',
             blockType: Scratch.BlockType.COMMAND,

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -165,11 +165,11 @@
   });
 
   /**
-   * @param {string|Blob} text Text or blob to download
+   * @param {string|Blob} data Text or blob to download
    * @param {string} file Name of the file
    */
-  const download = (text, file) => {
-    const blob = !(text instanceof Blob) ? new Blob([text]) : text;
+  const download = (data, file) => {
+    const blob = data instanceof Blob ? data : new Blob([data]);
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -342,7 +342,9 @@
         const resp = await Scratch.fetch(args.url);
         const blob = await resp.blob();
         download(blob, args.file);
-      } catch (e) { }
+      } catch (e) {
+        // ignore
+      }
     }
 
     setOpenMode (args) {

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -204,13 +204,16 @@
    * @param {string} url
    * @param {string} file
    */
-  const downloadUntrustedURL = async (url, file) => {
+  const downloadUntrustedURL = (url, file) => {
+    // Don't want to return a Promise here when not actually needed
     if (isDataURL(url)) {
       downloadURL(url, file);
     } else {
-      const response = await Scratch.fetch(url);
-      const blob = await response.blob();
-      downloadBlob(blob, file);
+      return Scratch.fetch(url)
+        .then(res => res.blob())
+        .then(blob => {
+          downloadBlob(blob, file);
+        });
     }
   };
 
@@ -370,7 +373,7 @@
     }
 
     downloadURL (args) {
-      downloadUntrustedURL(Scratch.Cast.toString(args.url), Scratch.Cast.toString(args.file));
+      return downloadUntrustedURL(Scratch.Cast.toString(args.url), Scratch.Cast.toString(args.file));
     }
 
     setOpenMode (args) {


### PR DESCRIPTION
![image](https://github.com/TurboWarp/extensions/assets/68464103/01157859-146f-4b37-a264-bd874b527073)
Useful for downloading binary data that downloading as text would mess up, like PNG or zip (*hint hint*) files.