### PR TITLE
Add clamp and scale blocks to Math

### DIFF
--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -326,6 +326,53 @@
           },
           "---",
           {
+            opcode: "clamp_block",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "clamp [A] between [B] and [C]",
+            arguments: {
+              A: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "\n",
+              },
+              B: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "0",
+              },
+              C: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "100",
+              },
+            },
+          },
+          {
+            opcode: "scale_block",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "map [A] from range [m1] - [M1] to range [m2] - [M2]",
+            arguments: {
+              A: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "\n",
+              },
+              m1: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "0",
+              },
+              M1: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "100",
+              },
+              m2: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "0",
+              },
+              M2: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "1",
+              },
+            },
+          },
+          "---",
+          {
             opcode: "trunc2_block",
             blockType: Scratch.BlockType.REPORTER,
             text: "trunc of [A] with [B] digits after dot",
@@ -495,6 +542,17 @@
     }
     exactly_cont_block({ A, B }) {
       return cast.toString(A).includes(cast.toString(B));
+    }
+    clamp_block({ A, B, C }) {
+      return Math.min(Math.max(A, B), C);
+    }
+    scale_block({ A, m1, M1, m2, M2 }) {
+      return (
+        ((cast.toNumber(A) - cast.toNumber(m1)) *
+          (cast.toNumber(M2) - cast.toNumber(m2))) /
+          (cast.toNumber(M1) - cast.toNumber(m1)) +
+        cast.toNumber(m2)
+      );
     }
     trunc2_block({ A, B }) {
       let n = Math.floor(cast.toNumber(B));

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -544,7 +544,7 @@
       return cast.toString(A).includes(cast.toString(B));
     }
     clamp_block({ A, B, C }) {
-      return Math.min(Math.max(A, B), C);
+      return B < C ? Math.min(Math.max(A, B), C) : Math.min(Math.max(A, C), B);
     }
     scale_block({ A, m1, M1, m2, M2 }) {
       return (

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -544,15 +544,13 @@
       return cast.toString(A).includes(cast.toString(B));
     }
     clamp_block({ A, B, C }) {
-      return B < C
-        ? Math.min(
-            Math.max(cast.toNumber(A), cast.toNumber(B)),
-            cast.toNumber(C)
-          )
-        : Math.min(
-            Math.max(cast.toNumber(A), cast.toNumber(C)),
-            cast.toNumber(B)
-          );
+      if (cast.compare(A, B) < 0) {
+        return B;
+      } else if (cast.compare(A, C) > 0) {
+        return C;
+      } else {
+        return A;
+      }
     }
     scale_block({ A, m1, M1, m2, M2 }) {
       return (

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -115,11 +115,11 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -130,11 +130,11 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -145,7 +145,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -157,7 +157,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -172,7 +172,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -187,7 +187,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -202,7 +202,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -217,7 +217,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -232,7 +232,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -247,7 +247,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.STRING,
@@ -332,7 +332,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -351,7 +351,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               m1: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -379,7 +379,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -394,7 +394,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -406,11 +406,11 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -422,7 +422,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               B: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -454,7 +454,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -466,7 +466,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -477,7 +477,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -488,7 +488,7 @@
             arguments: {
               A: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
             },
           },
@@ -544,7 +544,15 @@
       return cast.toString(A).includes(cast.toString(B));
     }
     clamp_block({ A, B, C }) {
-      return B < C ? Math.min(Math.max(A, B), C) : Math.min(Math.max(A, C), B);
+      return B < C
+        ? Math.min(
+            Math.max(cast.toNumber(A), cast.toNumber(B)),
+            cast.toNumber(C)
+          )
+        : Math.min(
+            Math.max(cast.toNumber(A), cast.toNumber(C)),
+            cast.toNumber(B)
+          );
     }
     scale_block({ A, m1, M1, m2, M2 }) {
       return (


### PR DESCRIPTION
Resolves #888

- Clamp restricts the outputted number between a certain range. This block was copied from the unlisted Math and String extension. Its new home in the _listed_ Math extension is much more accessible.
- Map (scale) maps a number to a range and then scales that range to a second range.