### PR TITLE
Use endOfLine: auto for prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
On Windows, editors typically use CRLF by default. I don't see a reason why we should be violating platform conventions, so just let anyone use whatever (as long as it isn't mixed)