### PR TITLE
add Fix X and Fix Y block

### DIFF
--- a/extensions/DT/cameracontrols.js
+++ b/extensions/DT/cameracontrols.js
@@ -410,6 +410,29 @@
           */
           "---",
           {
+            opcode: "blocktx",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "fix x [x]",
+            arguments: {
+              x: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 100,
+              },
+            },
+          },
+          {
+            opcode: "blockty",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "fix y [y]",
+            arguments: {
+              y: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 100,
+              },
+            },
+          },
+          "---",
+          {
             opcode: "changeZoom",
             blockType: Scratch.BlockType.COMMAND,
             text: "change camera zoom by [val]",
@@ -542,6 +565,12 @@
     }
     getDirection() {
       return cameraDirection;
+    }
+    blocktx(args){
+      return _translateX(args.x);
+    }
+    blockty(args){
+      return _translateY(args.y);
     }
     setCol(args, util) {
       cameraBG = args.val;


### PR DESCRIPTION
I know it automatically fixes those, but that's only for things already built in. If you wanted to use, say, Sensing Plus' finger X and Y detection, it wouldn't work because those aren't automatically adjusted. Also I think it's just nice having them, unless someone has a proper reason as to why they shouldn't exist.

I don't think I named the blocks well enough, so please leave suggestions. Unless I get approval I'll keep this a draft.
![image](https://github.com/TurboWarp/extensions/assets/26834442/da68d46e-ddaf-469a-b5b0-6ced09beb3d8)
