### PR TITLE
Fix oversight in Canvas Effects

### DIFF
--- a/extensions/TheShovel/CanvasEffects.js
+++ b/extensions/TheShovel/CanvasEffects.js
@@ -69,7 +69,7 @@
                     {
                         opcode: 'renderscale',
                         blockType: Scratch.BlockType.COMMAND,
-                        text: 'set canvas render size to x:[X] y:[Y]',
+                        text: 'set canvas render size to width:[X] height:[Y]',
                         arguments: {
                             X: {
                                 type: Scratch.ArgumentType.NUMBER,


### PR DESCRIPTION
X and Y are usually used for position, not size.