### PR TITLE
local-storage: wait a few seconds between each namespace warning

### DIFF
--- a/extensions/local-storage.js
+++ b/extensions/local-storage.js
@@ -13,12 +13,15 @@
   let namespace = "";
   const getFullStorageKey = () => `${PREFIX}${namespace}`;
 
+  let lastNamespaceWarning = 0;
+
   const validNamespace = () => {
     const valid = !!namespace;
-    if (!valid) {
+    if (!valid && Date.now() - lastNamespaceWarning > 3000) {
       alert(
         'Local Storage extension: project must run the "set storage namespace ID" block before it can use other blocks'
       );
+      lastNamespaceWarning = Date.now();
     }
     return valid;
   };


### PR DESCRIPTION
So if someone does this in a loop, for example, they wont be spammed with alerts forever

Which matters especially in the desktop app as it won't give you an option to disable alerts for the site