### PR TITLE
[Text] tiny consistency change

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -163,7 +163,7 @@
           {
             opcode: "unicodeof",
             blockType: Scratch.BlockType.REPORTER,
-            text: "Unicode of [STRING]",
+            text: "unicode of [STRING]",
             arguments: {
               STRING: {
                 type: Scratch.ArgumentType.STRING,
@@ -174,7 +174,7 @@
           {
             opcode: "unicodefrom",
             blockType: Scratch.BlockType.REPORTER,
-            text: "Unicode [NUM] as letter",
+            text: "unicode [NUM] as letter",
             arguments: {
               NUM: {
                 type: Scratch.ArgumentType.NUMBER,


### PR DESCRIPTION
<img width="240" alt="Screen Shot 2023-08-30 at 3 53 04 AM" src="https://github.com/TurboWarp/extensions/assets/116464667/9ff7c0e6-6213-488e-a2a3-232e5d1f0127">

Old blocks

<img width="245" alt="Screen Shot 2023-08-30 at 3 54 30 AM" src="https://github.com/TurboWarp/extensions/assets/116464667/35736280-57ff-4eaa-b28e-85f564b9069e">

New blocks

There was random caps on two blocks, just a change for consistency within the extension 