### PR TITLE
[JSON] Reword "replace item" block to be more consistent

### DIFF
--- a/extensions/Skyhigh173/json.js
+++ b/extensions/Skyhigh173/json.js
@@ -239,7 +239,7 @@
           {
             opcode: "json_array_set",
             blockType: Scratch.BlockType.REPORTER,
-            text: "replace item [pos] of [json] to [item]",
+            text: "replace item [pos] of [json] with [item]",
             arguments: {
               item: {
                 type: Scratch.ArgumentType.STRING,


### PR DESCRIPTION
Just changed "replace item to" to "replace item with"