### PR TITLE
[Runtime Options] Rename reporters for consistency

### DIFF
--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -28,7 +28,7 @@
         blocks: [
           {
             opcode: "getEnabled",
-            text: "is [thing] enabled?",
+            text: "[thing] enabled?",
             blockType: Scratch.BlockType.BOOLEAN,
             arguments: {
               thing: {

--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -60,7 +60,7 @@
 
           {
             opcode: "getFramerate",
-            text: "get framerate limit",
+            text: "framerate limit",
             blockType: Scratch.BlockType.REPORTER,
           },
           {
@@ -79,7 +79,7 @@
 
           {
             opcode: "getCloneLimit",
-            text: "get clone limit",
+            text: "clone limit",
             blockType: Scratch.BlockType.REPORTER,
           },
           {
@@ -99,7 +99,7 @@
 
           {
             opcode: "getDimension",
-            text: "get stage [dimension]",
+            text: "stage [dimension]",
             blockType: Scratch.BlockType.REPORTER,
             arguments: {
               dimension: {

--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -84,7 +84,7 @@
           },
           {
             opcode: "setCloneLimit",
-            text: "set clone limit [limit]",
+            text: "set clone limit to [limit]",
             blockType: Scratch.BlockType.COMMAND,
             arguments: {
               limit: {


### PR DESCRIPTION
Removed the "get" in the reporters for consistency