### PR TITLE
Remove uses of window.Scratch

### DIFF
--- a/extensions/obviousAlexC/SensingPlus.js
+++ b/extensions/obviousAlexC/SensingPlus.js
@@ -1077,4 +1077,4 @@
     }
   }
   Scratch.extensions.register(new SensingPlus());
-})(window.Scratch);
+})(Scratch);

--- a/extensions/obviousAlexC/newgroundsIO.js
+++ b/extensions/obviousAlexC/newgroundsIO.js
@@ -9724,4 +9724,4 @@
   }, 1500);
 
   Scratch.extensions.register(new NewgroundsAPI());
-})(window.Scratch);
+})(Scratch);

--- a/extensions/penplus.js
+++ b/extensions/penplus.js
@@ -2656,4 +2656,4 @@ Other various small fixes
   }
 
   Scratch.extensions.register(new PenPlus());
-})(window.Scratch); // use window.Scratch so it doesn't throw error in plugin loaders
+})(Scratch);

--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -297,4 +297,4 @@
   }
 
   Scratch.extensions.register(new RuntimeOptions());
-})(window.Scratch);
+})(Scratch);


### PR DESCRIPTION
Can't promise this will still work with upcoming extension loading changes
