### PR TITLE
Correct closing span tag in documentation

### DIFF
--- a/website/CubesterYT/TurboHook.html
+++ b/website/CubesterYT/TurboHook.html
@@ -67,7 +67,7 @@
 	</head>
 	<body>
 		<div class="uppertext">
-			<span class="title">TurboHook extension documentation</title>
+			<span class="title">TurboHook extension documentation</span>
 		</div>
 		<div class="inbox">
 			<h2>About this extension</h2>

--- a/website/ar.html
+++ b/website/ar.html
@@ -71,7 +71,7 @@
 	</head>
 	<body>
 		<div class="uppertext">
-			<span class="title">Augmented Reality extension documentation</title>
+			<span class="title">Augmented Reality extension documentation</span>
 		</div>
 		<div class="inbox">
 			<h2>Requirements</h2>

--- a/website/bitwise.html
+++ b/website/bitwise.html
@@ -71,7 +71,7 @@
 	</head>
 	<body>
 		<div class="uppertext">
-			<span class="title">Bitwise extension documentation</title>
+			<span class="title">Bitwise extension documentation</span>
 		</div>
 		<div class="inbox">
 			<h2>About this extension</h2>

--- a/website/box2d.html
+++ b/website/box2d.html
@@ -71,7 +71,7 @@
 	</head>
 	<body>
 		<div class="uppertext">
-			<span class="title">Box2D Physics extension documentation</title>
+			<span class="title">Box2D Physics extension documentation</span>
 		</div>
 		<div class="inbox">
 			<h2>About this extension</h2>

--- a/website/local-storage.html
+++ b/website/local-storage.html
@@ -71,7 +71,7 @@
 	</head>
 	<body>
 		<div class="uppertext">
-			<span class="title">How to use Local Storage</title>
+			<span class="title">How to use Local Storage</span>
 		</div>
 		<div class="inbox">
 			<h2>About this extension</h2>


### PR DESCRIPTION
Corrects `<span class="title">...</title>` to `<span class="title">...</span>`.