### PR TITLE
[Box2D] Clarity + Consistency improvements

### DIFF
--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12522,7 +12522,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setStage",
-              default: "setup stage [stageType]",
+              default: "set stage boundaries to [stageType]",
               description: "Set the stage type",
             }),
             arguments: {
@@ -12802,7 +12802,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setStatic",
-              default: "set fixed [static]",
+              default: "set fixed to [static]",
               description: "Sets whether this block is static or dynamic",
             }),
             arguments: {
@@ -12833,7 +12833,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setDensity",
-              default: "set density [density]",
+              default: "set density to [density]",
               description: "Set the density of the object",
             }),
             arguments: {
@@ -12880,7 +12880,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setFriction",
-              default: "set friction [friction]",
+              default: "set friction to [friction]",
               description: "Set the friction of the object",
             }),
             arguments: {
@@ -12927,7 +12927,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setRestitution",
-              default: "set bounce [restitution]",
+              default: "set bounce to [restitution]",
               description: "Set the bounce of the object",
             }),
             arguments: {
@@ -13024,7 +13024,7 @@
             opcode: "getTouching",
             text: formatMessage({
               id: "griffpatch.getTouching",
-              default: "touching [where]",
+              default: "list sprites touching [where]",
               description: "get the name of any sprites we are touching",
             }),
             blockType: BlockType.REPORTER,
@@ -13047,7 +13047,7 @@
             blockType: BlockType.COMMAND,
             text: formatMessage({
               id: "griffpatch.setScroll",
-              default: "set scroll x: [ox] y: [oy]",
+              default: "set scroll to x: [ox] y: [oy]",
               description: "Sets whether this block is static or dynamic",
             }),
             arguments: {


### PR DESCRIPTION
<img width="775" alt="Screen Shot 2023-08-30 at 3 37 42 AM" src="https://github.com/TurboWarp/extensions/assets/116464667/2f1e32e9-54a2-405e-961e-d5ed7b70e87b">

This is mainly for clarity and consistency within itself and other extensions. This extentions specifically gets a lot of questions i'll try to hopefully alleviate with better worded blocks.
- change "setup stage <>" to "set stage boundaries to <>" makes it more clear that this is just setting bounds
- add "to" back to the older physics properties properties (set bounce <>) is now (set bounce to <>)
- the confusing "touching <>" block is now a much more clear "list sprites touching <>"
- added "to" to the set scroll block for internal consistency and global consistency