### PR TITLE
Block to get details of gamepads

### DIFF
--- a/extensions/gamepad.js
+++ b/extensions/gamepad.js
@@ -71,6 +71,14 @@
     return axisValue;
   };
 
+  const matchVendor = (id) => {
+    return id.match(/vendor:\s*(\w+)/i)[1];
+  };
+
+  const matchProduct = (id) => {
+    return id.match(/product:\s*(\w+)/i)[1];
+  };
+
   class GamepadExtension {
     getInfo() {
       return {
@@ -89,6 +97,26 @@
               }
             }
           },
+          {
+            opcode: 'gamepadDetail',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'get [d] of pad [i]',
+            arguments: {
+              d: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'id',
+                menu: 'detailMenu'
+              },
+              i: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: '1',
+                menu: 'padMenu'
+              }
+            }
+          },
+
+          '---',
+
           {
             opcode: 'buttonDown',
             blockType: Scratch.BlockType.BOOLEAN,
@@ -272,6 +300,10 @@
               }
             ],
           },
+          detailMenu: {
+            acceptReporters: true,
+            items: ['id', 'vendor', 'product', 'mapping']
+          },
           buttonMenu: {
             acceptReporters: true,
             items: [
@@ -400,6 +432,18 @@
 
     gamepadConnected ({pad}) {
       return getGamepads(pad).length > 0;
+    }
+
+    gamepadDetail ({d, i}) {
+      for (const gamepad of getGamepads(i)) {
+        switch (d) {
+          case 'mapping': return gamepad.mapping;
+          case 'vendor': return matchVendor(gamepad.id);
+          case 'product': return matchProduct(gamepad.id);
+          case 'id': return gamepad.id;
+        }
+      }
+      return 'not connected';
     }
 
     buttonDown ({b, i}) {

--- a/extensions/gamepad.js
+++ b/extensions/gamepad.js
@@ -71,10 +71,18 @@
     return axisValue;
   };
 
+  /**
+   * @param {Gamepad.id} id
+   * @returns {string}
+   */
   const matchVendor = (id) => {
     return id.match(/vendor:\s*(\w+)/i)[1];
   };
 
+  /**
+   * @param {Gamepad.id} id
+   * @returns {string}
+   */
   const matchProduct = (id) => {
     return id.match(/product:\s*(\w+)/i)[1];
   };


### PR DESCRIPTION
Resolves #147

Adds a block to the Gamepad extension that allows you to get information about connected gamepads.

At some point, I'd like to add a way to get the model (like is this an Xbox One controller or a PlayStation DualShock or...?) so you don't ever have to write your own code to use the vendor or product to tell what kind of controller it is, you just leave it up to the block and it'll tell you. I've already done some work on such a function, I just need to find more information so it works on more controllers.

It'd also be nice to add cross-browser compatibility. Currently, the vendor and product matching functions only work properly on Chromium-based browsers. For Firefox, see [Gamepad: id property](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id).

Tested in Edge 115.