### PR TITLE
Skins: Fix "restore targets with skin" block

### DIFF
--- a/extensions/Lily/Skins.js
+++ b/extensions/Lily/Skins.js
@@ -356,7 +356,7 @@
       if (!createdSkins[skinName]) return;
       const skinId = createdSkins[skinName];
 
-      this._refreshTargetsFromID(skinId, false);
+      this._refreshTargetsFromID(skinId, true);
     }
 
     // Utility Functions


### PR DESCRIPTION
I don't remember how this value got changed, but it did at some point 