### PR TITLE
Add CORS Proxy docs/extension

### DIFF
--- a/docs/NexusKitten/corsproxy.md
+++ b/docs/NexusKitten/corsproxy.md
@@ -1,0 +1,34 @@
+# CORS Proxies
+
+The CORS Proxy extension is an extension to easily add CORS proxies to fetch requests, or to send fetch requests with built-in CORS proxies.
+
+## What is CORS?
+
+CORS, or Cross-Origin Resource Sharing, is a browser mechanism that allows one website to fetch information from another. For example, CORS would be used to grab information from GitHub on the TurboWarp website.
+However, most websites don't support CORS off the bat. With the exception of certain APIs, most sites will return an error when you try to fetch from them.
+
+## What is a CORS Proxy?
+
+A CORS proxy is a website that accepts CORS fetch requests, and is specially designed to fetch from other sites, even if they don't support CORS. It essentially acts as a middle man; when a fetch request is sent to a CORS proxy, it then sends a special fetch request to the site, and returns the data without CORS errors. Most CORS proxies are free for use as long as the files requested aren't too large or frequent.
+
+## Extension Blocks
+
+Although it's relatively simple to modify fetch requests to include a CORS Proxy, [this extension](https://extensions.turbowarp.org/NexusKitten/corsproxy.js) includes 3 blocks to make the process simpler.
+
+```scratch
+([] CORS protected :: #376661)
+```
+
+Modifies the inputted URL to go through a CORS proxy. This can be used in conjunction with extensions such as ShovelUtils. The block may cause issues if the inputted URL already uses a CORS proxy.
+
+```scratch
+(fetch [] CORS protected :: #376661)
+```
+
+Sends a fetch request with a built in CORS proxy. The block may cause issues if the inputted URL already uses a CORS proxy.
+
+```scratch
+change proxy to [corsproxy v] :: #376661
+```
+
+Choose between 2 CORS proxy providers. The ones provided are [corsproxy.io](https://corsproxy.io) and [allorigins](https://allorigins.win). The latter of these two does not support images.

--- a/extensions/NexusKitten/corsproxy.js
+++ b/extensions/NexusKitten/corsproxy.js
@@ -1,3 +1,8 @@
+// Name: CORS Proxy
+// ID: nkcorsproxy
+// Description: Simple blocks for avoiding CORS errors.
+// By: NamelessCat <https://scratch.mit.edu/users/NexusKitten/>
+
 (function(Scratch) {
   'use strict';
 
@@ -16,7 +21,7 @@
       return {
         id: 'nkcorsproxy',
         name: 'CORS Proxy',
-        docsURI: "https://extensions.turbowarp.org/NexusKitten/corsproxy.html",
+        docsURI: "https://extensions.turbowarp.org/CubesterYT/corsproxy",
         color1: '#376661',
         color2: '#3b6766',
         blocks: [

--- a/extensions/NexusKitten/corsproxy.js
+++ b/extensions/NexusKitten/corsproxy.js
@@ -1,0 +1,93 @@
+(function(Scratch) {
+  'use strict';
+
+  if (!Scratch.extensions.unsandboxed) {
+    throw new Error('CORS Proxy must run unsandboxed');
+  }
+
+  var proxy = 'corsproxy';
+
+  // Provide 2 options in case one goes down, or something.
+  const corsproxy = 'https://corsproxy.io/?';
+  const allorigins = 'https://api.allorigins.win/raw?url=';
+
+  class nkcorsproxy {
+    getInfo() {
+      return {
+        id: 'nkcorsproxy',
+        name: 'CORS Proxy',
+        docsURI: "https://extensions.turbowarp.org/NexusKitten/corsproxy.html",
+        color1: '#376661',
+        color2: '#3b6766',
+        blocks: [
+          '---',
+          {
+            opcode: 'addcors',
+            blockType: Scratch.BlockType.REPORTER,
+            text: '[URL] CORS protected',
+            arguments: {
+              URL: {
+                type: Scratch.ArgumentType.STRING,
+                default: ''
+              }
+            }
+          },
+          {
+            opcode: 'fetchcors',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'fetch [URL] CORS protected',
+            arguments: {
+              URL: {
+                type: Scratch.ArgumentType.STRING,
+                default: ''
+              }
+            }
+          },
+          '---',
+          {
+            opcode: 'setcors',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'change proxy to [PROXY]',
+            arguments: {
+              PROXY: {
+                type: Scratch.ArgumentType.STRING,
+                menu: 'PROXIES',
+                default: proxy
+              }
+            }
+          },
+        ],
+        menus: {
+          PROXIES: {
+            acceptreporters: true,
+            items: ['corsproxy', 'allorigins']
+          }
+        }
+      };
+    }
+
+    addcors(args) {
+      if (proxy === 'allorigins') {
+        return allorigins + args.URL;
+      }
+      return corsproxy + encodeURIComponent(args.URL);
+    }
+
+    async fetchcors(args) {
+      if (proxy === 'allorigins') {
+        return await Scratch.fetch(allorigins + args.URL)
+          .then(r => r.text())
+          .catch(() => '');
+      }
+      return await Scratch.fetch(corsproxy + encodeURIComponent(args.URL))
+        .then(r => r.text())
+        .catch(() => '');
+    }
+
+    setcors(args) {
+      proxy = args.PROXY;
+    }
+  }
+
+  Scratch.extensions.register(new nkcorsproxy());
+})(Scratch);

--- a/extensions/NexusKitten/corsproxy.js
+++ b/extensions/NexusKitten/corsproxy.js
@@ -4,59 +4,59 @@
 // By: NamelessCat <https://scratch.mit.edu/users/NexusKitten/>
 
 (function(Scratch) {
-  'use strict';
+  "use strict";
 
   if (!Scratch.extensions.unsandboxed) {
-    throw new Error('CORS Proxy must run unsandboxed');
+    throw new Error("CORS Proxy must run unsandboxed");
   }
 
-  var proxy = 'corsproxy';
+  var proxy = "corsproxy";
 
   // Provide 2 options in case one goes down, or something.
-  const corsproxy = 'https://corsproxy.io/?';
-  const allorigins = 'https://api.allorigins.win/raw?url=';
+  const corsproxy = "https://corsproxy.io/?";
+  const allorigins = "https://api.allorigins.win/raw?url=";
 
   class nkcorsproxy {
     getInfo() {
       return {
-        id: 'nkcorsproxy',
-        name: 'CORS Proxy',
+        id: "nkcorsproxy",
+        name: "CORS Proxy",
         docsURI: "https://extensions.turbowarp.org/CubesterYT/corsproxy",
-        color1: '#376661',
-        color2: '#3b6766',
+        color1: "#376661",
+        color2: "#3b6766",
         blocks: [
-          '---',
+          "---",
           {
-            opcode: 'addcors',
+            opcode: "addcors",
             blockType: Scratch.BlockType.REPORTER,
-            text: '[URL] CORS protected',
+            text: "[URL] CORS protected",
             arguments: {
               URL: {
                 type: Scratch.ArgumentType.STRING,
-                default: ''
+                default: ""
               }
             }
           },
           {
-            opcode: 'fetchcors',
+            opcode: "fetchcors",
             blockType: Scratch.BlockType.REPORTER,
-            text: 'fetch [URL] CORS protected',
+            text: "fetch [URL] CORS protected",
             arguments: {
               URL: {
                 type: Scratch.ArgumentType.STRING,
-                default: ''
+                default: ""
               }
             }
           },
-          '---',
+          "---",
           {
-            opcode: 'setcors',
+            opcode: "setcors",
             blockType: Scratch.BlockType.COMMAND,
-            text: 'change proxy to [PROXY]',
+            text: "change proxy to [PROXY]",
             arguments: {
               PROXY: {
                 type: Scratch.ArgumentType.STRING,
-                menu: 'PROXIES',
+                menu: "PROXIES",
                 default: proxy
               }
             }
@@ -65,28 +65,28 @@
         menus: {
           PROXIES: {
             acceptreporters: true,
-            items: ['corsproxy', 'allorigins']
+            items: ["corsproxy", "allorigins"]
           }
         }
       };
     }
 
     addcors(args) {
-      if (proxy === 'allorigins') {
+      if (proxy === "allorigins") {
         return allorigins + args.URL;
       }
       return corsproxy + encodeURIComponent(args.URL);
     }
 
     async fetchcors(args) {
-      if (proxy === 'allorigins') {
+      if (proxy === "allorigins") {
         return await Scratch.fetch(allorigins + args.URL)
           .then(r => r.text())
-          .catch(() => '');
+          .catch(() => "");
       }
       return await Scratch.fetch(corsproxy + encodeURIComponent(args.URL))
         .then(r => r.text())
-        .catch(() => '');
+        .catch(() => "");
     }
 
     setcors(args) {

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -8,6 +8,7 @@
   "cursor",
   "runtime-options",
   "fetch",
+  "NexusKitten/corsproxy",
   "text",
   "local-storage",
   "true-fantom/base",


### PR DESCRIPTION
AN extension to help teach about CORS errors, and hopefully avoid future GitHub issues for them lol.

This is my first time using the documentation API, lmk if I messed anything up.

![image](https://github.com/TurboWarp/extensions/assets/127152751/e43a49df-41a3-4f90-91fc-427b59affcf2)
![image](https://github.com/TurboWarp/extensions/assets/127152751/3094c77f-c930-4482-a6ef-6d3d988e46c5)


# **_Any feedback/upvotes (👍) are apprecieted!_**