### PR TITLE
Camera Controls: Minor Fixes

### DIFF
--- a/extensions/DT/cameracontrols.js
+++ b/extensions/DT/cameracontrols.js
@@ -19,6 +19,7 @@
 
   vm.runtime.runtimeOptions.fencing = false;
   vm.renderer.offscreenTouching = true;
+  vm.setInterpolation(false);
 
   function updateCamera(x = cameraX, y = cameraY, scale = cameraZoom / 100, rot = -cameraDirection + 90) {
     rot = rot / 180 * Math.PI;
@@ -347,6 +348,7 @@
     setCol(args, util) {
       const rgb = Scratch.Cast.toRgbColorList(args.val);
       Scratch.vm.renderer.setBackgroundColor(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+      cameraBG = args.val;
     }
     getCol() {
       return cameraBG;


### PR DESCRIPTION
- Actually set the camera BG value that's used in the reporter
- Disable interpolation when loading which almost completely ruins the camera