### PR TITLE
Update GitHub.io links

### DIFF
--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -110,7 +110,7 @@
               TEXT: {
                 type: Scratch.ArgumentType.STRING,
                 defaultValue:
-                  "https://theshovel.github.io/Bullet-Hell/Bullet%20Hell",
+                  "https://extensions.turbowarp.org/samples/Box2D.sb3",
               },
             },
           },

--- a/extensions/cloudlink.js
+++ b/extensions/cloudlink.js
@@ -12,7 +12,9 @@
 
   // Get the server URL list
   try {
-    Scratch.fetch("https://raw.githubusercontent.com/MikeDev101/cloudlink/master/serverlist.json")
+    Scratch.fetch(
+      "https://raw.githubusercontent.com/MikeDev101/cloudlink/master/serverlist.json"
+    )
       .then((response) => {
         return response.text();
       })
@@ -324,8 +326,7 @@
             arguments: {
               url: {
                 type: "string",
-                defaultValue:
-                  "https://extensions.turbowarp.org/hello.txt",
+                defaultValue: "https://extensions.turbowarp.org/hello.txt",
               },
             },
           },
@@ -341,8 +342,7 @@
               },
               url: {
                 type: "string",
-                defaultValue:
-                  "https://extensions.turbowarp.org/hello.txt",
+                defaultValue: "https://extensions.turbowarp.org/hello.txt",
               },
               data: {
                 type: "string",

--- a/extensions/cloudlink.js
+++ b/extensions/cloudlink.js
@@ -12,7 +12,7 @@
 
   // Get the server URL list
   try {
-    Scratch.fetch("https://mikedev101.github.io/cloudlink/serverlist.json")
+    Scratch.fetch("https://raw.githubusercontent.com/MikeDev101/cloudlink/master/serverlist.json")
       .then((response) => {
         return response.text();
       })
@@ -325,7 +325,7 @@
               url: {
                 type: "string",
                 defaultValue:
-                  "https://mikedev101.github.io/cloudlink/fetch_test",
+                  "https://extensions.turbowarp.org/hello.txt",
               },
             },
           },
@@ -342,7 +342,7 @@
               url: {
                 type: "string",
                 defaultValue:
-                  "https://mikedev101.github.io/cloudlink/fetch_test",
+                  "https://extensions.turbowarp.org/hello.txt",
               },
               data: {
                 type: "string",


### PR DESCRIPTION
These now require permission because we will follow redirects. Point them to alternatives that are known to be safe.