### PR TITLE
[Gamepad] Slightly reword "connected" block

### DIFF
--- a/extensions/gamepad.js
+++ b/extensions/gamepad.js
@@ -84,7 +84,7 @@
           {
             opcode: "gamepadConnected",
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "is gamepad [pad] connected?",
+            text: "gamepad [pad] connected?",
             arguments: {
               pad: {
                 type: Scratch.ArgumentType.NUMBER,


### PR DESCRIPTION
Just renaming the "connected" block for conciseness along with consistency with other booleans

<img width="172" alt="Screen Shot 2023-08-30 at 3 25 31 AM" src="https://github.com/TurboWarp/extensions/assets/116464667/7d6c3f28-668a-48ca-9e01-bf1f981840fc">

Old block

<img width="201" alt="Screen Shot 2023-08-30 at 3 26 05 AM" src="https://github.com/TurboWarp/extensions/assets/116464667/84a9e9e5-4906-4d08-b7dc-c383c96b84f9">

Proposed block (with consistency example)
