### PR TITLE
CST1229/zip: fix going to `/`

### DIFF
--- a/extensions/CST1229/zip.js
+++ b/extensions/CST1229/zip.js
@@ -824,7 +824,7 @@
       try {
         let newPath = this.normalize(this.zipPath, DIR);
         if (!newPath.endsWith("/")) newPath += "/";
-        if (!this.getObj(newPath)) return;
+        if (!this.getObj(newPath) && newPath !== "/") return;
         this.zipPath = newPath;
       } catch (e) {
         console.error(`Error going to directory ${DIR}:`, e);

--- a/website/CST1229/zip.html
+++ b/website/CST1229/zip.html
@@ -490,7 +490,9 @@
     </h3>
     <p>
       Moves the current directory (the default origin of most file operations)
-      to the speficied directory. If it doesn't exist, this block will do nothing.
+      to the specified directory. If it doesn't exist, this block will do nothing.
+      Use <code>..</code> to go to the previous (parent) directory, and
+      <code>/</code> to go to the root.
     </p>
 
     <h3 id="dir-contents">


### PR DESCRIPTION
Resolves #753
whoops
(also adds a sentence about going to the root and the parent directory in the docs for the block)