### PR TITLE
docs-examples/.../broadcast-5: Fix blocktype

### DIFF
--- a/extensions/docs-examples/unsandboxed/broadcast-5.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-5.js
@@ -8,7 +8,7 @@
         blocks: [
           {
             opcode: 'whenReceived',
-            blockType: Scratch.BlockType.HAT,
+            blockType: Scratch.BlockType.EVENT,
             text: 'when I receive [EVENT_OPTION]',
             isEdgeActivated: false,
             arguments: {


### PR DESCRIPTION
The extension throws an error when it isn't an event.