### PR TITLE
ShovelUtils Update.

### DIFF
--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -353,7 +353,7 @@
     }
 
     deleteImage({ SPRITE, COSNAME }){
-      //0znzw, since shovel did not add it yet.
+      // 0znzw, since shovel did not add it yet.
       const target = vm.runtime.getSpriteTargetByName(SPRITE);
       if (!target) {
         return;
@@ -362,10 +362,9 @@
     }
 
     getAllSprites(){
-      //0znzw, since shovel did not add it yet.
-      let sprites = new Object([]), target = "";
-      for (target in vm.runtime.targets) {
-        target = vm.runtime.targets[target];
+      // 0znzw, since shovel did not add it yet.
+      let sprites = [];
+      for (const target of vm.runtime.targets) {
         if (target.isOriginal) sprites.push(target.sprite.name);
       }
       return JSON.stringify(sprites);

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -1,6 +1,9 @@
 (function (Scratch) {
   'use strict';
-  console.log("ShovelUtils v1.3");
+  if (!Scratch.extensions.unsandboxed) {
+    throw new Error('ShovelUtils must be run unsandboxed');
+  }
+  console.log("ShovelUtils v1.4");
   const vm = Scratch.vm;
 
   // Based on from https://www.growingwiththeweb.com/2017/12/fast-simple-js-fps-counter.html
@@ -139,6 +142,21 @@
             }
           },
           {
+            opcode: 'deleteImage',
+            blockType: Scratch.BlockType.COMMAND,
+            text: 'Delete costume [COSNAME] in [SPRITE]',
+            arguments: {
+              COSNAME: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'costume1'
+              },
+              SPRITE: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'Sprite1'
+              }
+            }
+          },
+          {
             opcode: 'setedtarget',
             blockType: Scratch.BlockType.COMMAND,
             text: 'Set editing target to [NAME]',
@@ -162,6 +180,11 @@
             }
           },
 
+          {
+            opcode: 'getAllSprites',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'get all sprites'
+          },
           {
             opcode: 'getfps',
             blockType: Scratch.BlockType.REPORTER,
@@ -328,8 +351,25 @@
     getfps(){
       return fps;
     }
-  }
 
+    deleteImage({ SPRITE, COSNAME }){
+      //0znzw, since shovel did not add it yet.
+      const target = vm.runtime.getSpriteTargetByName(SPRITE);
+      if (!target) {
+        return;
+      }
+      target.deleteCostume(target.getCostumeIndexByName(COSNAME));
+    }
+
+    getAllSprites(){
+      //0znzw, since shovel did not add it yet.
+      let sprites = new Object([]), target = "";
+      for (target in vm.runtime.targets) {
+        sprites.push(vm.runtime.targets[target].sprite.name);
+      }
+      return JSON.stringify(sprites);
+    }
+  }
   Scratch.extensions.register(new ShovelUtils());
 // @ts-ignore
 })(Scratch);

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -365,7 +365,8 @@
       //0znzw, since shovel did not add it yet.
       let sprites = new Object([]), target = "";
       for (target in vm.runtime.targets) {
-        sprites.push(vm.runtime.targets[target].sprite.name);
+        target = vm.runtime.targets[target];
+        if (target.isOriginal) sprites.push(target.sprite.name);
       }
       return JSON.stringify(sprites);
     }


### PR DESCRIPTION
Added a "get all sprites" reporter, 
![image](https://github.com/TurboWarp/extensions/assets/135030944/0d40711a-dbed-48f0-a0f7-2bf65d7d0d80)
and a "delete image named [name] in sprite [sprite]" block
![image](https://github.com/TurboWarp/extensions/assets/135030944/c7ddcfe1-5f7f-4351-8e03-14c9b2d4f323)


Other changes.
Changed the version number to v1.4,
Added a unsandboxed error.