### PR TITLE
TheShovel/LZ-String: remove docsURI

### DIFF
--- a/extensions/TheShovel/LZ-String.js
+++ b/extensions/TheShovel/LZ-String.js
@@ -224,7 +224,6 @@
             return {
                 id: 'shovellzcompress',
                 name: 'LZ Compress',
-                docsURI: 'https://pieroxy.net/blog/pages/lz-string/index.html',
                 blocks: [{
                         opcode: 'compress',
                         blockType: Scratch.BlockType.REPORTER,


### PR DESCRIPTION
The linked page is not very useful from the perspective of people using this as a Scratch extension