### PR TITLE
gamejolt: major update

### DIFF
--- a/docs/gamejolt.md
+++ b/docs/gamejolt.md
@@ -1,8 +1,6 @@
 # Game Jolt API
----
 This extension allows you to easily implement the Game Jolt API using a public domain library.
 ## Blocks
----
 Blocks that the extension uses to send requests to the Game Jolt API.
 
 ```scratch
@@ -10,7 +8,6 @@ Blocks that the extension uses to send requests to the Game Jolt API.
 ```
 Checks to see if the URL is the Game Jolt website.
 ### Session Blocks
----
 Operating on the game's session.
 
 ```scratch
@@ -52,7 +49,6 @@ Sets the session status to active/idle.
 Checks to see if there is an open session for the user.
 - Can be used to see if a particular user account is active in the game.
 ### User Blocks
----
 Login, logout and fetch users.
 
 ```scratch
@@ -146,7 +142,6 @@ Returns fetched user's friend ID at passed index.
 ```
 Returns fetched user's friend IDs in JSON.
 ### Trophy Blocks
----
 Achieve, remove and fetch trophies.
 
 ```scratch
@@ -195,7 +190,6 @@ Returns fetched trophy data at passed index by passed key.
 ```
 Returns fetched trophy data in JSON
 ### Score Blocks
----
 ```scratch
 Add score (1) in table of ID (0) with text [1 point] and comment [optional] :: #2F7F6F
 ```
@@ -279,7 +273,6 @@ Returns fetched table data at passed index by passed key.
 ```
 Returns fetched tables in JSON.
 ### Data Storage Blocks
----
 Operate on Game Jolt's cloud variables.
 
 ```scratch
@@ -347,7 +340,6 @@ Returns fetched key at passed index.
 ```
 Returns fetched keys in JSON.
 ### Time Blocks
----
 Track server's time.
 
 ```scratch
@@ -367,7 +359,6 @@ Returns fetched server's time data by passed key.
 ```
 Returns fetched server's time data in JSON.
 ### Batch Blocks
----
 Fetch more data per request.
 
 ```scratch
@@ -409,7 +400,6 @@ User based sub requests require to be logged in.
 Returns fetched batch data in JSON.
 
 ### Debug Blocks
----
 Blocks used for debugging.
 
 ```scratch
@@ -431,7 +421,6 @@ Checks to see if debug mode is on.
 Returns the last API error.
 
 ### Handling Common Errors
----
 Handling commonly encountered errors.
 
 ```scratch

--- a/docs/gamejolt.md
+++ b/docs/gamejolt.md
@@ -174,9 +174,12 @@ Requires to be logged in.
 
 ---
 ```scratch
-Fetch all trophies :: #2F7F6F
+Fetch [all v] trophies :: #2F7F6F
 ```
-Fetches all of the game's trophies.
+Fetches game trophies:
+- All - fetches all trophies.
+- All achieved - fetches all achieved trophies.
+- All unachieved - fetches all unachieved trophies.
 
 Requires to be logged in.
 

--- a/docs/gamejolt.md
+++ b/docs/gamejolt.md
@@ -371,7 +371,7 @@ Returns fetched server's time data in JSON.
 Fetch more data per request.
 
 ```scratch
-Add [data-store/set] request with [{"key":"key", "data":"data"}] parameters :: #2F7F6F
+Add [data-store/set] request with [{"key":"key", "data":"data"}] to batch :: #2F7F6F
 ```
 Adds passed arguments to the batch.
 - The batch is an array of sub requests consisting of the namespace and the parameters object.

--- a/docs/gamejolt.md
+++ b/docs/gamejolt.md
@@ -145,7 +145,6 @@ Returns fetched user's friend ID at passed index.
 (Fetched user's friend IDs in JSON :: #2F7F6F)
 ```
 Returns fetched user's friend IDs in JSON.
-
 ### Trophy Blocks
 ---
 Achieve, remove and fetch trophies.
@@ -192,7 +191,6 @@ Returns fetched trophy data at passed index by passed key.
 (Fetched trophies in JSON :: #2F7F6F)
 ```
 Returns fetched trophy data in JSON
-
 ### Score Blocks
 ---
 ```scratch
@@ -277,7 +275,6 @@ Returns fetched table data at passed index by passed key.
 (Fetched tables in JSON :: #2F7F6F)
 ```
 Returns fetched tables in JSON.
-
 ### Data Storage Blocks
 ---
 Operate on Game Jolt's cloud variables.
@@ -328,10 +325,10 @@ Fetch [global v] keys matching with [*] :: #2F7F6F
 ```
 Fetches global/user keys matching with passed pattern.
 - Examples:
-  - A pattern of `*` matches all keys.
-  - A pattern of `key*` matches all keys with `key` at the start.
-  - A pattern of `*key` matches all keys with `key` at the end.
-  - A pattern of `*key*` matches all keys containing `key`.
+    - A pattern of `*` matches all keys.
+    - A pattern of `key*` matches all keys with `key` at the start.
+    - A pattern of `*key` matches all keys with `key` at the end.
+    - A pattern of `*key*` matches all keys containing `key`.
 
 User option requires to be logged in.
 
@@ -346,7 +343,6 @@ Returns fetched key at passed index.
 (Fetched keys in JSON :: #2F7F6F)
 ```
 Returns fetched keys in JSON.
-
 ### Time Blocks
 ---
 Track server's time.
@@ -367,6 +363,47 @@ Returns fetched server's time data by passed key.
 (Fetched server's time in JSON :: #2F7F6F)
 ```
 Returns fetched server's time data in JSON.
+### Batch Blocks
+---
+Fetch more data per request.
+
+```scratch
+Add [data-store/set] request with [{"key":"key", "data":"data"}] parameters :: #2F7F6F
+```
+Adds passed arguments to the batch.
+- The batch is an array of sub requests consisting of the namespace and the parameters object.
+
+---
+```scratch
+Clear batch :: #2F7F6F
+```
+Clears the batch of all sub requests.
+
+---
+```scratch
+(Batch in JSON :: #2F7F6F)
+```
+Returns the batch in JSON.
+
+---
+```scratch
+Fetch batch [sequentially v] :: #2F7F6F
+```
+Fetches the batch.
+- After the fetch the batch is not cleared.
+
+You can call the batch request in different ways:
+- Sequentially - all sub requests are processed in sequence.
+- Sequentially, break on error - all sub requests are processed in sequence, if an error in one of them occurs, the whole request will fail.
+- In parallel - all sub requests are processed in parallel, this is the fastest way but the results may vary depending on which request finished first.
+
+User based sub requests require to be logged in.
+
+---
+```scratch
+(Fetched batch data in JSON :: #2F7F6F)
+```
+Returns fetched batch data in JSON.
 
 ### Debug Blocks
 ---
@@ -389,6 +426,85 @@ Checks to see if debug mode is on.
 (Last API error :: #2F7F6F)
 ```
 Returns the last API error.
-- Doesn't return errors based on invalid input.
+
+### Handling Common Errors
+---
+Handling commonly encountered errors.
+
+```scratch
+// Error: The game ID you passed in does not point to a valid game.
+```
+This error occurs when the game ID you set is invalid.
+#### Handling
+This error can be avoided by using this block:
+```scratch
+Set game ID to [0] and private key to [private key] :: #2F7F6F
+```
+- Make sure the value matches your game's ID.
 
 ---
+```scratch
+// Error: The signature you entered for the request is invalid.
+```
+This error occurs when the private key you set is invalid.
+#### Handling
+This error can be avoided by using this block:
+```scratch
+Set game ID to [0] and private key to [private key] :: #2F7F6F
+```
+- Make sure the value matches your game's private key.
+
+---
+```scratch
+// Error: No user logged in.
+```
+This error occurs when no user is logged in.
+- The most common cause is that the extension failed to recognize the user.
+#### Handling
+This error can be avoided with a manual login option.
+```scratch
+when flag clicked
+if <not<Autologin available? :: #2F7F6F>> then
+ask [login or continue as guest?] and wait
+if <(answer) = [login]> then
+ask [enter your username] and wait
+set [username v] to (answer)
+ask [enter your private game token] and wait
+set [private game token v] to (answer)
+Login with (username :: variables) and (private game token) :: #2F7F6F 
+end
+end
+```
+
+---
+```scratch
+// Error: No such user with the credentials passed in could be found.
+```
+This error occurs when manual login failed to recognize the user credentials you passed in.
+- It can also occur with autologin when no user is recognized by the extension.
+#### Handling
+This error can be avoided by modifying the previous example to try again after a failed login attempt.
+```scratch
+when flag clicked
+if <not<Autologin available? :: #2F7F6F>> then
+ask [login or continue as guest?] and wait
+if <(answer) = [login]> then
+repeat until <Logged in? :: #2F7F6F>
+ask [enter your username] and wait
+set [username v] to (answer)
+ask [enter your private game token] and wait
+set [private game token v] to (answer)
+Login with (username :: variables) and (private game token) :: #2F7F6F 
+end
+end
+end
+```
+
+---
+```scratch
+// Error: Data not found.
+// Error: Data at such index not found.
+```
+These errors occur when you are trying to access non-existent data.
+- Make sure you have previously fetched the data you are trying to access.
+- Make sure you have the right index as indexing starts at 0 instead of 1.

--- a/docs/gamejolt.md
+++ b/docs/gamejolt.md
@@ -1,0 +1,394 @@
+# Game Jolt API
+---
+This extension allows you to easily implement the Game Jolt API using a public domain library.
+## Blocks
+---
+Blocks that the extension uses to send requests to the Game Jolt API.
+
+```scratch
+<On Game Jolt? :: #2F7F6F>
+```
+Checks to see if the URL is the Game Jolt website.
+### Session Blocks
+---
+Operating on the game's session.
+
+```scratch
+Set game ID to (0) and private key [private key] :: #2F7F6F
+```
+This block is required for all requests to work.
+
+---
+```scratch
+[Open v] session :: #2F7F6F
+```
+Opens/closes a game session.
+- You must ping the session to keep it open and you must close it when you're done with it.
+
+When you login the session is opened automatically.
+
+---
+```scratch
+Ping session :: #2F7F6F
+```
+Pings an open session.
+- If the session hasn't been pinged within 120 seconds, the system will close the session and you will have to open another one.
+- It's recommended that you ping about every 30 seconds or so to keep the system from clearing out your session.
+
+When the session is opened it is pinged every 30 seconds automatically.
+- You can ping it manually to update the session status.
+
+---
+```scratch
+Set session status to [active v] :: #2F7F6F
+```
+Sets the session status to active/idle.
+- Ping the session to update it's status.
+
+---
+```scratch
+<Session open? :: #2F7F6F>
+```
+Checks to see if there is an open session for the user.
+- Can be used to see if a particular user account is active in the game.
+### User Blocks
+---
+Login, logout and fetch users.
+
+```scratch
+Login with [username] and [private token] :: #2F7F6F
+```
+This block is required for all user based requests to work.
+
+Requires to not be logged in.
+- When logged in on the Game Jolt website and the game is played on Game Jolt, the user is logged in automatically.
+
+---
+```scratch
+Login automatically :: #2F7F6F
+```
+Does automatic login after logout.
+
+Requires to not be logged in.
+- Requires to be logged in on the Game Jolt website and for the game to be played on Game Jolt.
+
+---
+```scratch
+Autologin available? :: #2F7F6F
+```
+Checks to see if the user is logged in on the Game Jolt website and the game is played on Game Jolt.
+
+---
+```scratch
+Logout :: #2F7F6F
+```
+Logs out the user, the game session is then closed.
+
+Requires to be logged in.
+
+---
+```scratch
+<Logged in? :: #2F7F6F>
+```
+Checks to see if the user is logged in.
+
+---
+```scratch
+Logged in user's username :: #2F7F6F
+```
+Returns the logged in user's username.
+
+Requires to be logged in.
+
+---
+```scratch
+Fetch user's [username] by [username v] :: #2F7F6F
+```
+Fetches user data based on the user's username or the ID
+
+---
+```scratch
+Fetch logged in user :: #2F7F6F
+```
+Fetches logged in user data.
+
+Requires to be logged in.
+
+---
+```scratch
+(Fetched user's [ID v] :: #2F7F6F)
+```
+Returns fetched user's data by passed key.
+
+---
+```scratch
+(Fetched user's data in JSON :: #2F7F6F)
+```
+Returns fetched user's data in JSON.
+
+---
+```scratch
+Fetch user's friend IDs :: #2F7F6F
+```
+Fetches user's friend IDs.
+
+Requires to be logged in.
+
+---
+```scratch
+(Fetched user's friend ID at index (0) :: #2F7F6F)
+```
+Returns fetched user's friend ID at passed index.
+
+---
+```scratch
+(Fetched user's friend IDs in JSON :: #2F7F6F)
+```
+Returns fetched user's friend IDs in JSON.
+
+### Trophy Blocks
+---
+Achieve, remove and fetch trophies.
+
+```scratch
+Achieve trophy of ID (0) :: #2F7F6F
+```
+Achieves trophy of passed ID.
+
+Requires to be logged in and for the trophy to not be achieved.
+
+---
+```scratch
+Remove trophy of ID (0) :: #2F7F6F
+```
+Removes trophy of passed ID.
+
+Requires to be logged in and for the trophy to be achieved.
+
+---
+```scratch
+Fetch trophy of ID (0) :: #2F7F6F
+```
+Fetches trophy of passed ID.
+
+Requires to be logged in.
+
+---
+```scratch
+Fetch all trophies :: #2F7F6F
+```
+Fetches all of the game's trophies.
+
+Requires to be logged in.
+
+---
+```scratch
+(Fetched trophy [ID v] at index (0) :: #2F7F6F)
+```
+Returns fetched trophy data at passed index by passed key.
+
+---
+```scratch
+(Fetched trophies in JSON :: #2F7F6F)
+```
+Returns fetched trophy data in JSON
+
+### Score Blocks
+---
+```scratch
+Add score (1) in table of ID (0) with text [1 point] and comment [optional] :: #2F7F6F
+```
+Adds a score in table of an ID with a text and an optional comment.
+- Score, table ID, text and optional comment are passed.
+
+Requires to be logged in.
+
+---
+```scratch
+Add [guest] score (1) in table of ID (0) with text [1 point] and comment [optional] :: #2F7F6F
+```
+Adds a score in table of an ID with text and optional comment for the a guest.
+- Score, table ID, text, optional comment and guest's username are passed.
+
+---
+```scratch
+Fetch (1) [global v] score/s in table of ID (0) :: #2F7F6F
+```
+Fetches global/user scores in table of an ID.
+- Limit, global/user option and table ID are passed.
+
+Requires to be logged in.
+
+--- 
+```scratch
+Fetch (1) [global v] score/s [better v] than (1) in table of ID (0) :: #2F7F6F
+```
+Fetches global/user scores better/worse than a value in table of an ID.
+- Limit, global/user option, better/worse option, a value and table ID are passed.
+
+Requires to be logged in.
+
+---
+```scratch
+Fetch (1) [guest] score/s in table of ID (0) :: #2F7F6F
+```
+Fetches guest's scores in table of an ID.
+- Limit, guest's username and table ID are passed.
+
+---
+```scratch
+Fetch (1) [guest] score/s [better v] than (1) in table of ID (0) :: #2F7F6F
+```
+Fetched quest's scores better/worse than a value in table of an ID.
+- Limit, guest's username, better/worse option, a value and a table ID are passed.
+
+---
+```scratch
+(Fetched score [value v] at index (0) :: #2F7F6F)
+```
+Returns fetched score data at passed index by passed key.
+
+---
+```scratch
+(Fetched score data in JSON :: #2F7F6F)
+```
+Returns fetched score data in JSON.
+
+---
+```scratch
+(Fetched rank of (1) in table of ID (0) :: #2F7F6F)
+```
+Fetches and returns a rank of passed value in table of passed ID.
+
+---
+```scratch
+Fetch score tables :: #2F7F6F
+```
+Fetches score tables.
+
+---
+```scratch
+(Fetched table [ID v] at index (0) :: #2F7F6F)
+```
+Returns fetched table data at passed index by passed key.
+
+---
+```scratch
+(Fetched tables in JSON :: #2F7F6F)
+```
+Returns fetched tables in JSON.
+
+### Data Storage Blocks
+---
+Operate on Game Jolt's cloud variables.
+
+```scratch
+Set [global v] data at [key] to [data] :: #2F7F6F
+```
+Sets global/user data at passed key to passed data.
+
+User option requires to be logged in.
+
+---
+```scratch
+(Fetched [global v] data at [key] :: #2F7F6F)
+```
+Fetches and returns global/user data at passed key.
+
+User option requires to be logged in.
+
+---
+```scratch
+Update [global v] data at [key] by [adding v](1) :: #2F7F6F
+```
+Updates global/user data at key by operation with value.
+- Global/user option, key, operation and value are passed.
+
+User option requires to be logged in.
+
+---
+```scratch
+Remove [global v] data at [key] :: #2F7F6F
+```
+Removes global/user data at passed key.
+
+User option requires to be logged in.
+
+---
+```scratch
+Fetch all [global v] keys :: #2F7F6F
+```
+Fetches all global/user keys.
+
+User option requires to be logged in.
+
+---
+```scratch
+Fetch [global v] keys matching with [*] :: #2F7F6F
+```
+Fetches global/user keys matching with passed pattern.
+- Examples:
+  - A pattern of `*` matches all keys.
+  - A pattern of `key*` matches all keys with `key` at the start.
+  - A pattern of `*key` matches all keys with `key` at the end.
+  - A pattern of `*key*` matches all keys containing `key`.
+
+User option requires to be logged in.
+
+---
+```scratch
+(Fetched key at index (0) :: #2F7F6F)
+```
+Returns fetched key at passed index.
+
+---
+```scratch
+(Fetched keys in JSON :: #2F7F6F)
+```
+Returns fetched keys in JSON.
+
+### Time Blocks
+---
+Track server's time.
+
+```scratch
+Fetch server's time :: #2F7F6F
+```
+Fetches server's time.
+
+---
+```scratch
+(Fetched server's [timestamp v] :: #2F7F6F)
+```
+Returns fetched server's time data by passed key.
+
+---
+```scratch
+(Fetched server's time in JSON :: #2F7F6F)
+```
+Returns fetched server's time data in JSON.
+
+### Debug Blocks
+---
+Blocks used for debugging.
+
+```scratch
+Turn debug mode [off v] :: #2F7F6F
+```
+Turns debug mode on/off.
+- When debug mode is off, instead of errors, reporters return an empty string and booleans return false.
+
+---
+```scratch
+<In debug mode? :: #2F7F6F>
+```
+Checks to see if debug mode is on.
+
+---
+```scratch
+(Last API error :: #2F7F6F)
+```
+Returns the last API error.
+- Doesn't return errors based on invalid input.
+
+---

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -2587,7 +2587,7 @@
         GameJolt.TrophyFetch(
           Number(trophyFetchGroup),
           (pResponse) => {
-            if (pResponse != trueStr) {
+            if (pResponse.success != trueStr) {
               [err.trophies, err.last] =
                 [pResponse.message, pResponse.message];
               data.trophies = undefined;
@@ -2606,7 +2606,7 @@
         GameJolt.TrophyFetchSingle(
           ID,
           (pResponse) => {
-            if (pResponse != trueStr) {
+            if (pResponse.success != trueStr) {
               [err.trophies, err.last] =
                 [pResponse.message, pResponse.message];
               data.trophies = undefined;

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -1658,7 +1658,14 @@
             opcode: "trophyFetchAll",
             blockIconURI: icons.trophy,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Fetch all trophies",
+            text: "Fetch [trophyFetchGroup] trophies",
+            arguments: {
+              trophyFetchGroup: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "trophyFetchGroup",
+                defaultValue: "0",
+              },
+            },
           },
           {
             opcode: "trophyReturn",
@@ -2305,6 +2312,13 @@
               { text: "user", value: "true" },
             ],
           },
+          trophyFetchGroup: {
+            items: [
+              { text: "all", value: "0" },
+              { text: "all achieved", value: "1" },
+              { text: "all unachieved", value: "-1" },
+            ],
+          },
           indexOrID: {
             items: [
               { text: "index", value: "true" },
@@ -2568,9 +2582,10 @@
       }
       return data.trophies[trophyDataType] || err.get("noData");
     }
-    trophyFetchAll() {
+    trophyFetchAll({ trophyFetchGroup }) {
       return new Promise((resolve) =>
         GameJolt.TrophyFetch(
+          Number(trophyFetchGroup),
           (pResponse) => {
             if (pResponse != trueStr) {
               [err.trophies, err.last] =

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -1,4 +1,4 @@
-// Name: GameJolt
+// Name: Game Jolt
 // ID: GameJoltAPI
 // Description: Blocks that allow games to interact with the GameJolt API. Unofficial.
 // By: softed <https://scratch.mit.edu/users/softed/>
@@ -246,6 +246,8 @@
       },
     };
 
+    GJAPI.sStatus = "active";
+
     GJAPI.iGameID = 0;
     GJAPI.sGameKey = "";
     GJAPI.bAutoLogin = true;
@@ -275,7 +277,7 @@
       return asOutput;
     })();
 
-    GJAPI.bOnGJ = window.location.hostname.match(/gamejolt/) ? true : false;
+    GJAPI.bOnGJ = window.location.hostname.match(/gamejolt\.net/) ? true : false;
 
     /**
      * Log message and stack trace
@@ -438,7 +440,7 @@
       }
 
       GJAPI.SendRequest(
-        "/sessions/ping/?status=" + (GJAPI.bSessionActive ? "active" : "idle"),
+        "/sessions/ping/?status=" + GJAPI.sStatus,
         GJAPI.SEND_FOR_USER,
         pCallback
       );
@@ -1067,16 +1069,10 @@
      * @param {function} pCallback
      */
     GJAPI.UserFetchComb = (bIsUsername, sValue, pCallback) => {
-      if (bIsUsername) {
-        GJAPI.SendRequest(
-          "/users/?username=" + sValue,
-          GJAPI.SEND_GENERAL,
-          pCallback
-        );
-        return;
-      }
       GJAPI.SendRequest(
-        "/users/?user_id=" + sValue,
+        "/users/" +
+        (bIsUsername ? "?username=" : "?user_id=") +
+        sValue,
         GJAPI.SEND_GENERAL,
         pCallback
       );
@@ -1276,6 +1272,52 @@
       );
     };
 
+    GJAPI.SEQUENTIALLY = "sequentially";
+    GJAPI.BREAK_ON_ERROR = "break_on_error";
+    GJAPI.PARALLEL = "parallel";
+
+    /**
+     * @param {string[]} sRequests
+     * @param {string} sParam
+     * @param {function} pCallback
+     */
+    GJAPI.SendBatchRequest = (sRequests, sParam, pCallback) => {
+      if (!sRequests) {
+        pCallback(GJAPI.err.get("No requests found."));
+        return;
+      }
+      let sFinalURL = GJAPI.sAPI + "/batch?game_id=" + GJAPI.iGameID;
+      for (let i = 0; i < sRequests.length; i++) {
+        sRequests[i] +=
+          (sRequests[i].indexOf("/?") === -1 ? "?" : "&") +
+          "game_id=" + 
+          GJAPI.iGameID;
+        sFinalURL += "&requests[]=" +
+          encodeURIComponent(sRequests[i] +
+            "&signature=" +
+            md5(sRequests[i] + GJAPI.sGameKey)
+          );
+      }
+      switch(sParam) {
+        case "break_on_error":
+          sFinalURL += "&break_on_error=true";
+          break;
+        case "parallel":
+          sFinalURL += "&parallel=true";
+          break;
+        case "sequentially": // request is processed sequentially by default
+        default:
+          break;
+      }
+      sFinalURL += "&format=json";
+      sFinalURL += "&signature=" + md5(sFinalURL + GJAPI.sGameKey);
+
+      __CreateAjax(sFinalURL, "", (sResponse) => {
+        console.info(GJAPI.sLogName + " <" + sFinalURL + "> " + sResponse);
+        pCallback(JSON.parse(sResponse).response);
+      });
+    }
+
     return GJAPI;
   })();
 
@@ -1283,21 +1325,23 @@
    * Used for storing API error messages
    */
   let err = {
+    debug: true,
+
     noLogin: "No user logged in.",
-    noItem: "Item not found.",
-    noIndex: "Index not found.",
+    noData: "Data not found.",
+    noIndex: "Data at such index not found.",
 
     /**
      * Used for returning a standartized error message
      * @param {string} code
      */
-    get: (code) => (err[code] ? "Error: " + err[code] : "Error."),
+    get: (code) => (err.debug ? (err[code] ? "Error: " + err[code] : "Error: Data not found.") : ""),
 
     /**
      * Used for returning a standartized error message
      * @param {string} text
      */
-    show: (text) => "Error: " + text,
+    show: (text) => (err.debug ? "Error: " + text : ""),
   };
 
   /**
@@ -1306,20 +1350,18 @@
   let data = {};
 
   /**
-   * Apparently API response object's success property is a string and not a boolean
-   * That's why there is stuff like 'pResponse.success == bool.f'
+   * The API response object's success property is a string and not a boolean
+   * So there is stuff like "pResponse.success == trueStr"
    */
-  const bool = {
-    t: "true",
-    f: "false",
-  };
+  const trueStr = "true";
 
-  /**
+  /*!
    * GameJolt icon by GameJolt
    * Other icons by softed
    * Can be used outside of this extension
    */
   const icons = {
+    debug: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABkdJREFUeF7t3NGt1EgQhtGZjJAIiQAghAkBAiAkpM1oVrwhMSPK/OXudnP2uctuf32wrtZc7jf/KbBRgftGz+JRFLgBDcFWBYDe6jg9DNAMbFUA6K2O08MAzcBWBYDe6jg9DNAMbFUA6K2O08MAvZiB5/P5XGxLf7Wd+/0+xdaUm/5VoX9kCOjsoIHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+pWnu6F+eHwp37tz4X+Pr6XL+VJYynTdRUCPOTtv6DGdb0CPCQ30mM5AD+oM9KDQ3tBjQgM9prM39KDOQA8K7Q09JjTQYzp7Qw/qDPSg0N7QY0IDPaazN/SgzkAPCl19Q6/+BXBQrt9uU/3yCPSgEwI6Cw101q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99ehbo6u8Adj9w9YtndX9Ad59QeD2gXwcEOoQ1axxooGfZO+W+QAN9CqxZFwUa6Fn2Trkv0ECfAmvWRYEGepa9U+4LNNCnwJp1UaCBnmXvlPsCDfQpsGZddBfQ1S+A1c4+rFRLLbYOaG/oxUhm2wEa6EzQYtNAA70YyWw7QAOdCVpsGmigFyOZbQdooDNBi00DDfRiJLPtAA10JmixaaCBXozk6+1UoVYfpvtLXPW+s9b5Ujir/Jv7Ap0dCNBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/L0LKjfH99Ke/z0+FxaN+t6H2/P0v6qi/zro9VSb9YB/TpM9Q8I0CHA7nGgge42NfV6QAM9FWD3zYEGutvU1OsBDfRUgN03BxroblNTrwc00FMBdt8caKC7TU29HtBATwVYvfkuUKufjKtdZq2rfgGs7u9eXbjLOqDXOkmgw/MAOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8DHQYFOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8D/SZoN9QftznfnGb96lKz02mXm3NqJzwu0K+jdr8BTzi61ksC/SanN3Srs2EXAxroYdhG3AhooEc4G3YPoIEehm3EjYAGeoSzYfcAGuhh2EbcCGigRzgbdg+ggR6GbcSNlgftg4kPJkf+IAB9pFaw1iftIN6BUaAPxEqWAp3Uq88CXW8VrQQ6ylceBrqcKlsIdNavOg10tVS4DugwYHEc6GKodBnQacHaPNC1TvEqoOOEpQsAXcqULwI6b1i5AtCVSg1rgG6IWLjENNC+AL4+nX/tV6YKRg8tAfpQrt8Xe/OGAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHy6C7v+xVn8O/MVctZd3PAkC/ceDNe80/IEADfU25b3YNNNBAjyzgZ+iRta9/L29ob+jrK/7lCYAGGuiRBfzIMbL29e/lDe0NfX3FfuT48xn6/9B/brTiivY39KwfEapxQa2WuuY6oMNz80utYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDm8WmgPz0+lx7l++NbaZ0vgKVM2y8C+s0Re/Ne0z7QQF9T7rtzqz5N9Z8xqP7lJD9yVMtbd6SAN7Q39BEvy68FGujlkR7ZINBAH/Gy/FqggV4e6ZENAg30ES/LrwUa6OWRHtngNNBHNllZW/1S6INJpeZ11wB93bOz8xcFgMZiqwJAb3WcHgZoBrYqAPRWx+lhgGZgqwJAb3WcHgZoBrYqAPRWx+lh2kGvntSXwtVPKNsf0Fk/04sVAHqxA7GdrADQWT/TixUAerEDsZ2sANBZP9OLFQB6sQOxnawA0Fk/04sVAHqxA7GdrADQWT/TixUog15s37ajwMsCQIOxVQGgtzpODwM0A1sVAHqr4/QwQDOwVQGgtzpODwM0A1sVAHqr4/QwQDOwVYH/ASxGnPG1nIUEAAAAAElFTkSuQmCC",
     GameJolt:
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEQCAYAAABfpKr9AAAAAXNSR0IArs4c6QAAC2dJREFUeF7t3dGNZNlxRdEsjwTIJBkgmtAmiAbQJAHyqATygwbUJnDqMtb8n7nv7ojYE5nT+frrc/yf7+/v7+MIXP8wga/Dd//H1Qngegfcvj8B2ABuT8Dx2xMAARwfgdvXJwACuD0Bx29PAARwfARuX58ACOD2BBy/PQEQwPERuH19AiCA2xNw/PYEQADHR+D29QmAAG5PwPHbEwABHB+B29cnAAK4PQHHb08ABHB8BG5fnwAI4PYEHL89ARDA8RG4fX0CIIDbE/D47b++vtIMp/Dj7P7x+N4H8O9Qxbt3IIBYewKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SuC8ANYD/B9//jJtAIc3Av/353/avyCm6wDH4z/Pvw+AAGoL3M4TwOP1J4DHCzh+fAIYF6AeTwCV4O08ATxefwJ4vIDjxyeAcQHq8QRQCd7OE8Dj9SeAxws4fnwCGBegHk8AleDtPAE8Xn8CeLyA48cngHEB6vEEUAnezhPA4/UngMcLOH58AhgXoB5PAJXg7TwBPF5/Ani8gOPHJ4BxAerxBFAJ3s4TwOP1J4DHCzh+fAIYF6AeTwCV4O08ATxefwJ4vIDx8a8PcMTnfQAVoBeCVIItTwCNnxeCNH4fAogAY5wAGkACaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBOcC8Hv+VsDX0wZ4W0EC+POXbQWOn04A2wYgAAKYdiABTPHv3wjkI8C2AdanE8C2AjYAG8C0Awlgit8G4JVe2wYkgC1/G4ANYNqBBDDFbwOwAWwbkAC2/G0ANoBpBxLAFL8NwAawbUAC2PK3AdgAph1IAFP8NgAbwLYBCWDL3wZgA5h2IAFM8dsAbADbBiSALX8bgA1g2oEEMMVvA7ABbBuQALb8bQA2gNSB6wFOD/9vEP76+koznML/Cn5+DfivoLj7dxDAjv3fTyaAyN9HgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqei6A13/O+7c/f001+K8//53yr5//n5/vdP/r4TrAlV9+HwABEEBtwst5AojVryv86/8FXm8gNoDWwATQ+H0IYLuBEEBrYAJo/Ahg/B0EAbQGJoDGjwAIIHbQNk4Akb+PAD4CxBaaxgkg4icAAogtNI0TQMRPAAQQW2gaJ4CInwAIILbQNE4AET8BEEBsoWmcACJ+AiCA2ELTOAFE/ARAALGFpnECiPgJgABiC03jBBDxEwABxBaaxgkg4icAAogtNI0TQMT/v5/2i+b1r+mc3wS2fiHJeoDj+MTp+Xw+6/cBEMDtF5oQQFNA+88nAXy8T2ArIAIggETACt5W8LUACSC1v48ABEAAZYR8B/D9PX0rpO8Atiu4DeArf4wuAqrZ/PC+BLw9gARAADaAoGEfQdpHEN8BhOb7fHwHYADbANoAbAA2gCBhAmoCsgGE5rMBfD4GsA2gDcAGYAMIEiagJiAbQGg+G4AN4HUBEQABJAKvD8B6BV+fTwCp/f1fAAJoKzgB+A7AdwBBwgTUBGQDCM339+8A1n+Srz2+dCVQ/yh1PX/9dwu+/mf5K38CqAQfzxPA2yt8bT8CqAQfzxMAAUw/wz8+P88/PgEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/v0AVgN/z/5z9b0j6OfBvqMLwGQhgCP8XHE0Av6AIy0cggCX9/dkEsK/B9AkIYIp/fjgBzEuwfQAC2PJfn04A6wqMzyeAcQHGxxPAuADr4wlgXYHt+QSw5T8/nQDmJZg+AAFM8e8PJ4B9DZZPQABL+r/gbAL4BUUYPgIBDOH/hqMJ4DdUYfcMBLBj/ytOJoBfUYbZQxDADP3vOJgAfkcdVk9BACvyv+RcAvglhRg9BgGMwP+WYwngt1Ri8xwEsOH+a04lgF9TismDfE1Odeg/CXx/f59+H8PX1+0XcqxHgQDGFSAAAli2IAEs6X8+HwIggGULEsCSPgF8fATYNiABbPnbAHwHMO1AApji9xHABrBtQALY8rcB2ACmHUgAU/w2ABvAtgEJYMvfBmADmHYgAUzx2wBsANsGJIAtfxuADWDagQQwxW8DsAFsG5AAtvxtADaAaQcSwBS/DcAGsG1AAtjytwHYAKYdSABT/DYAG8C2AQlgy//5DcAAjxsoHk8AEWCNv/5zYAKoHbDNE8CWvw1gzP/68QQw7gAbwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngNgABjgCFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPgJIAIUnxIggIifACJA8SkBAoj4CSACFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPgJIAIUnxIggIifACJA8SkBAoj4CSACFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPjXAvDXc8cCHo8TQGwAAogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBM4LwABP+8/hYwIE8P39vayBF3os6TubAAjAFBwmQAAEcLj9XZ0ACMAUHCZAAARwuP1dnQAIwBQcJkAABHC4/V2dAAjAFBwmQAAEcLj9XZ0ACMAUHCZAAARwuP1dnQAIwBQcJkAABHC4/V2dAAjAFBwmQAAEcLj9XZ0AogD8nNcQvUyAAAjg5f717JEAARBAbCHxlwkQAAG83L+ePRIgAAKILST+MgECIICX+9ezRwIEQACxhcRfJkAABPBy/3r2SIAACCC2kPjLBAiAAF7uX88eCRAAAcQWEn+ZAAEQwMv969kjAQIggNhC4i8TIAACeLl/PXskQAAEEFtI/GUCBEAAL/evZ48EnhfAtwGOLSB+mQABfH09z+ByA7t7I/B889sAWgNI3yZAADaA2xNw/PYEQADHR+D29QmAAG5PwPHbEwABHB+B29cnAAK4PQHHb08ABHB8BG5fnwAI4PYEHL89ARDA8RG4fX0CIIDbE3D89gRAAMdH4Pb1CYAAbk/A8dsTAAEcH4Hb1ycAArg9Acdv///LGLErEwwsYgAAAABJRU5ErkJggg==",
     main: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABjtJREFUeF7t3cGNIzcQRuFWRgs4JAfgDUEheANwSAackQzPxRdJW9q/wCbZ356ruouvHgvUcEZ7O/xDYCMCt43WYikIHIQmwVYECL1VOy2G0BzYigCht2qnxRCaA1sRIPRW7bQYQnNgKwKE3qqdFlMW+vF4PGbGdbvdymuZeR1qywiUJSB0Blr2GAKEHsPZWwYRIPQg0F4zhgChx3D2lkEECD0ItNeMIUDoMZy9ZRABQg8C7TVjCBB6DGdvGUSA0INAe80YAu1Cf7t/b638n/ufrc+rPszNY5XUXHGEftEPQs8larUaQhO66soScYQm9BKiVoskNKGrriwRR2hCLyFqtUhCE7rqyhJxhCb0EqJWiyQ0oauuLBFHaEIvIWq1yOmFri6kGufmsUpqzThCD+qbm8cxoAk9hvNB6DGgCT2GM6FHca6+p/o1Bt2/bVetrxrnDF0ltWacCT2ob44cY0ATegxnR45RnKvvceSoknoeZ0Jn/KrZJnSVVBhH6BBgMZ3QRVBpGKFTgrX8ywldw1KP8lOTOqsRkYQOKRM6BNicTugQKKFDgM3phA6BEjoE2JxO6BAooUOAzemEDoESOgTYnE7oECihQ4DN6YQOgRI6BNicTugQKKFDgM3phA6BEjoE2JxO6Gag6eNskIwgoTN+7dmEzpASOuPXnk3oDCmhM37t2YTOkBI649eeTegMKaEzfu3ZhM6QEjrj155N6AwpoTN+7dmEzpASOuPXnk3oDCmhM37t2YTOkBI64zd99tU2CKGnVzIrkNAv+O3yRTOZHutlE5rQ61n7pmJCE5rQDQTO+mIdZ+iG5s38CBPahJ7Zz49rIzShP5Zm5gRCE3pmPz+ujdCE/liamRMITeiZ/Ty9ttk3iJ9ynK7IWgUQeq1+qfYnBAhNka0IEHqrdloMoTmwFQFCb9VOiyE0B7YiQOit2mkxhObAVgQuJ/TfR+2u5vf7H6VG/3X/UYrzvOeYZudX3SDV36+u2XccR/VPsAj9XCwb7jkXQr+Y14Qxof8jYELbIF8EzhoIJjQBTxWw+0xOaEIT+s2PCRw5bJBTN4gJTcBTBXTkIOBWAhKa0IR+c+ad/sjx7f69dLPXvdM9b80Lnd+OR8mX024KCb3mBcdZA4HQL/bzWQ0560Jil/USmtBfBAj9XIT2n0M7cjhyfLLhTGgT2oQeeVNoQpvQJvSbHedD194bxJHDkcORw5HjfwIm/lwTf/oJXf0TrNL1kKDpCFQF7C78tJtCQne3cq7nEXqufqgmJEDoEKD0uQgQeq5+qCYkQOgQoPS5CBB6rn6oJiRA6BCg9LkIEHqufqgmJEDoEKD0uQgQeq5+XK6a2QXsbkj7L/i7KexuUfY8Qr/g1/11ulmbZFcJEJrQVVeWiCM0oZcQtVokoQlddWWJOEITeglRq0USmtBVV5aIIzShlxC1WiShCV11ZYk4QhP6VFGvJmA3bDeF3UTD5xE6A0jojF97NqEzpITO+LVnEzpDSuiMX3s2oTOkhM74tWcTOkNK6IxfezahM6SEzvi1ZxM6Q0rojF97NqEzpITO+LVnEzpDSuiM30HAEGBzOqFDoIQOATanEzoESugQYHM6oUOghA4BNqcTOgRK6BBgczqhQ6CEDgE2pxM6BEroEGBzOqFDoIQOATanEzoESugQYHM6oUOghA4BNqdfTmgCNhs02eMIPagh1f84clA5276G0INaS+gxoAk9hvNB6DGgCT2GM6FHca6+Z5cvPPehsNrxNeNM6EF9c+QYA5rQYzg7coziXH2PI0eV1PM4EzrjV802oaukwjhChwCL6dML7UNcsZPCvggQ+oUIJuqaO4TQhF7T3Fd9q67mrA+FjhzVDolz5HjjgCPHmhvEkcORY01zHTk+65sJ/RmvWaJNaBN6Fhdb6iA0oVtEmuUhhCb0LC621NEudEtVv/AQZ95fgLZhCqE3bOqVl0ToK3d/w7UTesOmXnlJhL5y9zdcO6E3bOqVl0ToK3d/w7UTesOmXnlJhL5y9zdcO6E3bOqVl1QW+sqQrH0dAoRep1cqLRAgdAGSkHUIEHqdXqm0QIDQBUhC1iFA6HV6pdICAUIXIAlZhwCh1+mVSgsECF2AJGQdAoRep1cqLRD4F7peZQBIeX0KAAAAAElFTkSuQmCC",
@@ -1331,10 +1373,11 @@
     store:
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABVJJREFUeF7t3d1t20AQRWGrIwMpKQXEJaiEpICUFCAdMZBebAT6WcJDz/Lyy6uJ2Z1zz44oKZJOL/4hEETgFNSLVhB4ITQJoggQOipOzRCaA1EECB0Vp2YIzYEoAoSOilMzhOZAFAFCR8WpmWGhl2VZ4EKgi8DpdBpydeiiSxOE7orSuhcChOZBFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIkDoqDg10yb06/kNfQSGCfw9/xy6ltBDmFzUTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k1geqH/vIz9Utz3848hlr/Pv4auU+82ptn5EfqO3oQm9IXA2Dhd8cObJvRtsRy421xMaBP6SiDlgBCa0IR+8KzKLYcD0npATGgCtgpY/aoJoQlNaLcc7wSqJ4x6n3tVx4Q2oU3or5zQQ2/ruQiBlQTafqdw5T5djsAQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQgTahX89vQxt0EQIXAtP/Xw5CE3UNAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANgemF9t12t+NM+equ6k+5E/rO8SfMbTDVAlbXIzShrwRSDjChCU3oBzfpvqzRAWk9ICY0AVsFdA9NwCgBCU1oQj+453XL4YBEHRBCE5rQX/kqx+hHsKrvxdTb5zuU316WoXfKp/+QLAH3KWD1GzqEvnOeHZB9HhBCE/pKIOUAE5rQhPak8J1A9T2gerftGn0EMaFNaBPahDahn702NjpRqx+RTGgT2oQ2oU1oE/o/AsuyDL2lM/qZwmeA/f0YBKa/5SD0MUSs6pLQVSTVmYIAoaeIwSaqCBC6iqQ6UxAg9BQx2EQVAUJXkVRnCgKEniIGm6giQOgqkupMQYDQU8RgE1UEphe6qlF1EPhIoO0zhWJAYAsChN6CqpptBAjdht7CWxAg9BZU1WwjQOg29BbeggCht6CqZhsBQreht/AWBAi9BVU12wgQug29hbcg0Ca0bx+9HWfX1wRUf+1Adb3p3/omNKEvBEYPMKHvPJ6NAqyeMOp97gATmtBXAikHmNCEJvSDZ53lP7zpHvpzD8FHu4UxoU1oE9qEfidwtAk4e78mtAltQpvQJvSzd++6XjWZfkL7ssZn6vj7RwKE5kMUAUJHxakZQnMgigCho+LUDKE5EEWA0FFxaobQHIgiQOioODVDaA5EESB0VJyaITQHoggQOipOzRCaA1EECB0Vp2YIzYEoAoSOilMzhOZAFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIkDoqDg1Q2gORBEgdFScmiE0B6IIEDoqTs0QmgNRBKYXOoq2ZqYh0PbDm9MQsJEoAoSOilMzhOZAFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIlAudBQdzcQSOMV2prFDEiD0IWPPbZrQudkesjNCHzL23KYJnZvtITsj9CFjz22a0LnZHrIzQh8y9tymCZ2b7SE7+wcob7kPY5BclgAAAABJRU5ErkJggg==",
     time: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABk5JREFUeF7t3eFtJEUUhVE7IyRCIgAIYUOAAAgJiYyMdn/b6Fn3dr927eF3v6rpr88Mo6219/XFfwocVOD1oHtxKwq8AA3BUQWAPupxuhmgGTiqANBHPU43AzQDRxUA+qjH6WaAZuCoAkAf9TjdzBj029vbm1wKbBV4fX0dWR1d9P0mgN56lPb9XgBoDo4qAPRRj9PNAM3AUQWAPupxuhmgGTiqANBHPU43AzQDRxUA+qjH6WbWQP/y7Q/1FRgX+Pfbn6NrgR5lctF2AaC3n4D9qwWArua02HYBoLefgP2rBYCu5rTYdgGgt5+A/asFgK7mtNh2AaC3n4D9qwWArua02HaBx4OeBnKiOC31Na+bQp3e3dpJ4fQFAj0t9TWvA/prPjev+oMCQKNxVAGgj3qcbgZoBo4qAPRRj9PNAM3AUQWAPupxuhmgGTiqwONBT2u3f6mjA5hp+Xuu24I6vbvxbx+dLgj0tNTXvA7o8Ln5hA4DlseBDoMCHQYsjwMdBgU6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONBhUKDDgOVxoMOgQIcBy+M/HehpPwcw01L3XPd0qNMK9ZPC6cZAT0vdcx3QYWegw4DlcaDDoECHAcvjQIdBgQ4DlseBDoMCHQYsjwMdBgU6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONDloB8tB34W+hSo0wprJ4XTFwj0tNT71wGd9atPA50lBTrrV58GOksKdNavPg10lhTorF99GugsKdBZv/o00FlSoLN+9Wmgs6RAZ/3q00BnSYHO+tWngc6SAp31W5v+2eD/bFCnsB5/Uji9EaCnpd6/bvoPW2a7XD8N9AeNn/7rE3xCf/DGvP49c88OPqGzzj6hs371aaCzpEBn/erTQGdJgc761aeBzpICnfWrTwOdJQU661efBjpLCnTWrz4NdJYU6Kzf2vQU/vTPof/+9tfoXn779vvouul6v768jdY7BeroZl9eXo45WJneMNDTUl/zOqDDk8LpJ6pP6HveIEADfY+0m3YBGuibqN2zDdBA3yPtpl2ABvomavdsAzTQ90i7aReggb6J2j3bAA30PdJu2gXoD0L/Mzxzav/58nS96U+sOCm86Z20tc30pBDorSeU7esT2id0Juhh00AD/TCS2csBGuhM0MOmgQb6YSSzlwM00Jmgh00DDfTDSGYvB2igM0EPmwYa6IeRzF7OMaCnBybTXNODlel67eumP1M43feUE0Wgw0/oKZj2dUC/XxRooH8U8And/sgJ1/OVIwsIdNavPg10lhTorF99GugsKdBZv/o00FlSoLN+9Wmgs6RAZ/3q00BnSYHO+tWngc6SAp31G0//bFCnYdo/ezjd9+nwH3+wAvT71ID+oieFQAM9/b/HjxPPz1y8cS3QQH/GHdCfqfWga33l8JXjR4Gn/7XQ6XsGaKCBnr5b/uc6f8oRRvQd2nfozxDyHfoztR50ra8cvnL4ylF4Q/rK8UHE9leJ9r8rWHj2X2qJU36ka+0rB9DP8g50+DyADgOWx4EOgwIdBiyPAx0GBToMWB4HOgwKdBiwPA50GBToMGB5HOgwKNBhwPI40GFQoMOA5XGgw6BAhwHL40DfdAJ4yl/3LPtbW+7p8Osnhe1PXqDX7L67MdDh8wA6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONBhUKDDgOVxoMOgQIcBy+NAh0GBDgOWx4EOgwIdBiyPHwPagUlZxuHLbcEfnxQCfbjA8u0BXQ5qud0CQO/2t3u5ANDloJbbLQD0bn+7lwsAXQ5qud0CQO/2t3u5ANDloJbbLQD0bn+7lwscA9pRdVnG4ctN4U9/jW/9pBDowwWWbw/oclDL7RYAere/3csFgC4HtdxuAaB3+9u9XADoclDL7RYAere/3csFgC4HtdxuAaB3+9u9XODxoMv3azkFfhRYOynUX4ErCgB9RVVrrhUAei29ja8oAPQVVa25VgDotfQ2vqIA0FdUteZaAaDX0tv4igJAX1HVmmsFgF5Lb+MrCtRBX/EiralAu8D4ZwrbG1tPgSsKAH1FVWuuFQB6Lb2NrygA9BVVrblWAOi19Da+ogDQV1S15loBoNfS2/iKAkBfUdWaawWAXktv4ysK/AdZX2DxTCYQ4gAAAABJRU5ErkJggg==",
+    batch: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABrBJREFUeF7t3e2R4zYQhOFVRq66kByAHcKGYAfgkFzljOQ6/VlfmVQ1biBSGD739wZc4J1mo0F93T78Q6ARgVujtVgKAh8ETQStCBB0q3ZaDEHTQCsCBN2qnRZD0DTQigBBt2qnxRA0DbQiQNCt2mkxsaDv9/sdLgTOInC73SKtRkXfF0HQZ7XS3/1OgKDpoBUBgm7VToshaBpoRYCgW7XTYgiaBloRIOhW7bQYgqaBVgQIulU7LeY0Qf/y+ftb0//n849oftYRYSoXpf0g6B3UKUCCLms1ukDaD4Im6AeBLjcmQRM0QT/bI9I3J3VxBOuIEkO5SOQoIkwBEnQRdDg87YfIIXKIHCLHFwEOHVpssYxDHwSQoIugw+EEHYLaK0sBEnQRdDg87YcMLUPL0DK0DB0a67QyDl1EmQIUOYqgw+FpP0QOkUPkEDlEjtBYp5Vx6CLKFKDIUQQdDk/7IXKIHCKHyCFyhMY6rYxDF1GmAEWOIuhweNoPkUPkEDlEDpEjNNZpZRy6iDIFKHIUQYfD036IHCKHyCFyiByhsU4r49BFlClAkaMIOhye9kPkEDlEDpFD5AiNdVoZhy6iTAGKHEXQ4fC0HyKHyCFyiBwiR2is08raOPRfn39GUH79/C2qS6/37SP7ucW/P7JfvJs9v/R6qRDS6JTyS+eXXi/tx9tHjnTBZwEk6G0fOasfBL3j66kjEDRBDx1COHRNMCLHNr8sKA78NHKXzMahazdcaljpjilyiBytdkyCJmiCPvI5dLolnXWqFjlEjlaOQNAETdBPtrjZO5KnHAc95Yhe1lOEwCCB0w6Fg/NUjkBEgKAjTIpWIUDQq3TKPCMCBB1hUrQKAYJepVPmGREg6AiTolUIEPQqnTLPiABBR5gUrUKAoFfplHlGBE4TdPp+6GgVLyia/ZLxC6YYXfJq6yDoHVlcTQhdDIagCfpBgKB3hHC/36PP/3cBaB1R8ikXpTsmh+bQHPrZ7cahy2Y09QKps3XZaTg0h+bQHPqLQBdn67IODs2hOTSH5tBTg35wsfQscJpD+7T0dhd9HcM2F4LeuetTwaQA0+w5+9Pc6fXSr9DqYjAc+qAMnQowveHS6xH0doOnf1ljF0fg0NuCSW+49AZOd0wOzaEfBLoYDEETNEHPeGzXxRFEDpGjlSMQNEET9JMtLj0kpYcuTzk85XgQSE/VHJpDD713IHUizlZ7ha3LjXnaU44uAB1u3+slfILeybNXy55dDIagCbpVBCRogiboGS+sdNniZGgZupUjEDRBE/STLW72Y8qrPU+XoWXoVgZD0ARN0DMOhWn2fPa3Xvl/s59Dv3Kuz659tXWc5tAEfYzECfrN3px0TNv//1euJoQuBsOhD8rQbswagdRgCJqgHwQ49I4Q0m8f7QLQOmrOm47m0CkpDs2hPbb7IsChi84RDufQIai9shQgQRdBh8PTfjgUihwix4zIEd6YyhAYInCaQw/NUjECIQGCDkEpW4MAQa/RJ7MMCRB0CErZGgQIeo0+mWVIgKBDUMrWIEDQa/TJLEMCBB2CUrYGAYJeo09mGRI4TdDpeyBmf6toer2rffy/Sz8IeufOJ+htMKkhnPX9IgRN0A8CHHpHCLM/sfLujuA7+raFwKF3bhCCrgkmfR8xh+bQDwIcunbDpYaVnmlkaBlahn72SFCGPsax0owqcmz3w4/X79zFIscxN7DIUTxkpgAJmqCHMlv4iuf0stlb9fQJhhe82jre/lAY9m162dWEkD62mw46vGDaD4LeAZoC7CKELusgaIJuFQEJmqAJ+sjn0GHEml4mckxHWrpg2g8OzaE5NIf+ItDlMNVlHRyaQ3NoDs2hS4H4JwbL0D8B7b9DUoBdtuou6xA5RA6RQ+QQOYob4PDwdMfk0ByaQ3NoDj1sscUBHPoggF0OU13WIXKIHCKHyCFyFDfA4eEixzCyHwekALts1V3WIXKIHCKHyCFyFDfA4eHpjsmhOTSH5tAcethiiwM49EEAuxymuqxD5BA5RA6RQ+QoboDDw0WOYWSeQxeRvXQ4QRfxpgC7ZM8u65ChZWgZWoaWoYsb4PDwdMc8zaGHV2QAAgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iFA0Ov0ykwDAgQdQFKyDgGCXqdXZhoQIOgAkpJ1CEwX9DpLN9MrE4h/GvnKkKx9HQIEvU6vzDQgQNABJCXrECDodXplpgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iHwL5ShIS3TtLVvAAAAAElFTkSuQmCC",
   };
 
   const docs =
-    "https://softedco.github.io/GameJolt-API-Scratch-extension/DOCUMENTATION";
+    "https://extensions.turbowarp.org/gamejolt";
 
   /**
    * Mostly visual stuff for Scratch GUI
@@ -1344,7 +1387,7 @@
     getInfo() {
       return {
         id: "GameJoltAPI",
-        name: "GameJolt API",
+        name: "Game Jolt API",
         color1: "#2F7F6F",
         color2: "#2A2731",
         color3: "#CCFF00",
@@ -1355,7 +1398,7 @@
             opcode: "gamejoltBool",
             blockIconURI: icons.GameJolt,
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "GameJolt?",
+            text: "On Game Jolt?",
           },
           {
             blockType: Scratch.BlockType.LABEL,
@@ -1365,7 +1408,7 @@
             opcode: "setGame",
             blockIconURI: icons.main,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Set game ID:[ID] and key:[key]",
+            text: "Set game ID to [ID] and private key to [key]",
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1373,7 +1416,7 @@
               },
               key: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "key",
+                defaultValue: "private key",
               },
             },
           },
@@ -1403,10 +1446,23 @@
             text: "Ping session",
           },
           {
+            opcode: "sessionSetStatus",
+            blockIconURI: icons.main,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Set session status to [status]",
+            arguments: {
+              status: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "status",
+                defaultValue: "active",
+              },
+            },
+          },
+          {
             opcode: "sessionBool",
             blockIconURI: icons.main,
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "Session?",
+            text: "Session open?",
             disableMonitor: true,
           },
           {
@@ -1417,7 +1473,7 @@
             opcode: "loginManual",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Login with username:[username] and token:[token]",
+            text: "Login with [username] and [token]",
             arguments: {
               username: {
                 type: Scratch.ArgumentType.STRING,
@@ -1425,7 +1481,7 @@
               },
               token: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "token",
+                defaultValue: "private token",
               },
             },
           },
@@ -1439,7 +1495,7 @@
             opcode: "loginAutoBool",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "Autologin?",
+            text: "Autologin available?",
           },
           {
             opcode: "logout",
@@ -1451,19 +1507,19 @@
             opcode: "loginBool",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "Login?",
+            text: "Logged in?",
           },
           {
             opcode: "loginUser",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.REPORTER,
-            text: "User logged in as",
+            text: "Logged in user's username",
           },
           {
             opcode: "userFetch",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Fetch user:[usernameOrID] by [fetchType]",
+            text: "Fetch user's [usernameOrID] by [fetchType]",
             arguments: {
               usernameOrID: {
                 type: Scratch.ArgumentType.STRING,
@@ -1486,7 +1542,7 @@
             opcode: "returnUserData",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return fetched user's [userDataType]",
+            text: "Fetched user's [userDataType]",
             arguments: {
               userDataType: {
                 type: Scratch.ArgumentType.STRING,
@@ -1496,16 +1552,47 @@
             },
           },
           {
+            opcode: "returnUserDataJson",
+            blockIconURI: icons.user,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched user's data in JSON",
+          },
+          {
+            hideFromPalette: true,
             opcode: "friendsFetch",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return user's friend ID by index:[index]",
+            text: "Fetched user's friend ID at index[index] (Deprecated)",
             arguments: {
               index: {
                 type: Scratch.ArgumentType.NUMBER,
                 defaultValue: 0,
               },
             },
+          },
+          {
+            opcode: "friendsFetchNew",
+            blockIconURI: icons.user,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch user's friend IDs",
+          },
+          {
+            opcode: "friendsReturn",
+            blockIconURI: icons.user,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched user's friend ID at index[index]",
+            arguments: {
+              index: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
+              },
+            },
+          },
+          {
+            opcode: "friendsReturnJson",
+            blockIconURI: icons.user,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched user's friend IDs in JSON",
           },
           {
             blockType: Scratch.BlockType.LABEL,
@@ -1515,7 +1602,7 @@
             opcode: "trophyAchieve",
             blockIconURI: icons.trophy,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Achieve trophy with ID:[ID]",
+            text: "Achieve trophy of ID [ID]",
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1527,7 +1614,7 @@
             opcode: "trophyRemove",
             blockIconURI: icons.trophy,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Remove trophy with ID:[ID]",
+            text: "Remove trophy of ID [ID]",
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1536,10 +1623,11 @@
             },
           },
           {
+            hideFromPalette: true,
             opcode: "trophyFetch",
             blockIconURI: icons.trophy,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Fetch trophy [trophyDataType] by [indexOrID]:[value]",
+            text: "Fetched trophy [trophyDataType] at [indexOrID][value] (Deprecated)",
             arguments: {
               trophyDataType: {
                 type: Scratch.ArgumentType.STRING,
@@ -1558,6 +1646,47 @@
             },
           },
           {
+            opcode: "trophyFetchId",
+            blockIconURI: icons.trophy,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch trophy of ID[ID]",
+            arguments: {
+              ID: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
+              },
+            },
+          },
+          {
+            opcode: "trophyFetchAll",
+            blockIconURI: icons.trophy,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch all trophies",
+          },
+          {
+            opcode: "trophyReturn",
+            blockIconURI: icons.trophy,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched trophy [trophyDataType] at index [index]",
+            arguments: {
+              trophyDataType: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "trophyDataTypes",
+                defaultValue: "id",
+              },
+              index: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
+              },
+            },
+          },
+          {
+            opcode: "trophyReturnJson",
+            blockIconURI: icons.trophy,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched trophies in JSON",
+          },
+          {
             blockType: Scratch.BlockType.LABEL,
             text: "Score Blocks",
           },
@@ -1565,7 +1694,7 @@
             opcode: "scoreAdd",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Add score by ID:[ID] with value:[value] text:[text] and extra data:[extraData]",
+            text: "Add score [value] in table of ID [ID] with text [text] and comment [extraData]",
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1589,7 +1718,7 @@
             opcode: "scoreAddGuest",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Add score by ID:[ID] with value:[value] text:[text] and extra data:[extraData] as guest:[username]",
+            text: "Add [username] score [value] in table of ID [ID] with text [text] and comment [extraData]",
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1609,7 +1738,28 @@
               },
               username: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "username",
+                defaultValue: "guest",
+              },
+            },
+          },
+          {
+            opcode: "scoreFetchSimple",
+            blockIconURI: icons.score,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch [amount] [globalOrPerUser] score/s in table of ID [ID]",
+            arguments: {
+              amount: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 1,
+              },
+              globalOrPerUser: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "globalOrPerUser",
+                defaultValue: "false",
+              },
+              ID: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
               },
             },
           },
@@ -1617,7 +1767,7 @@
             opcode: "scoreFetch",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Fetch [amount][globalOrPerUser] score/scores [betterOrWorse] than [value] by ID:[ID]",
+            text: "Fetch [amount] [globalOrPerUser] score/s [betterOrWorse] than [value] in table of ID [ID]",
             arguments: {
               amount: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1644,10 +1794,10 @@
             },
           },
           {
-            opcode: "scoreFetchGuest",
+            opcode: "scoreFetchGuestSimple",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Fetch [amount] guest's [username] score/scores [betterOrWorse] than [value] by ID:[ID]",
+            text: "Fetch [amount] [username] score/s in table of ID [ID]",
             arguments: {
               amount: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1655,7 +1805,27 @@
               },
               username: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "username",
+                defaultValue: "guest",
+              },
+              ID: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
+              }
+            },
+          },
+          {
+            opcode: "scoreFetchGuest",
+            blockIconURI: icons.score,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch [amount] [username] score/s [betterOrWorse] than [value] in table of ID [ID]",
+            arguments: {
+              amount: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 1,
+              },
+              username: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "guest",
               },
               betterOrWorse: {
                 type: Scratch.ArgumentType.STRING,
@@ -1676,7 +1846,7 @@
             opcode: "returnScoreData",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return fetched score [scoreDataType] by index:[index]",
+            text: "Fetched score [scoreDataType] at index [index]",
             arguments: {
               scoreDataType: {
                 type: Scratch.ArgumentType.STRING,
@@ -1690,10 +1860,16 @@
             },
           },
           {
+            opcode: "returnScoreDataJson",
+            blockIconURI: icons.score, 
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched score data in JSON",
+          },
+          {
             opcode: "scoreGetRank",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return rank of [value] by ID:[ID]",
+            text: "Fetched rank of [value] in table of ID [ID]",
             arguments: {
               value: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -1706,10 +1882,11 @@
             },
           },
           {
+            hideFromPalette: true,
             opcode: "scoreGetTables",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return table [tableDataType] by index:[index]",
+            text: "Fetched table [tableDataType] at index[index] (Deprecated)",
             arguments: {
               tableDataType: {
                 type: Scratch.ArgumentType.STRING,
@@ -1723,6 +1900,35 @@
             },
           },
           {
+            opcode: "scoreFetchTables",
+            blockIconURI: icons.score,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch score tables",
+          },
+          {
+            opcode: "scoreReturnTables",
+            blockIconURI: icons.score,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched table [tableDataType] at index [index]",
+            arguments: {
+              tableDataType: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "tableDataTypes",
+                defaultValue: "id"
+              },
+              index: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0
+              },
+            },
+          },
+          {
+            opcode: "scoreReturnTablesJson",
+            blockIconURI: icons.score,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched tables in JSON"
+          },
+          {
             blockType: Scratch.BlockType.LABEL,
             text: "Data Storage Blocks",
           },
@@ -1730,7 +1936,7 @@
             opcode: "dataStoreSet",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Set [globalOrPerUser] data with key:[key] to data:[data]",
+            text: "Set [globalOrPerUser] data at [key] to [data]",
             arguments: {
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
@@ -1751,7 +1957,7 @@
             opcode: "dataStoreFetch",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Fetch [globalOrPerUser] data with key:[key]",
+            text: "Fetched [globalOrPerUser] data at [key]",
             arguments: {
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
@@ -1768,7 +1974,7 @@
             opcode: "dataStoreUpdate",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Update [globalOrPerUser] data with key:[key] by operation:[operationType] with value:[value]",
+            text: "Update [globalOrPerUser] data at [key] by [operationType] [value]",
             arguments: {
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
@@ -1794,7 +2000,7 @@
             opcode: "dataStoreRemove",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.COMMAND,
-            text: "Remove [globalOrPerUser] data with key:[key]",
+            text: "Remove [globalOrPerUser] data at [key]",
             arguments: {
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
@@ -1808,10 +2014,11 @@
             },
           },
           {
+            hideFromPalette: true,
             opcode: "dataStoreGetKey",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Fetch [globalOrPerUser] keys with pattern [pattern] by index:[index]",
+            text: "Fetched [globalOrPerUser] keys with pattern [pattern] at index [index] (Deprecated)",
             arguments: {
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
@@ -1829,14 +2036,63 @@
             },
           },
           {
+            opcode: "dataStoreFetchKeys",
+            blockIconURI: icons.store,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch all [globalOrPerUser] keys",
+            arguments: {
+              globalOrPerUser: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "globalOrPerUser",
+                defaultValue: "false"
+              },
+            },
+          },
+          {
+            opcode: "dataStoreFetchPatternKeys",
+            blockIconURI: icons.store,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch [globalOrPerUser] keys matching with [pattern]",
+            arguments: {
+              globalOrPerUser: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "globalOrPerUser",
+                defaultValue: "false"
+              },
+              pattern: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "*"
+              },
+            },
+          },
+          {
+            opcode: "dataStoreReturnKeys",
+            blockIconURI: icons.store,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched key at index [index]",
+            arguments: {
+              index: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0
+              },
+            },
+          },
+          {
+            opcode: "dataStoreReturnKeysJson",
+            blockIconURI: icons.store,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched keys in JSON",
+          },
+          {
             blockType: Scratch.BlockType.LABEL,
             text: "Time Blocks",
           },
           {
+            hideFromPalette: true,
             opcode: "timeFetch",
             blockIconURI: icons.time,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Return server's current [timeType]",
+            text: "Server's current [timeType] (Deprecated)",
             arguments: {
               timeType: {
                 type: Scratch.ArgumentType.STRING,
@@ -1845,8 +2101,125 @@
               },
             },
           },
+          {
+            opcode: "timeFetchNew",
+            blockIconURI: icons.time,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch server's time",
+          },
+          {
+            opcode: "timeReturn",
+            blockIconURI: icons.time,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched server's [timeType]",
+            arguments: {
+              timeType: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "timeTypes",
+                defaultValue: "timestamp",
+              },
+            },
+          },
+          {
+            opcode: "timeReturnJson",
+            blockIconURI: icons.time,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched server's time in JSON",
+          },
+          {
+            blockType: Scratch.BlockType.LABEL,
+            text: "Batch Blocks (For Developers)",
+          },
+          {
+            opcode: "batchAdd",
+            blockIconURI: icons.batch,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Add [field] request with [params] to batch",
+            arguments: {
+              field: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "data-store/set"
+              },
+              params: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "key=key&data=data",
+              },
+            },
+          },
+          {
+            opcode: "batchClear",
+            blockIconURI: icons.batch,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Clear batch",
+          },
+          {
+            opcode: "batchJson",
+            blockIconURI: icons.batch,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Batch in JSON",
+          },
+          {
+            opcode: "batchCall",
+            blockIconURI: icons.batch,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Fetch batch [parameter]",
+            arguments: {
+              parameter: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "batchParameters",
+                defaultValue: "sequentially"
+              },
+            },
+          },
+          {
+            opcode: "batchReturnJson",
+            blockIconURI: icons.batch,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Fetched batch data in JSON",
+          },
+          {
+            blockType: Scratch.BlockType.LABEL,
+            text: "Debug Blocks",
+          },
+          {
+            opcode: "debug",
+            blockIconURI: icons.debug,
+            blockType: Scratch.BlockType.COMMAND,
+            text: "Turn debug mode [toggle]",
+            arguments: {
+              toggle: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "debug",
+                defaultValue: "",
+              },
+            },
+          },
+          {
+            opcode: "debugBool",
+            blockIconURI: icons.debug,
+            blockType: Scratch.BlockType.BOOLEAN,
+            text: "In debug mode?",
+          },
+          {
+            opcode: "debugLastErr",
+            blockIconURI: icons.debug,
+            blockType: Scratch.BlockType.REPORTER,
+            text: "Last API error",
+          },
         ],
         menus: {
+          debug: {
+            items: [
+              { text: "on", value: "true" },
+              { text: "off", value: "" },
+            ],
+          },
+          status: {
+            items: [
+              "active",
+              "idle",
+            ],
+          },
           fetchTypes: {
             items: [
               { text: "username", value: "true" },
@@ -1874,19 +2247,19 @@
           },
           operationTypes: {
             items: [
-              "add",
-              "subtract",
-              "multiply",
-              "divide",
-              "append",
-              "prepend",
+              { text: "adding", value: "add" },
+              { text: "subtracting", value: "subtract" },
+              { text: "multiplying by", value: "multiply" },
+              { text: "dividing by", value: "divide" },
+              { text: "appending", value: "append" },
+              { text: "prepending", value: "prepend" },
             ],
           },
           scoreDataTypes: {
             items: [
               { text: "value", value: "sort" },
               { text: "text", value: "score" },
-              { text: "extra data", value: "extra_data" },
+              { text: "comment", value: "extra_data" },
               { text: "username", value: "user" },
               { text: "user ID", value: "user_id" },
               { text: "score date", value: "stored" },
@@ -1947,8 +2320,24 @@
               { text: "worse", value: "" },
             ],
           },
+          batchParameters: {
+            items: [
+              { text: "sequentially", value: "sequentially" },
+              { text: "sequentially, break on error", value: "break_on_error" },
+              { text: "in parallel", value: "parallel"}
+            ],
+          },
         },
       };
+    }
+    debug({ toggle }) {
+      err.debug = (toggle == trueStr);
+    }
+    debugBool() {
+      return err.debug;
+    }
+    debugLastErr() {
+      return err.last ? "Error: " + err.last : "";
     }
     gamejoltBool() {
       return GameJolt.bOnGJ;
@@ -1959,7 +2348,14 @@
     }
     session({ openOrClose }) {
       return new Promise((resolve) =>
-        GameJolt.SessionSetStatus(openOrClose, resolve)
+        GameJolt.SessionSetStatus(
+          openOrClose,
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
       );
     }
 
@@ -1967,12 +2363,24 @@
      * Not necessary since the library handles pinging for you
      */
     sessionPing() {
-      return new Promise((resolve) => GameJolt.SessionPing(resolve));
+      return new Promise((resolve) =>
+        GameJolt.SessionPing(
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
+      );
+    }
+    sessionSetStatus({ status }) {
+      GameJolt.sStatus = status;
     }
     sessionBool() {
       return new Promise((resolve) =>
-        GameJolt.SessionCheck((pResponse) =>
-          resolve(pResponse.success == bool.t)
+        GameJolt.SessionCheck(
+          (pResponse) =>
+            resolve(pResponse.success == trueStr)
         )
       );
     }
@@ -1982,7 +2390,15 @@
      */
     loginManual({ username, token }) {
       return new Promise((resolve) =>
-        GameJolt.UserLoginManual(username, token, resolve)
+        GameJolt.UserLoginManual(
+          username,
+          token,
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
       );
     }
 
@@ -1990,50 +2406,85 @@
      * Not necessary since the library handles logging in for you
      */
     loginAuto() {
-      return new Promise((resolve) => GameJolt.UserLoginAuto(resolve));
+      return new Promise((resolve) =>
+        GameJolt.UserLoginAuto(
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
+      );
     }
     loginAutoBool() {
       return Boolean(GameJolt.asQueryParam["gjapi_username"]);
     }
     logout() {
-      return new Promise((resolve) => GameJolt.UserLogout(resolve));
+      return new Promise((resolve) =>
+        GameJolt.UserLogout(
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
+      );
     }
     loginBool() {
       return GameJolt.bLoggedIn;
     }
     loginUser() {
-      return GameJolt.sUserName;
+      return GameJolt.sUserName || err.get("noLogin");
     }
     userFetch({ fetchType, usernameOrID }) {
       return new Promise((resolve) =>
-        GameJolt.UserFetchComb(fetchType, usernameOrID, (pResponse) =>
-          resolve(
-            pResponse.success == bool.t
-              ? (data.user = pResponse.users[0])
-              : (err.user = pResponse.message)
-          )
+        GameJolt.UserFetchComb(
+          fetchType,
+          usernameOrID,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.user, err.last] =
+                [pResponse.message, pResponse.message];
+              data.user = undefined;
+              resolve();
+              return;
+            }
+            data.user = pResponse.users[0];
+            err.user = undefined;
+            resolve();
+          }
         )
       );
     }
     userFetchCurrent() {
       return new Promise((resolve) =>
-        GameJolt.UserFetchCurrent((pResponse) =>
-          resolve(
-            pResponse.success == bool.t
-              ? (data.user = pResponse.users[0])
-              : (err.user = pResponse.message)
-          )
+        GameJolt.UserFetchCurrent(
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.user, err.last] =
+                [pResponse.message, pResponse.message];
+              data.user = undefined;
+              resolve();
+              return;
+            }
+            data.user = pResponse.users[0];
+            err.user = undefined;
+            resolve();
+          }
         )
       );
     }
     returnUserData({ userDataType }) {
       if (!data.user) return err.get("user");
-      return data.user[userDataType] || err.get("noItem");
+      return data.user[userDataType] || err.get("noData");
+    }
+    returnUserDataJson() {
+      return JSON.stringify(data.user) || err.get("user") || "{}";
     }
     friendsFetch({ index }) {
       if (!GameJolt.bLoggedIn) return err.get("noLogin");
       GameJolt.FriendsFetch((pResponse) => {
-        if (pResponse.success == bool.f) {
+        if (pResponse.success != trueStr) {
           err.friends = pResponse.message;
           return;
         }
@@ -2041,13 +2492,59 @@
       });
       if (!data.friends) return err.get("friends");
       if (!data.friends[index]) return err.get("noIndex");
-      return data.friends[index].friend_id || err.get("noItem");
+      return data.friends[index].friend_id || err.get("noData");
+    }
+    friendsFetchNew() {
+      return new Promise((resolve) =>
+        GameJolt.FriendsFetch(
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.friends, err.last] =
+                [pResponse.message, pResponse.message];
+              data.friends = undefined;
+              resolve();
+              return;
+            }
+            data.friends = pResponse.friends;
+            err.friends = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    friendsReturn({ index }) {
+      if (!data.friends) return err.get("friends");
+      if (!data.friends[Math.floor(index)]) return err.get("noIndex");
+      return data.friends[Math.floor(index)].friend_id || err.get("noData");
+    }
+    friendsReturnJson() {
+      return JSON.stringify(data.friends) || err.get("friends") || "{}";
     }
     trophyAchieve({ ID }) {
-      return new Promise((resolve) => GameJolt.TrophyAchieve(ID, resolve));
+      return new Promise((resolve) =>
+        GameJolt.TrophyAchieve(
+          ID,
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              [err.trophies, err.last] =
+                [pResponse.message, pResponse.message];
+            resolve();
+          }
+        )
+      );
     }
     trophyRemove({ ID }) {
-      return new Promise((resolve) => GameJolt.TrophyRemove(ID, resolve));
+      return new Promise((resolve) =>
+        GameJolt.TrophyRemove(
+          ID,
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              [err.trophies, err.last] =
+                [pResponse.message, pResponse.message];
+            resolve();
+          }
+        )
+      );
     }
     trophyFetch({ indexOrID, value, trophyDataType }) {
       if (!GameJolt.bLoggedIn) return err.get("noLogin");
@@ -2055,7 +2552,7 @@
         indexOrID,
         indexOrID ? GameJolt.TROPHY_ALL : value,
         (pResponse) => {
-          if (pResponse.success == bool.f) {
+          if (pResponse.success != trueStr) {
             err.trophies = pResponse.message;
             return;
           }
@@ -2067,40 +2564,162 @@
       if (!data.trophies) return err.get("trophies");
       if (indexOrID) {
         if (!data.trophies[value]) return err.get("noIndex");
-        return data.trophies[value][trophyDataType] || err.get("noItem");
+        return data.trophies[value][trophyDataType] || err.get("noData");
       }
-      return data.trophies[trophyDataType] || err.get("noItem");
+      return data.trophies[trophyDataType] || err.get("noData");
+    }
+    trophyFetchAll() {
+      return new Promise((resolve) =>
+        GameJolt.TrophyFetch(
+          (pResponse) => {
+            if (pResponse != trueStr) {
+              [err.trophies, err.last] =
+                [pResponse.message, pResponse.message];
+              data.trophies = undefined;
+              resolve();
+              return;
+            }
+            data.trophies = pResponse.trophies;
+            err.trophies = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    trophyFetchId({ ID }) {
+      return new Promise((resolve) =>
+        GameJolt.TrophyFetchSingle(
+          ID,
+          (pResponse) => {
+            if (pResponse != trueStr) {
+              [err.trophies, err.last] =
+                [pResponse.message, pResponse.message];
+              data.trophies = undefined;
+              resolve();
+              return;
+            }
+            data.trophies = pResponse.trophies[0];
+            err.trophies = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    trophyReturn({ trophyDataType, index }) {
+      if (!data.trophies) return err.get("trophies");
+      if (!data.trophies[Math.floor(index)]) return err.get("noIndex");
+      return data.trophies[Math.floor(index)][trophyDataType] || err.get("noData");
+    }
+    trophyReturnJson() {
+      return JSON.stringify(data.trohies) || err.get("trophies") || "{}";
     }
     scoreAdd({ ID, value, text, extraData }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreAdd(ID, value, text, extraData, resolve)
+        GameJolt.ScoreAdd(
+          ID,
+          value,
+          text,
+          extraData, 
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
       );
     }
     scoreAddGuest({ ID, value, text, username, extraData }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreAddGuest(ID, value, text, username, extraData, resolve)
+        GameJolt.ScoreAddGuest(
+          ID,
+          value,
+          text,
+          username,
+          extraData, 
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
+      );
+    }
+    scoreFetchSimple({ amount, globalOrPerUser, ID }) {
+      if (globalOrPerUser == trueStr && !GameJolt.bLoggedIn) {
+        err.scores = err.noLogin;
+        data.scores = undefined;
+        return;
+      }
+      return new Promise((resolve) =>
+        GameJolt.ScoreFetch(
+          ID,
+          globalOrPerUser == trueStr
+            ? GameJolt.SCORE_ONLY_USER
+            : GameJolt.SCORE_ALL,
+          amount,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.scores, err.last] =
+                [pResponse.message, pResponse.message];
+              data.scores = undefined;
+              resolve();
+              return;
+            }
+            data.scores = pResponse.scores;
+            err.scores = undefined;
+            resolve();
+          }
+        )
       );
     }
     scoreFetch({ globalOrPerUser, ID, amount, betterOrWorse, value }) {
-      if (globalOrPerUser == bool.t && !GameJolt.bLoggedIn) {
+      if (globalOrPerUser == trueStr && !GameJolt.bLoggedIn) {
         err.scores = err.noLogin;
+        data.scores = undefined
         return;
       }
       return new Promise((resolve) =>
         GameJolt.ScoreFetchEx(
           ID,
-          globalOrPerUser == bool.t
+          globalOrPerUser == trueStr
             ? GameJolt.SCORE_ONLY_USER
             : GameJolt.SCORE_ALL,
           amount,
           betterOrWorse,
           value,
-          (pResponse) =>
-            resolve(
-              pResponse.success == bool.t
-                ? (data.scores = pResponse.scores)
-                : (err.scores = pResponse.message)
-            )
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.scores, err.last] =
+                [pResponse.message, pResponse.message];
+              data.scores = undefined;
+              resolve();
+              return;
+            }
+            data.scores = pResponse.scores;
+            err.scores = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    scoreFetchGuestSimple({ amount, username, ID}) {
+      return new Promise((resolve) =>
+        GameJolt.ScoreFetchGuestEx(
+          ID,
+          username,
+          amount,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.scores, err.last] =
+                [pResponse.message, pResponse.message];
+              data.scores = undefined;
+              resolve();
+              return;
+            }
+            data.scores = pResponse.scores;
+            err.scores = undefined;
+            resolve();
+          }
         )
       );
     }
@@ -2112,12 +2731,18 @@
           amount,
           betterOrWorse,
           value,
-          (pResponse) =>
-            resolve(
-              pResponse.success == bool.t
-                ? (data.scores = pResponse.scores)
-                : (err.scores = pResponse.message)
-            )
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.scores, err.last] =
+                [pResponse.message, pResponse.message];
+              data.scores = undefined;
+              resolve();
+              return;
+            }
+            data.scores = pResponse.scores;
+            err.scores = undefined;
+            resolve();
+          }
         )
       );
     }
@@ -2128,81 +2753,146 @@
         return (
           data.scores[index].user ||
           data.scores[index].guest ||
-          err.get("noItem")
+          err.get("noData")
         );
-      return data.scores[index][scoreDataType] || err.get("noItem");
+      return data.scores[index][scoreDataType] || err.get("noData");
+    }
+    returnScoreDataJson() {
+      return JSON.stringify(data.scores) || err.get("scores") || "{}";
     }
     scoreGetRank({ ID, value }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreGetRank(ID, value, (pResponse) =>
-          resolve(
-            pResponse.success == bool.t
-              ? pResponse.rank
-              : err.show(pResponse.message)
-          )
+        GameJolt.ScoreGetRank(
+          ID,
+          value,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              err.last = pResponse.message;
+              resolve(err.get("last"));
+              return;
+            }
+            resolve(pResponse.rank);
+          }
         )
       );
     }
     scoreGetTables({ index, tableDataType }) {
-      GameJolt.ScoreGetTables((pResponse) => {
-        if (pResponse.success == bool.f) {
-          err.tables = pResponse.message;
-          return;
+      GameJolt.ScoreGetTables(
+        (pResponse) => {
+          if (pResponse.success != trueStr) {
+            err.tables = pResponse.message;
+            return;
+          }
+          data.tables = pResponse.tables;
         }
-        data.tables = pResponse.tables;
-      });
+      );
       if (!data.tables) return err.get("tables");
       if (!data.tables[index]) return err.get("noIndex");
-      return data.tables[index][tableDataType] || err.get("noItem");
+      return data.tables[index][tableDataType] || err.get("noData");
+    }
+    scoreFetchTables() {
+      return new Promise((resolve) =>
+        GameJolt.ScoreGetTables(
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.tables, err.last] =
+                [pResponse.message, pResponse.message];
+              data.tables = undefined;
+              resolve();
+              return;
+            }
+            data.tables = pResponse.tables;
+            err.tables = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    scoreReturnTables({ tableDataType, index }) {
+      if (!data.tables) return err.get("tables");
+      if (!data.tables[Math.floor(index)]) return err.get("noIndex");
+      return !data.tables[Math.floor(index)][tableDataType] || err.get("noData");
+    }
+    scoreReturnTablesJson() {
+      return JSON.stringify(data.tables) || err.get("tables") || "{}";
     }
     dataStoreSet({ globalOrPerUser, key, data }) {
       return new Promise((resolve) =>
-        GameJolt.DataStoreSet(globalOrPerUser == bool.t, key, data, resolve)
+        GameJolt.DataStoreSet(
+          globalOrPerUser == trueStr,
+          key,
+          data, 
+          (pResponse) => {
+            if (pResponse.success != trueStr)
+              err.last = pResponse.message;
+            resolve();
+          }
+        )
       );
     }
     dataStoreFetch({ globalOrPerUser, key }) {
-      if (globalOrPerUser == bool.t && !GameJolt.bLoggedIn)
+      if (globalOrPerUser == trueStr && !GameJolt.bLoggedIn)
         return err.get("noLogin");
       return new Promise((resolve) =>
-        GameJolt.DataStoreFetch(globalOrPerUser == bool.t, key, (pResponse) =>
-          resolve(
-            pResponse.success == bool.t
-              ? pResponse.data
-              : err.show(pResponse.message)
-          )
+        GameJolt.DataStoreFetch(
+          globalOrPerUser == trueStr,
+          key,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              err.last = pResponse.message;
+              resolve(err.get("last"));
+              return;
+            }
+            resolve(pResponse.data);
+          }
         )
       );
     }
     dataStoreUpdate({ globalOrPerUser, key, operationType, value }) {
       return new Promise((resolve) =>
         GameJolt.DataStoreUpdate(
-          globalOrPerUser == bool.t,
+          globalOrPerUser == trueStr,
           key,
           operationType,
           value,
-          resolve
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              err.last = pResponse.message;
+            }
+            resolve();
+          }
         )
       );
     }
     dataStoreRemove({ globalOrPerUser, key }) {
       return new Promise((resolve) =>
-        GameJolt.DataStoreRemove(globalOrPerUser == bool.t, key, resolve)
+        GameJolt.DataStoreRemove(
+          globalOrPerUser == trueStr,
+          key,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              err.last = pResponse.message;
+            }
+            resolve();
+          }
+        )
       );
     }
     dataStoreGetKey({ globalOrPerUser, pattern, index }) {
-      if (globalOrPerUser == bool.t && !GameJolt.bLoggedIn)
+      if (globalOrPerUser == trueStr && !GameJolt.bLoggedIn)
         return err.get("noLogin");
       GameJolt.DataStoreGetKeysEx(
-        globalOrPerUser == bool.t,
+        globalOrPerUser == trueStr,
         pattern,
         (pResponse) => {
-          if (pResponse.success == bool.f) {
+          if (pResponse.success != trueStr) {
             err.keys = pResponse.message;
+            data.keys = undefined;
             return;
           }
           if (!pResponse.keys) {
-            data.keys = "";
             err.keys = err.noIndex;
+            data.keys = undefined;
             return;
           }
           data.keys = pResponse.keys;
@@ -2210,18 +2900,138 @@
       );
       if (!data.keys) return err.get("keys");
       if (!data.keys[index]) return err.get("noIndex");
-      return data.keys[index].key || err.get("noItem");
+      return data.keys[index].key || err.get("noData");
+    }
+    dataStoreFetchKeys({ globalOrPerUser }) {
+      return new Promise((resolve) => 
+        GameJolt.DataStoreGetKeys(
+          globalOrPerUser == trueStr,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.keys, err.last] =
+                [pResponse.message, pResponse.message];
+              data.keys = undefined;
+              resolve();
+              return;
+            }
+            if (!pResponse.keys) {
+              data.keys = undefined;
+              err.keys = err.noIndex;
+              resolve();
+              return;
+            }
+            data.keys = pResponse.keys;
+            err.keys = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    dataStoreFetchPatternKeys({ globalOrPerUser, pattern }) {
+      return new Promise((resolve) => 
+        GameJolt.DataStoreGetKeysEx(
+          globalOrPerUser == trueStr,
+          pattern,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.keys, err.last] =
+                [pResponse.message, pResponse.message];
+              data.keys = undefined;
+              resolve();
+              return;
+            }
+            if (!pResponse.keys) {
+              data.keys = undefined;
+              err.keys = err.noIndex;
+              resolve();
+              return;
+            }
+            data.keys = pResponse.keys;
+            err.keys = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    dataStoreReturnKeys({ index }) {
+      if (!data.keys) return err.get("keys");
+      if (!data.keys[Math.floor(index)]) return err.get("noIndex");
+      return data.keys[Math.floor(index)].key || err.get("noData");
+    }
+    dataStoreReturnKeysJson() {
+      return JSON.stringify(data.keys) || err.get("keys") || "{}";
     }
     timeFetch({ timeType }) {
       return new Promise((resolve) =>
-        GameJolt.TimeFetch((pResponse) =>
-          resolve(
-            pResponse.success == bool.t
-              ? pResponse[timeType]
-              : err.show(pResponse.message)
-          )
+        GameJolt.TimeFetch((pResponse) => {
+            if (pResponse.success != trueStr) {
+              err.last = pResponse.message;
+              resolve(err.get("last"));
+            }
+            resolve(pResponse[timeType]);
+          }
         )
       );
+    }
+    timeFetchNew() {
+      return new Promise((resolve) =>
+        GameJolt.TimeFetch(
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.time, err.last] =
+                [pResponse.message, pResponse.message];
+              data.time = undefined;
+              resolve();
+              return;
+            }
+            data.time = pResponse;
+            data.time.success = undefined;
+            data.time.message = undefined;
+            err.time = undefined;
+            resolve();
+          }
+        )
+      );
+    }
+    timeReturn({ timeType }) {
+      if (!data.time) return err.get("time");
+      return data.time[timeType] || err.get("noData");
+    }
+    timeReturnJson() {
+      return JSON.stringify(data.time) || err.get("time") || "{}";
+    }
+    batchAdd({ field, params }) {
+      if (!data.batchRequests) data.batchRequests = [];
+      data.batchRequests.push(`/${field}/?${params}`);
+    }
+    batchClear() {
+      data.batchRequests = undefined;
+    }
+    batchJson() {
+      return JSON.stringify(data.batchRequests) || err.get("batch") || "{}";
+    }
+    batchCall({ parameter }) {
+      return new Promise((resolve) =>
+        GameJolt.SendBatchRequest(
+          data.batchRequests,
+          parameter,
+          (pResponse) => {
+            if (pResponse.success != trueStr) {
+              [err.batch, err.last] =
+                [pResponse.message, pResponse.message];
+              data.batch = undefined;
+              resolve();
+              return;
+            }
+            data.batch = pResponse.responses;
+            err.batch = undefined;
+            resolve();
+          }
+        )
+      )
+    }
+    batchReturnJson() {
+      return JSON.stringify(data.batch) || err.get("batch") || "{}";
     }
   }
   Scratch.extensions.register(new GameJoltAPI());

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -3024,7 +3024,8 @@
       return new Promise((resolve) =>
         GameJolt.SendBatchRequest(
           data.batchRequests
-          .map((I) => `
+          .map(
+            (I) => `
               /${I.namespace.split("/").map((i) => encodeURIComponent(i)).join("/")}/
               ?game_id=${GameJolt.iGameID}
               &${new URLSearchParams(I.parameters).toString()}

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -277,7 +277,9 @@
       return asOutput;
     })();
 
-    GJAPI.bOnGJ = window.location.hostname.match(/gamejolt\.net/) ? true : false;
+    GJAPI.bOnGJ = window.location.hostname.match(/gamejolt\.net/)
+      ? true
+      : false;
 
     /**
      * Log message and stack trace
@@ -1070,9 +1072,7 @@
      */
     GJAPI.UserFetchComb = (bIsUsername, sValue, pCallback) => {
       GJAPI.SendRequest(
-        "/users/" +
-        (bIsUsername ? "?username=" : "?user_id=") +
-        sValue,
+        "/users/" + (bIsUsername ? "?username=" : "?user_id=") + sValue,
         GJAPI.SEND_GENERAL,
         pCallback
       );
@@ -1288,14 +1288,15 @@
       }
       let sFinalURL = GJAPI.sAPI + "/batch?game_id=" + GJAPI.iGameID;
       for (let i = 0; i < sRequests.length; i++) {
-        sFinalURL += "&requests[]=" +
+        sFinalURL +=
+          "&requests[]=" +
           encodeURIComponent(
             encodeURI(sRequests[i]) +
-            "&signature=" +
-            md5(sRequests[i] + GJAPI.sGameKey)
+              "&signature=" +
+              md5(sRequests[i] + GJAPI.sGameKey)
           );
       }
-      switch(sParam) {
+      switch (sParam) {
         case "break_on_error":
           sFinalURL += "&break_on_error=true";
           break;
@@ -1313,7 +1314,7 @@
         console.info(GJAPI.sLogName + " <" + sFinalURL + "> " + sResponse);
         pCallback(JSON.parse(sResponse).response);
       });
-    }
+    };
 
     return GJAPI;
   })();
@@ -1332,7 +1333,12 @@
      * Used for returning a standartized error message
      * @param {string} code
      */
-    get: (code) => (err.debug ? (err[code] ? "Error: " + err[code] : "Error: Data not found.") : ""),
+    get: (code) =>
+      err.debug
+        ? err[code]
+          ? "Error: " + err[code]
+          : "Error: Data not found."
+        : "",
 
     /**
      * Used for returning a standartized error message
@@ -1358,7 +1364,8 @@
    * Can be used outside of this extension
    */
   const icons = {
-    debug: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABkdJREFUeF7t3NGt1EgQhtGZjJAIiQAghAkBAiAkpM1oVrwhMSPK/OXudnP2uctuf32wrtZc7jf/KbBRgftGz+JRFLgBDcFWBYDe6jg9DNAMbFUA6K2O08MAzcBWBYDe6jg9DNAMbFUA6K2O08MAvZiB5/P5XGxLf7Wd+/0+xdaUm/5VoX9kCOjsoIHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+pWnu6F+eHwp37tz4X+Pr6XL+VJYynTdRUCPOTtv6DGdb0CPCQ30mM5AD+oM9KDQ3tBjQgM9prM39KDOQA8K7Q09JjTQYzp7Qw/qDPSg0N7QY0IDPaazN/SgzkAPCl19Q6/+BXBQrt9uU/3yCPSgEwI6Cw101q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99ehbo6u8Adj9w9YtndX9Ad59QeD2gXwcEOoQ1axxooGfZO+W+QAN9CqxZFwUa6Fn2Trkv0ECfAmvWRYEGepa9U+4LNNCnwJp1UaCBnmXvlPsCDfQpsGZddBfQ1S+A1c4+rFRLLbYOaG/oxUhm2wEa6EzQYtNAA70YyWw7QAOdCVpsGmigFyOZbQdooDNBi00DDfRiJLPtAA10JmixaaCBXozk6+1UoVYfpvtLXPW+s9b5Ujir/Jv7Ap0dCNBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/L0LKjfH99Ke/z0+FxaN+t6H2/P0v6qi/zro9VSb9YB/TpM9Q8I0CHA7nGgge42NfV6QAM9FWD3zYEGutvU1OsBDfRUgN03BxroblNTrwc00FMBdt8caKC7TU29HtBATwVYvfkuUKufjKtdZq2rfgGs7u9eXbjLOqDXOkmgw/MAOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8DHQYFOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8D/SZoN9QftznfnGb96lKz02mXm3NqJzwu0K+jdr8BTzi61ksC/SanN3Srs2EXAxroYdhG3AhooEc4G3YPoIEehm3EjYAGeoSzYfcAGuhh2EbcCGigRzgbdg+ggR6GbcSNlgftg4kPJkf+IAB9pFaw1iftIN6BUaAPxEqWAp3Uq88CXW8VrQQ6ylceBrqcKlsIdNavOg10tVS4DugwYHEc6GKodBnQacHaPNC1TvEqoOOEpQsAXcqULwI6b1i5AtCVSg1rgG6IWLjENNC+AL4+nX/tV6YKRg8tAfpQrt8Xe/OGAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHy6C7v+xVn8O/MVctZd3PAkC/ceDNe80/IEADfU25b3YNNNBAjyzgZ+iRta9/L29ob+jrK/7lCYAGGuiRBfzIMbL29e/lDe0NfX3FfuT48xn6/9B/brTiivY39KwfEapxQa2WuuY6oMNz80utYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDm8WmgPz0+lx7l++NbaZ0vgKVM2y8C+s0Re/Ne0z7QQF9T7rtzqz5N9Z8xqP7lJD9yVMtbd6SAN7Q39BEvy68FGujlkR7ZINBAH/Gy/FqggV4e6ZENAg30ES/LrwUa6OWRHtngNNBHNllZW/1S6INJpeZ11wB93bOz8xcFgMZiqwJAb3WcHgZoBrYqAPRWx+lhgGZgqwJAb3WcHgZoBrYqAPRWx+lh2kGvntSXwtVPKNsf0Fk/04sVAHqxA7GdrADQWT/TixUAerEDsZ2sANBZP9OLFQB6sQOxnawA0Fk/04sVAHqxA7GdrADQWT/TixUog15s37ajwMsCQIOxVQGgtzpODwM0A1sVAHqr4/QwQDOwVQGgtzpODwM0A1sVAHqr4/QwQDOwVYH/ASxGnPG1nIUEAAAAAElFTkSuQmCC",
+    debug:
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABkdJREFUeF7t3NGt1EgQhtGZjJAIiQAghAkBAiAkpM1oVrwhMSPK/OXudnP2uctuf32wrtZc7jf/KbBRgftGz+JRFLgBDcFWBYDe6jg9DNAMbFUA6K2O08MAzcBWBYDe6jg9DNAMbFUA6K2O08MAvZiB5/P5XGxLf7Wd+/0+xdaUm/5VoX9kCOjsoIHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+rVPA50lBTrr1z4NdJYU6Kxf+zTQWVKgs37t00BnSYHO+pWnu6F+eHwp37tz4X+Pr6XL+VJYynTdRUCPOTtv6DGdb0CPCQ30mM5AD+oM9KDQ3tBjQgM9prM39KDOQA8K7Q09JjTQYzp7Qw/qDPSg0N7QY0IDPaazN/SgzkAPCl19Q6/+BXBQrt9uU/3yCPSgEwI6Cw101q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99ehbo6u8Adj9w9YtndX9Ad59QeD2gXwcEOoQ1axxooGfZO+W+QAN9CqxZFwUa6Fn2Trkv0ECfAmvWRYEGepa9U+4LNNCnwJp1UaCBnmXvlPsCDfQpsGZddBfQ1S+A1c4+rFRLLbYOaG/oxUhm2wEa6EzQYtNAA70YyWw7QAOdCVpsGmigFyOZbQdooDNBi00DDfRiJLPtAA10JmixaaCBXozk6+1UoVYfpvtLXPW+s9b5Ujir/Jv7Ap0dCNBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/ZpoLOkQGf92qeBzpICnfVrnwY6Swp01q99GugsKdBZv/L0LKjfH99Ke/z0+FxaN+t6H2/P0v6qi/zro9VSb9YB/TpM9Q8I0CHA7nGgge42NfV6QAM9FWD3zYEGutvU1OsBDfRUgN03BxroblNTrwc00FMBdt8caKC7TU29HtBATwVYvfkuUKufjKtdZq2rfgGs7u9eXbjLOqDXOkmgw/MAOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8DHQYFOgzYPA50GBToMGDzONBhUKDDgM3jQIdBgQ4DNo8D/SZoN9QftznfnGb96lKz02mXm3NqJzwu0K+jdr8BTzi61ksC/SanN3Srs2EXAxroYdhG3AhooEc4G3YPoIEehm3EjYAGeoSzYfcAGuhh2EbcCGigRzgbdg+ggR6GbcSNlgftg4kPJkf+IAB9pFaw1iftIN6BUaAPxEqWAp3Uq88CXW8VrQQ6ylceBrqcKlsIdNavOg10tVS4DugwYHEc6GKodBnQacHaPNC1TvEqoOOEpQsAXcqULwI6b1i5AtCVSg1rgG6IWLjENNC+AL4+nX/tV6YKRg8tAfpQrt8Xe/OGAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHy6C7v+xVn8O/MVctZd3PAkC/ceDNe80/IEADfU25b3YNNNBAjyzgZ+iRta9/L29ob+jrK/7lCYAGGuiRBfzIMbL29e/lDe0NfX3FfuT48xn6/9B/brTiivY39KwfEapxQa2WuuY6oMNz80utYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDmcaDDoECHAZvHgQ6DAh0GbB4HOgwKdBiweRzoMCjQYcDm8WmgPz0+lx7l++NbaZ0vgKVM2y8C+s0Re/Ne0z7QQF9T7rtzqz5N9Z8xqP7lJD9yVMtbd6SAN7Q39BEvy68FGujlkR7ZINBAH/Gy/FqggV4e6ZENAg30ES/LrwUa6OWRHtngNNBHNllZW/1S6INJpeZ11wB93bOz8xcFgMZiqwJAb3WcHgZoBrYqAPRWx+lhgGZgqwJAb3WcHgZoBrYqAPRWx+lh2kGvntSXwtVPKNsf0Fk/04sVAHqxA7GdrADQWT/TixUAerEDsZ2sANBZP9OLFQB6sQOxnawA0Fk/04sVAHqxA7GdrADQWT/TixUog15s37ajwMsCQIOxVQGgtzpODwM0A1sVAHqr4/QwQDOwVQGgtzpODwM0A1sVAHqr4/QwQDOwVYH/ASxGnPG1nIUEAAAAAElFTkSuQmCC",
     GameJolt:
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEQCAYAAABfpKr9AAAAAXNSR0IArs4c6QAAC2dJREFUeF7t3dGNZNlxRdEsjwTIJBkgmtAmiAbQJAHyqATygwbUJnDqMtb8n7nv7ojYE5nT+frrc/yf7+/v7+MIXP8wga/Dd//H1Qngegfcvj8B2ABuT8Dx2xMAARwfgdvXJwACuD0Bx29PAARwfARuX58ACOD2BBy/PQEQwPERuH19AiCA2xNw/PYEQADHR+D29QmAAG5PwPHbEwABHB+B29cnAAK4PQHHb08ABHB8BG5fnwAI4PYEHL89ARDA8RG4fX0CIIDbE/D47b++vtIMp/Dj7P7x+N4H8O9Qxbt3IIBYewKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SuC8ANYD/B9//jJtAIc3Av/353/avyCm6wDH4z/Pvw+AAGoL3M4TwOP1J4DHCzh+fAIYF6AeTwCV4O08ATxefwJ4vIDjxyeAcQHq8QRQCd7OE8Dj9SeAxws4fnwCGBegHk8AleDtPAE8Xn8CeLyA48cngHEB6vEEUAnezhPA4/UngMcLOH58AhgXoB5PAJXg7TwBPF5/Ani8gOPHJ4BxAerxBFAJ3s4TwOP1J4DHCzh+fAIYF6AeTwCV4O08ATxefwJ4vIDx8a8PcMTnfQAVoBeCVIItTwCNnxeCNH4fAogAY5wAGkACaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBAmg8SOAyK/GCaARJIDGjwAivxongEaQABo/Aoj8apwAGkECaPwIIPKrcQJoBOcC8Hv+VsDX0wZ4W0EC+POXbQWOn04A2wYgAAKYdiABTPHv3wjkI8C2AdanE8C2AjYAG8C0Awlgit8G4JVe2wYkgC1/G4ANYNqBBDDFbwOwAWwbkAC2/G0ANoBpBxLAFL8NwAawbUAC2PK3AdgAph1IAFP8NgAbwLYBCWDL3wZgA5h2IAFM8dsAbADbBiSALX8bgA1g2oEEMMVvA7ABbBuQALb8bQA2gNSB6wFOD/9vEP76+koznML/Cn5+DfivoLj7dxDAjv3fTyaAyN9HgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqmgAiQQJoAAmg8atpAogECaABJIDGr6YJIBIkgAaQABq/miaASJAAGkACaPxqei6A13/O+7c/f001+K8//53yr5//n5/vdP/r4TrAlV9+HwABEEBtwst5AojVryv86/8FXm8gNoDWwATQ+H0IYLuBEEBrYAJo/Ahg/B0EAbQGJoDGjwAIIHbQNk4Akb+PAD4CxBaaxgkg4icAAogtNI0TQMRPAAQQW2gaJ4CInwAIILbQNE4AET8BEEBsoWmcACJ+AiCA2ELTOAFE/ARAALGFpnECiPgJgABiC03jBBDxEwABxBaaxgkg4icAAogtNI0TQMT/v5/2i+b1r+mc3wS2fiHJeoDj+MTp+Xw+6/cBEMDtF5oQQFNA+88nAXy8T2ArIAIggETACt5W8LUACSC1v48ABEAAZYR8B/D9PX0rpO8Atiu4DeArf4wuAqrZ/PC+BLw9gARAADaAoGEfQdpHEN8BhOb7fHwHYADbANoAbAA2gCBhAmoCsgGE5rMBfD4GsA2gDcAGYAMIEiagJiAbQGg+G4AN4HUBEQABJAKvD8B6BV+fTwCp/f1fAAJoKzgB+A7AdwBBwgTUBGQDCM339+8A1n+Srz2+dCVQ/yh1PX/9dwu+/mf5K38CqAQfzxPA2yt8bT8CqAQfzxMAAUw/wz8+P88/PgEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/vwABEAAB/Hx+nk8SAAEQwPNj/PMLEAABEMDP5+f5JAEQAAE8P8Y/v0AVgN/z/5z9b0j6OfBvqMLwGQhgCP8XHE0Av6AIy0cggCX9/dkEsK/B9AkIYIp/fjgBzEuwfQAC2PJfn04A6wqMzyeAcQHGxxPAuADr4wlgXYHt+QSw5T8/nQDmJZg+AAFM8e8PJ4B9DZZPQABL+r/gbAL4BUUYPgIBDOH/hqMJ4DdUYfcMBLBj/ytOJoBfUYbZQxDADP3vOJgAfkcdVk9BACvyv+RcAvglhRg9BgGMwP+WYwngt1Ri8xwEsOH+a04lgF9TismDfE1Odeg/CXx/f59+H8PX1+0XcqxHgQDGFSAAAli2IAEs6X8+HwIggGULEsCSPgF8fATYNiABbPnbAHwHMO1AApji9xHABrBtQALY8rcB2ACmHUgAU/w2ABvAtgEJYMvfBmADmHYgAUzx2wBsANsGJIAtfxuADWDagQQwxW8DsAFsG5AAtvxtADaAaQcSwBS/DcAGsG1AAtjytwHYAKYdSABT/DYAG8C2AQlgy//5DcAAjxsoHk8AEWCNv/5zYAKoHbDNE8CWvw1gzP/68QQw7gAbwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngHEDEMC4AMePJ4BxAxDAuADHjyeAcQMQwLgAx48ngNgABjgCFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPgJIAIUnxIggIifACJA8SkBAoj4CSACFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPgJIAIUnxIggIifACJA8SkBAoj4CSACFJ8SIICInwAiQPEpAQKI+AkgAhSfEiCAiJ8AIkDxKQECiPjXAvDXc8cCHo8TQGwAAogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBAgg4ieACFB8SoAAIn4CiADFpwQIIOIngAhQfEqAACJ+AogAxacECCDiJ4AIUHxKgAAifgKIAMWnBM4LwABP+8/hYwIE8P39vayBF3os6TubAAjAFBwmQAAEcLj9XZ0ACMAUHCZAAARwuP1dnQAIwBQcJkAABHC4/V2dAAjAFBwmQAAEcLj9XZ0ACMAUHCZAAARwuP1dnQAIwBQcJkAABHC4/V2dAAjAFBwmQAAEcLj9XZ0AogD8nNcQvUyAAAjg5f717JEAARBAbCHxlwkQAAG83L+ePRIgAAKILST+MgECIICX+9ezRwIEQACxhcRfJkAABPBy/3r2SIAACCC2kPjLBAiAAF7uX88eCRAAAcQWEn+ZAAEQwMv969kjAQIggNhC4i8TIAACeLl/PXskQAAEEFtI/GUCBEAAL/evZ48EnhfAtwGOLSB+mQABfH09z+ByA7t7I/B889sAWgNI3yZAADaA2xNw/PYEQADHR+D29QmAAG5PwPHbEwABHB+B29cnAAK4PQHHb08ABHB8BG5fnwAI4PYEHL89ARDA8RG4fX0CIIDbE3D89gRAAMdH4Pb1CYAAbk/A8dsTAAEcH4Hb1ycAArg9Acdv///LGLErEwwsYgAAAABJRU5ErkJggg==",
     main: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABjtJREFUeF7t3cGNIzcQRuFWRgs4JAfgDUEheANwSAackQzPxRdJW9q/wCbZ356ruouvHgvUcEZ7O/xDYCMCt43WYikIHIQmwVYECL1VOy2G0BzYigCht2qnxRCaA1sRIPRW7bQYQnNgKwKE3qqdFlMW+vF4PGbGdbvdymuZeR1qywiUJSB0Blr2GAKEHsPZWwYRIPQg0F4zhgChx3D2lkEECD0ItNeMIUDoMZy9ZRABQg8C7TVjCBB6DGdvGUSA0INAe80YAu1Cf7t/b638n/ufrc+rPszNY5XUXHGEftEPQs8larUaQhO66soScYQm9BKiVoskNKGrriwRR2hCLyFqtUhCE7rqyhJxhCb0EqJWiyQ0oauuLBFHaEIvIWq1yOmFri6kGufmsUpqzThCD+qbm8cxoAk9hvNB6DGgCT2GM6FHca6+p/o1Bt2/bVetrxrnDF0ltWacCT2ob44cY0ATegxnR45RnKvvceSoknoeZ0Jn/KrZJnSVVBhH6BBgMZ3QRVBpGKFTgrX8ywldw1KP8lOTOqsRkYQOKRM6BNicTugQKKFDgM3phA6BEjoE2JxO6BAooUOAzemEDoESOgTYnE7oECihQ4DN6YQOgRI6BNicTugQKKFDgM3phA6BEjoE2JxO6Gag6eNskIwgoTN+7dmEzpASOuPXnk3oDCmhM37t2YTOkBI649eeTegMKaEzfu3ZhM6QEjrj155N6AwpoTN+7dmEzpASOuPXnk3oDCmhM37t2YTOkBI64zd99tU2CKGnVzIrkNAv+O3yRTOZHutlE5rQ61n7pmJCE5rQDQTO+mIdZ+iG5s38CBPahJ7Zz49rIzShP5Zm5gRCE3pmPz+ujdCE/liamRMITeiZ/Ty9ttk3iJ9ynK7IWgUQeq1+qfYnBAhNka0IEHqrdloMoTmwFQFCb9VOiyE0B7YiQOit2mkxhObAVgQuJ/TfR+2u5vf7H6VG/3X/UYrzvOeYZudX3SDV36+u2XccR/VPsAj9XCwb7jkXQr+Y14Qxof8jYELbIF8EzhoIJjQBTxWw+0xOaEIT+s2PCRw5bJBTN4gJTcBTBXTkIOBWAhKa0IR+c+ad/sjx7f69dLPXvdM9b80Lnd+OR8mX024KCb3mBcdZA4HQL/bzWQ0560Jil/USmtBfBAj9XIT2n0M7cjhyfLLhTGgT2oQeeVNoQpvQJvSbHedD194bxJHDkcORw5HjfwIm/lwTf/oJXf0TrNL1kKDpCFQF7C78tJtCQne3cq7nEXqufqgmJEDoEKD0uQgQeq5+qCYkQOgQoPS5CBB6rn6oJiRA6BCg9LkIEHqufqgmJEDoEKD0uQgQeq5+XK6a2QXsbkj7L/i7KexuUfY8Qr/g1/11ulmbZFcJEJrQVVeWiCM0oZcQtVokoQlddWWJOEITeglRq0USmtBVV5aIIzShlxC1WiShCV11ZYk4QhP6VFGvJmA3bDeF3UTD5xE6A0jojF97NqEzpITO+LVnEzpDSuiMX3s2oTOkhM74tWcTOkNK6IxfezahM6SEzvi1ZxM6Q0rojF97NqEzpITO+LVnEzpDSuiM30HAEGBzOqFDoIQOATanEzoESugQYHM6oUOghA4BNqcTOgRK6BBgczqhQ6CEDgE2pxM6BEroEGBzOqFDoIQOATanEzoESugQYHM6oUOghA4BNqdfTmgCNhs02eMIPagh1f84clA5276G0INaS+gxoAk9hvNB6DGgCT2GM6FHca6+Z5cvPPehsNrxNeNM6EF9c+QYA5rQYzg7coziXH2PI0eV1PM4EzrjV802oaukwjhChwCL6dML7UNcsZPCvggQ+oUIJuqaO4TQhF7T3Fd9q67mrA+FjhzVDolz5HjjgCPHmhvEkcORY01zHTk+65sJ/RmvWaJNaBN6Fhdb6iA0oVtEmuUhhCb0LC621NEudEtVv/AQZ95fgLZhCqE3bOqVl0ToK3d/w7UTesOmXnlJhL5y9zdcO6E3bOqVl0ToK3d/w7UTesOmXnlJhL5y9zdcO6E3bOqVl1QW+sqQrH0dAoRep1cqLRAgdAGSkHUIEHqdXqm0QIDQBUhC1iFA6HV6pdICAUIXIAlZhwCh1+mVSgsECF2AJGQdAoRep1cqLRD4F7peZQBIeX0KAAAAAElFTkSuQmCC",
@@ -1370,11 +1377,11 @@
     store:
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABVJJREFUeF7t3d1t20AQRWGrIwMpKQXEJaiEpICUFCAdMZBebAT6WcJDz/Lyy6uJ2Z1zz44oKZJOL/4hEETgFNSLVhB4ITQJoggQOipOzRCaA1EECB0Vp2YIzYEoAoSOilMzhOZAFAFCR8WpmWGhl2VZ4EKgi8DpdBpydeiiSxOE7orSuhcChOZBFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIkDoqDg10yb06/kNfQSGCfw9/xy6ltBDmFzUTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k2A0N0JWL+UAKFLcSrWTYDQ3QlYv5QAoUtxKtZNgNDdCVi/lAChS3Eq1k1geqH/vIz9Utz3848hlr/Pv4auU+82ptn5EfqO3oQm9IXA2Dhd8cObJvRtsRy421xMaBP6SiDlgBCa0IR+8KzKLYcD0npATGgCtgpY/aoJoQlNaLcc7wSqJ4x6n3tVx4Q2oU3or5zQQ2/ruQiBlQTafqdw5T5djsAQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQAUIPYXLRXggQei9J2ecQgTahX89vQxt0EQIXAtP/Xw5CE3UNAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANAUKvoeXa6QkQevqIbHANgemF9t12t+NM+equ6k+5E/rO8SfMbTDVAlbXIzShrwRSDjChCU3oBzfpvqzRAWk9ICY0AVsFdA9NwCgBCU1oQj+453XL4YBEHRBCE5rQX/kqx+hHsKrvxdTb5zuU316WoXfKp/+QLAH3KWD1GzqEvnOeHZB9HhBCE/pKIOUAE5rQhPak8J1A9T2gerftGn0EMaFNaBPahDahn702NjpRqx+RTGgT2oQ2oU1oE/o/AsuyDL2lM/qZwmeA/f0YBKa/5SD0MUSs6pLQVSTVmYIAoaeIwSaqCBC6iqQ6UxAg9BQx2EQVAUJXkVRnCgKEniIGm6giQOgqkupMQYDQU8RgE1UEphe6qlF1EPhIoO0zhWJAYAsChN6CqpptBAjdht7CWxAg9BZU1WwjQOg29BbeggCht6CqZhsBQreht/AWBAi9BVU12wgQug29hbcg0Ca0bx+9HWfX1wRUf+1Adb3p3/omNKEvBEYPMKHvPJ6NAqyeMOp97gATmtBXAikHmNCEJvSDZ53lP7zpHvpzD8FHu4UxoU1oE9qEfidwtAk4e78mtAltQpvQJvSzd++6XjWZfkL7ssZn6vj7RwKE5kMUAUJHxakZQnMgigCho+LUDKE5EEWA0FFxaobQHIgiQOioODVDaA5EESB0VJyaITQHoggQOipOzRCaA1EECB0Vp2YIzYEoAoSOilMzhOZAFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIkDoqDg1Q2gORBEgdFScmiE0B6IIEDoqTs0QmgNRBKYXOoq2ZqYh0PbDm9MQsJEoAoSOilMzhOZAFAFCR8WpGUJzIIoAoaPi1AyhORBFgNBRcWqG0ByIIlAudBQdzcQSOMV2prFDEiD0IWPPbZrQudkesjNCHzL23KYJnZvtITsj9CFjz22a0LnZHrIzQh8y9tymCZ2b7SE7+wcob7kPY5BclgAAAABJRU5ErkJggg==",
     time: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABk5JREFUeF7t3eFtJEUUhVE7IyRCIgAIYUOAAAgJiYyMdn/b6Fn3dr927eF3v6rpr88Mo6219/XFfwocVOD1oHtxKwq8AA3BUQWAPupxuhmgGTiqANBHPU43AzQDRxUA+qjH6WaAZuCoAkAf9TjdzBj029vbm1wKbBV4fX0dWR1d9P0mgN56lPb9XgBoDo4qAPRRj9PNAM3AUQWAPupxuhmgGTiqANBHPU43AzQDRxUA+qjH6WbWQP/y7Q/1FRgX+Pfbn6NrgR5lctF2AaC3n4D9qwWArua02HYBoLefgP2rBYCu5rTYdgGgt5+A/asFgK7mtNh2AaC3n4D9qwWArua02HaBx4OeBnKiOC31Na+bQp3e3dpJ4fQFAj0t9TWvA/prPjev+oMCQKNxVAGgj3qcbgZoBo4qAPRRj9PNAM3AUQWAPupxuhmgGTiqwONBT2u3f6mjA5hp+Xuu24I6vbvxbx+dLgj0tNTXvA7o8Ln5hA4DlseBDoMCHQYsjwMdBgU6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONBhUKDDgOVxoMOgQIcBy+M/HehpPwcw01L3XPd0qNMK9ZPC6cZAT0vdcx3QYWegw4DlcaDDoECHAcvjQIdBgQ4DlseBDoMCHQYsjwMdBgU6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONDloB8tB34W+hSo0wprJ4XTFwj0tNT71wGd9atPA50lBTrrV58GOksKdNavPg10lhTorF99GugsKdBZv/o00FlSoLN+9Wmgs6RAZ/3q00BnSYHO+tWngc6SAp31W5v+2eD/bFCnsB5/Uji9EaCnpd6/bvoPW2a7XD8N9AeNn/7rE3xCf/DGvP49c88OPqGzzj6hs371aaCzpEBn/erTQGdJgc761aeBzpICnfWrTwOdJQU661efBjpLCnTWrz4NdJYU6Kzf2vQU/vTPof/+9tfoXn779vvouul6v768jdY7BeroZl9eXo45WJneMNDTUl/zOqDDk8LpJ6pP6HveIEADfY+0m3YBGuibqN2zDdBA3yPtpl2ABvomavdsAzTQ90i7aReggb6J2j3bAA30PdJu2gXoD0L/Mzxzav/58nS96U+sOCm86Z20tc30pBDorSeU7esT2id0Juhh00AD/TCS2csBGuhM0MOmgQb6YSSzlwM00Jmgh00DDfTDSGYvB2igM0EPmwYa6IeRzF7OMaCnBybTXNODlel67eumP1M43feUE0Wgw0/oKZj2dUC/XxRooH8U8And/sgJ1/OVIwsIdNavPg10lhTorF99GugsKdBZv/o00FlSoLN+9Wmgs6RAZ/3q00BnSYHO+tWngc6SAp31G0//bFCnYdo/ezjd9+nwH3+wAvT71ID+oieFQAM9/b/HjxPPz1y8cS3QQH/GHdCfqfWga33l8JXjR4Gn/7XQ6XsGaKCBnr5b/uc6f8oRRvQd2nfozxDyHfoztR50ra8cvnL4ylF4Q/rK8UHE9leJ9r8rWHj2X2qJU36ka+0rB9DP8g50+DyADgOWx4EOgwIdBiyPAx0GBToMWB4HOgwKdBiwPA50GBToMGB5HOgwKNBhwPI40GFQoMOA5XGgw6BAhwHL40DfdAJ4yl/3LPtbW+7p8Osnhe1PXqDX7L67MdDh8wA6DFgeBzoMCnQYsDwOdBgU6DBgeRzoMCjQYcDyONBhUKDDgOVxoMOgQIcBy+NAh0GBDgOWx4EOgwIdBiyPHwPagUlZxuHLbcEfnxQCfbjA8u0BXQ5qud0CQO/2t3u5ANDloJbbLQD0bn+7lwsAXQ5qud0CQO/2t3u5ANDloJbbLQD0bn+7lwscA9pRdVnG4ctN4U9/jW/9pBDowwWWbw/oclDL7RYAere/3csFgC4HtdxuAaB3+9u9XADoclDL7RYAere/3csFgC4HtdxuAaB3+9u9XODxoMv3azkFfhRYOynUX4ErCgB9RVVrrhUAei29ja8oAPQVVa25VgDotfQ2vqIA0FdUteZaAaDX0tv4igJAX1HVmmsFgF5Lb+MrCtRBX/EiralAu8D4ZwrbG1tPgSsKAH1FVWuuFQB6Lb2NrygA9BVVrblWAOi19Da+ogDQV1S15loBoNfS2/iKAkBfUdWaawWAXktv4ysK/AdZX2DxTCYQ4gAAAABJRU5ErkJggg==",
-    batch: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABrBJREFUeF7t3e2R4zYQhOFVRq66kByAHcKGYAfgkFzljOQ6/VlfmVQ1biBSGD739wZc4J1mo0F93T78Q6ARgVujtVgKAh8ETQStCBB0q3ZaDEHTQCsCBN2qnRZD0DTQigBBt2qnxRA0DbQiQNCt2mkxsaDv9/sdLgTOInC73SKtRkXfF0HQZ7XS3/1OgKDpoBUBgm7VToshaBpoRYCgW7XTYgiaBloRIOhW7bQYgqaBVgQIulU7LeY0Qf/y+ftb0//n849oftYRYSoXpf0g6B3UKUCCLms1ukDaD4Im6AeBLjcmQRM0QT/bI9I3J3VxBOuIEkO5SOQoIkwBEnQRdDg87YfIIXKIHCLHFwEOHVpssYxDHwSQoIugw+EEHYLaK0sBEnQRdDg87YcMLUPL0DK0DB0a67QyDl1EmQIUOYqgw+FpP0QOkUPkEDlEjtBYp5Vx6CLKFKDIUQQdDk/7IXKIHCKHyCFyhMY6rYxDF1GmAEWOIuhweNoPkUPkEDlEDpEjNNZpZRy6iDIFKHIUQYfD036IHCKHyCFyiByhsU4r49BFlClAkaMIOhye9kPkEDlEDpFD5AiNdVoZhy6iTAGKHEXQ4fC0HyKHyCFyiBwiR2is08raOPRfn39GUH79/C2qS6/37SP7ucW/P7JfvJs9v/R6qRDS6JTyS+eXXi/tx9tHjnTBZwEk6G0fOasfBL3j66kjEDRBDx1COHRNMCLHNr8sKA78NHKXzMahazdcaljpjilyiBytdkyCJmiCPvI5dLolnXWqFjlEjlaOQNAETdBPtrjZO5KnHAc95Yhe1lOEwCCB0w6Fg/NUjkBEgKAjTIpWIUDQq3TKPCMCBB1hUrQKAYJepVPmGREg6AiTolUIEPQqnTLPiABBR5gUrUKAoFfplHlGBE4TdPp+6GgVLyia/ZLxC6YYXfJq6yDoHVlcTQhdDIagCfpBgKB3hHC/36PP/3cBaB1R8ikXpTsmh+bQHPrZ7cahy2Y09QKps3XZaTg0h+bQHPqLQBdn67IODs2hOTSH5tBTg35wsfQscJpD+7T0dhd9HcM2F4LeuetTwaQA0+w5+9Pc6fXSr9DqYjAc+qAMnQowveHS6xH0doOnf1ljF0fg0NuCSW+49AZOd0wOzaEfBLoYDEETNEHPeGzXxRFEDpGjlSMQNEET9JMtLj0kpYcuTzk85XgQSE/VHJpDD713IHUizlZ7ha3LjXnaU44uAB1u3+slfILeybNXy55dDIagCbpVBCRogiboGS+sdNniZGgZupUjEDRBE/STLW72Y8qrPU+XoWXoVgZD0ARN0DMOhWn2fPa3Xvl/s59Dv3Kuz659tXWc5tAEfYzECfrN3px0TNv//1euJoQuBsOhD8rQbswagdRgCJqgHwQ49I4Q0m8f7QLQOmrOm47m0CkpDs2hPbb7IsChi84RDufQIai9shQgQRdBh8PTfjgUihwix4zIEd6YyhAYInCaQw/NUjECIQGCDkEpW4MAQa/RJ7MMCRB0CErZGgQIeo0+mWVIgKBDUMrWIEDQa/TJLEMCBB2CUrYGAYJeo09mGRI4TdDpeyBmf6toer2rffy/Sz8IeufOJ+htMKkhnPX9IgRN0A8CHHpHCLM/sfLujuA7+raFwKF3bhCCrgkmfR8xh+bQDwIcunbDpYaVnmlkaBlahn72SFCGPsax0owqcmz3w4/X79zFIscxN7DIUTxkpgAJmqCHMlv4iuf0stlb9fQJhhe82jre/lAY9m162dWEkD62mw46vGDaD4LeAZoC7CKELusgaIJuFQEJmqAJ+sjn0GHEml4mckxHWrpg2g8OzaE5NIf+ItDlMNVlHRyaQ3NoDs2hS4H4JwbL0D8B7b9DUoBdtuou6xA5RA6RQ+QQOYob4PDwdMfk0ByaQ3NoDj1sscUBHPoggF0OU13WIXKIHCKHyCFyFDfA4eEixzCyHwekALts1V3WIXKIHCKHyCFyFDfA4eHpjsmhOTSH5tAcethiiwM49EEAuxymuqxD5BA5RA6RQ+QoboDDw0WOYWSeQxeRvXQ4QRfxpgC7ZM8u65ChZWgZWoaWoYsb4PDwdMc8zaGHV2QAAgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iFA0Ov0ykwDAgQdQFKyDgGCXqdXZhoQIOgAkpJ1CEwX9DpLN9MrE4h/GvnKkKx9HQIEvU6vzDQgQNABJCXrECDodXplpgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iHwL5ShIS3TtLVvAAAAAElFTkSuQmCC",
+    batch:
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAABrBJREFUeF7t3e2R4zYQhOFVRq66kByAHcKGYAfgkFzljOQ6/VlfmVQ1biBSGD739wZc4J1mo0F93T78Q6ARgVujtVgKAh8ETQStCBB0q3ZaDEHTQCsCBN2qnRZD0DTQigBBt2qnxRA0DbQiQNCt2mkxsaDv9/sdLgTOInC73SKtRkXfF0HQZ7XS3/1OgKDpoBUBgm7VToshaBpoRYCgW7XTYgiaBloRIOhW7bQYgqaBVgQIulU7LeY0Qf/y+ftb0//n849oftYRYSoXpf0g6B3UKUCCLms1ukDaD4Im6AeBLjcmQRM0QT/bI9I3J3VxBOuIEkO5SOQoIkwBEnQRdDg87YfIIXKIHCLHFwEOHVpssYxDHwSQoIugw+EEHYLaK0sBEnQRdDg87YcMLUPL0DK0DB0a67QyDl1EmQIUOYqgw+FpP0QOkUPkEDlEjtBYp5Vx6CLKFKDIUQQdDk/7IXKIHCKHyCFyhMY6rYxDF1GmAEWOIuhweNoPkUPkEDlEDpEjNNZpZRy6iDIFKHIUQYfD036IHCKHyCFyiByhsU4r49BFlClAkaMIOhye9kPkEDlEDpFD5AiNdVoZhy6iTAGKHEXQ4fC0HyKHyCFyiBwiR2is08raOPRfn39GUH79/C2qS6/37SP7ucW/P7JfvJs9v/R6qRDS6JTyS+eXXi/tx9tHjnTBZwEk6G0fOasfBL3j66kjEDRBDx1COHRNMCLHNr8sKA78NHKXzMahazdcaljpjilyiBytdkyCJmiCPvI5dLolnXWqFjlEjlaOQNAETdBPtrjZO5KnHAc95Yhe1lOEwCCB0w6Fg/NUjkBEgKAjTIpWIUDQq3TKPCMCBB1hUrQKAYJepVPmGREg6AiTolUIEPQqnTLPiABBR5gUrUKAoFfplHlGBE4TdPp+6GgVLyia/ZLxC6YYXfJq6yDoHVlcTQhdDIagCfpBgKB3hHC/36PP/3cBaB1R8ikXpTsmh+bQHPrZ7cahy2Y09QKps3XZaTg0h+bQHPqLQBdn67IODs2hOTSH5tBTg35wsfQscJpD+7T0dhd9HcM2F4LeuetTwaQA0+w5+9Pc6fXSr9DqYjAc+qAMnQowveHS6xH0doOnf1ljF0fg0NuCSW+49AZOd0wOzaEfBLoYDEETNEHPeGzXxRFEDpGjlSMQNEET9JMtLj0kpYcuTzk85XgQSE/VHJpDD713IHUizlZ7ha3LjXnaU44uAB1u3+slfILeybNXy55dDIagCbpVBCRogiboGS+sdNniZGgZupUjEDRBE/STLW72Y8qrPU+XoWXoVgZD0ARN0DMOhWn2fPa3Xvl/s59Dv3Kuz659tXWc5tAEfYzECfrN3px0TNv//1euJoQuBsOhD8rQbswagdRgCJqgHwQ49I4Q0m8f7QLQOmrOm47m0CkpDs2hPbb7IsChi84RDufQIai9shQgQRdBh8PTfjgUihwix4zIEd6YyhAYInCaQw/NUjECIQGCDkEpW4MAQa/RJ7MMCRB0CErZGgQIeo0+mWVIgKBDUMrWIEDQa/TJLEMCBB2CUrYGAYJeo09mGRI4TdDpeyBmf6toer2rffy/Sz8IeufOJ+htMKkhnPX9IgRN0A8CHHpHCLM/sfLujuA7+raFwKF3bhCCrgkmfR8xh+bQDwIcunbDpYaVnmlkaBlahn72SFCGPsax0owqcmz3w4/X79zFIscxN7DIUTxkpgAJmqCHMlv4iuf0stlb9fQJhhe82jre/lAY9m162dWEkD62mw46vGDaD4LeAZoC7CKELusgaIJuFQEJmqAJ+sjn0GHEml4mckxHWrpg2g8OzaE5NIf+ItDlMNVlHRyaQ3NoDs2hS4H4JwbL0D8B7b9DUoBdtuou6xA5RA6RQ+QQOYob4PDwdMfk0ByaQ3NoDj1sscUBHPoggF0OU13WIXKIHCKHyCFyFDfA4eEixzCyHwekALts1V3WIXKIHCKHyCFyFDfA4eHpjsmhOTSH5tAcethiiwM49EEAuxymuqxD5BA5RA6RQ+QoboDDw0WOYWSeQxeRvXQ4QRfxpgC7ZM8u65ChZWgZWoaWoYsb4PDwdMc8zaGHV2QAAgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iFA0Ov0ykwDAgQdQFKyDgGCXqdXZhoQIOgAkpJ1CEwX9DpLN9MrE4h/GvnKkKx9HQIEvU6vzDQgQNABJCXrECDodXplpgEBgg4gKVmHAEGv0yszDQgQdABJyToECHqdXplpQICgA0hK1iHwL5ShIS3TtLVvAAAAAElFTkSuQmCC",
   };
 
-  const docs =
-    "https://extensions.turbowarp.org/gamejolt";
+  const docs = "https://extensions.turbowarp.org/gamejolt";
 
   /**
    * Mostly visual stuff for Scratch GUI
@@ -1814,7 +1821,7 @@
               ID: {
                 type: Scratch.ArgumentType.NUMBER,
                 defaultValue: 0,
-              }
+              },
             },
           },
           {
@@ -1865,7 +1872,7 @@
           },
           {
             opcode: "returnScoreDataJson",
-            blockIconURI: icons.score, 
+            blockIconURI: icons.score,
             blockType: Scratch.BlockType.REPORTER,
             text: "Fetched score data in JSON",
           },
@@ -1918,11 +1925,11 @@
               tableDataType: {
                 type: Scratch.ArgumentType.STRING,
                 menu: "tableDataTypes",
-                defaultValue: "id"
+                defaultValue: "id",
               },
               index: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: 0
+                defaultValue: 0,
               },
             },
           },
@@ -1930,7 +1937,7 @@
             opcode: "scoreReturnTablesJson",
             blockIconURI: icons.score,
             blockType: Scratch.BlockType.REPORTER,
-            text: "Fetched tables in JSON"
+            text: "Fetched tables in JSON",
           },
           {
             blockType: Scratch.BlockType.LABEL,
@@ -2048,7 +2055,7 @@
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
                 menu: "globalOrPerUser",
-                defaultValue: "false"
+                defaultValue: "false",
               },
             },
           },
@@ -2061,11 +2068,11 @@
               globalOrPerUser: {
                 type: Scratch.ArgumentType.STRING,
                 menu: "globalOrPerUser",
-                defaultValue: "false"
+                defaultValue: "false",
               },
               pattern: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "*"
+                defaultValue: "*",
               },
             },
           },
@@ -2077,7 +2084,7 @@
             arguments: {
               index: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: 0
+                defaultValue: 0,
               },
             },
           },
@@ -2142,7 +2149,7 @@
             arguments: {
               namespace: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "data-store/set"
+                defaultValue: "data-store/set",
               },
               parameters: {
                 type: Scratch.ArgumentType.STRING,
@@ -2171,7 +2178,7 @@
               parameter: {
                 type: Scratch.ArgumentType.STRING,
                 menu: "batchParameters",
-                defaultValue: "sequentially"
+                defaultValue: "sequentially",
               },
             },
           },
@@ -2219,10 +2226,7 @@
             ],
           },
           status: {
-            items: [
-              "active",
-              "idle",
-            ],
+            items: ["active", "idle"],
           },
           fetchTypes: {
             items: [
@@ -2335,14 +2339,14 @@
             items: [
               { text: "sequentially", value: "sequentially" },
               { text: "sequentially, break on error", value: "break_on_error" },
-              { text: "in parallel", value: "parallel"}
+              { text: "in parallel", value: "parallel" },
             ],
           },
         },
       };
     }
     debug({ toggle }) {
-      err.debug = (toggle == trueStr);
+      err.debug = toggle == trueStr;
     }
     debugBool() {
       return err.debug;
@@ -2359,14 +2363,10 @@
     }
     session({ openOrClose }) {
       return new Promise((resolve) =>
-        GameJolt.SessionSetStatus(
-          openOrClose,
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              err.last = pResponse.message;
-            resolve();
-          }
-        )
+        GameJolt.SessionSetStatus(openOrClose, (pResponse) => {
+          if (pResponse.success != trueStr) err.last = pResponse.message;
+          resolve();
+        })
       );
     }
 
@@ -2375,13 +2375,10 @@
      */
     sessionPing() {
       return new Promise((resolve) =>
-        GameJolt.SessionPing(
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              err.last = pResponse.message;
-            resolve();
-          }
-        )
+        GameJolt.SessionPing((pResponse) => {
+          if (pResponse.success != trueStr) err.last = pResponse.message;
+          resolve();
+        })
       );
     }
     sessionSetStatus({ status }) {
@@ -2389,9 +2386,8 @@
     }
     sessionBool() {
       return new Promise((resolve) =>
-        GameJolt.SessionCheck(
-          (pResponse) =>
-            resolve(pResponse.success == trueStr)
+        GameJolt.SessionCheck((pResponse) =>
+          resolve(pResponse.success == trueStr)
         )
       );
     }
@@ -2401,16 +2397,11 @@
      */
     loginManual({ username, token }) {
       return new Promise((resolve) =>
-        GameJolt.UserLoginManual(
-          username,
-          token,
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              [err.user, err.last] =
-                [pResponse.message, pResponse.message];
-            resolve();
-          }
-        )
+        GameJolt.UserLoginManual(username, token, (pResponse) => {
+          if (pResponse.success != trueStr)
+            [err.user, err.last] = [pResponse.message, pResponse.message];
+          resolve();
+        })
       );
     }
 
@@ -2419,14 +2410,11 @@
      */
     loginAuto() {
       return new Promise((resolve) =>
-        GameJolt.UserLoginAuto(
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-            [err.user, err.last] =
-              [pResponse.message, pResponse.message];
-            resolve();
-          }
-        )
+        GameJolt.UserLoginAuto((pResponse) => {
+          if (pResponse.success != trueStr)
+            [err.user, err.last] = [pResponse.message, pResponse.message];
+          resolve();
+        })
       );
     }
     loginAutoBool() {
@@ -2434,14 +2422,11 @@
     }
     logout() {
       return new Promise((resolve) =>
-        GameJolt.UserLogout(
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-            [err.user, err.last] =
-              [pResponse.message, pResponse.message];
-            resolve();
-          }
-        )
+        GameJolt.UserLogout((pResponse) => {
+          if (pResponse.success != trueStr)
+            [err.user, err.last] = [pResponse.message, pResponse.message];
+          resolve();
+        })
       );
     }
     loginBool() {
@@ -2452,40 +2437,32 @@
     }
     userFetch({ fetchType, usernameOrID }) {
       return new Promise((resolve) =>
-        GameJolt.UserFetchComb(
-          fetchType,
-          usernameOrID,
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.user, err.last] =
-                [pResponse.message, pResponse.message];
-              data.user = undefined;
-              resolve();
-              return;
-            }
-            data.user = pResponse.users[0];
-            err.user = undefined;
+        GameJolt.UserFetchComb(fetchType, usernameOrID, (pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.user, err.last] = [pResponse.message, pResponse.message];
+            data.user = undefined;
             resolve();
+            return;
           }
-        )
+          data.user = pResponse.users[0];
+          err.user = undefined;
+          resolve();
+        })
       );
     }
     userFetchCurrent() {
       return new Promise((resolve) =>
-        GameJolt.UserFetchCurrent(
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.user, err.last] =
-                [pResponse.message, pResponse.message];
-              data.user = undefined;
-              resolve();
-              return;
-            }
-            data.user = pResponse.users[0];
-            err.user = undefined;
+        GameJolt.UserFetchCurrent((pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.user, err.last] = [pResponse.message, pResponse.message];
+            data.user = undefined;
             resolve();
+            return;
           }
-        )
+          data.user = pResponse.users[0];
+          err.user = undefined;
+          resolve();
+        })
       );
     }
     returnUserData({ userDataType }) {
@@ -2510,20 +2487,17 @@
     }
     friendsFetchNew() {
       return new Promise((resolve) =>
-        GameJolt.FriendsFetch(
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.friends, err.last] =
-                [pResponse.message, pResponse.message];
-              data.friends = undefined;
-              resolve();
-              return;
-            }
-            data.friends = pResponse.friends;
-            err.friends = undefined;
+        GameJolt.FriendsFetch((pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.friends, err.last] = [pResponse.message, pResponse.message];
+            data.friends = undefined;
             resolve();
+            return;
           }
-        )
+          data.friends = pResponse.friends;
+          err.friends = undefined;
+          resolve();
+        })
       );
     }
     friendsReturn({ index }) {
@@ -2536,28 +2510,20 @@
     }
     trophyAchieve({ ID }) {
       return new Promise((resolve) =>
-        GameJolt.TrophyAchieve(
-          ID,
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              [err.trophies, err.last] =
-                [pResponse.message, pResponse.message];
-            resolve();
-          }
-        )
+        GameJolt.TrophyAchieve(ID, (pResponse) => {
+          if (pResponse.success != trueStr)
+            [err.trophies, err.last] = [pResponse.message, pResponse.message];
+          resolve();
+        })
       );
     }
     trophyRemove({ ID }) {
       return new Promise((resolve) =>
-        GameJolt.TrophyRemove(
-          ID,
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              [err.trophies, err.last] =
-                [pResponse.message, pResponse.message];
-            resolve();
-          }
-        )
+        GameJolt.TrophyRemove(ID, (pResponse) => {
+          if (pResponse.success != trueStr)
+            [err.trophies, err.last] = [pResponse.message, pResponse.message];
+          resolve();
+        })
       );
     }
     trophyFetch({ indexOrID, value, trophyDataType }) {
@@ -2584,63 +2550,50 @@
     }
     trophyFetchAll({ trophyFetchGroup }) {
       return new Promise((resolve) =>
-        GameJolt.TrophyFetch(
-          Number(trophyFetchGroup),
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.trophies, err.last] =
-                [pResponse.message, pResponse.message];
-              data.trophies = undefined;
-              resolve();
-              return;
-            }
-            data.trophies = pResponse.trophies;
-            err.trophies = undefined;
+        GameJolt.TrophyFetch(Number(trophyFetchGroup), (pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.trophies, err.last] = [pResponse.message, pResponse.message];
+            data.trophies = undefined;
             resolve();
+            return;
           }
-        )
+          data.trophies = pResponse.trophies;
+          err.trophies = undefined;
+          resolve();
+        })
       );
     }
     trophyFetchId({ ID }) {
       return new Promise((resolve) =>
-        GameJolt.TrophyFetchSingle(
-          ID,
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.trophies, err.last] =
-                [pResponse.message, pResponse.message];
-              data.trophies = undefined;
-              resolve();
-              return;
-            }
-            data.trophies = pResponse.trophies;
-            err.trophies = undefined;
+        GameJolt.TrophyFetchSingle(ID, (pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.trophies, err.last] = [pResponse.message, pResponse.message];
+            data.trophies = undefined;
             resolve();
+            return;
           }
-        )
+          data.trophies = pResponse.trophies;
+          err.trophies = undefined;
+          resolve();
+        })
       );
     }
     trophyReturn({ trophyDataType, index }) {
       if (!data.trophies) return err.get("trophies");
       if (!data.trophies[Math.floor(index)]) return err.get("noIndex");
-      return data.trophies[Math.floor(index)][trophyDataType] || err.get("noData");
+      return (
+        data.trophies[Math.floor(index)][trophyDataType] || err.get("noData")
+      );
     }
     trophyReturnJson() {
       return JSON.stringify(data.trophies) || err.get("trophies") || "{}";
     }
     scoreAdd({ ID, value, text, extraData }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreAdd(
-          ID,
-          value,
-          text,
-          extraData, 
-          (pResponse) => {
-            if (pResponse.success != trueStr)
-              err.last = pResponse.message;
-            resolve();
-          }
-        )
+        GameJolt.ScoreAdd(ID, value, text, extraData, (pResponse) => {
+          if (pResponse.success != trueStr) err.last = pResponse.message;
+          resolve();
+        })
       );
     }
     scoreAddGuest({ ID, value, text, username, extraData }) {
@@ -2650,10 +2603,9 @@
           value,
           text,
           username,
-          extraData, 
+          extraData,
           (pResponse) => {
-            if (pResponse.success != trueStr)
-              err.last = pResponse.message;
+            if (pResponse.success != trueStr) err.last = pResponse.message;
             resolve();
           }
         )
@@ -2674,8 +2626,7 @@
           amount,
           (pResponse) => {
             if (pResponse.success != trueStr) {
-              [err.scores, err.last] =
-                [pResponse.message, pResponse.message];
+              [err.scores, err.last] = [pResponse.message, pResponse.message];
               data.scores = undefined;
               resolve();
               return;
@@ -2690,7 +2641,7 @@
     scoreFetch({ globalOrPerUser, ID, amount, betterOrWorse, value }) {
       if (globalOrPerUser == trueStr && !GameJolt.bLoggedIn) {
         err.scores = err.noLogin;
-        data.scores = undefined
+        data.scores = undefined;
         return;
       }
       return new Promise((resolve) =>
@@ -2704,8 +2655,7 @@
           value,
           (pResponse) => {
             if (pResponse.success != trueStr) {
-              [err.scores, err.last] =
-                [pResponse.message, pResponse.message];
+              [err.scores, err.last] = [pResponse.message, pResponse.message];
               data.scores = undefined;
               resolve();
               return;
@@ -2717,25 +2667,19 @@
         )
       );
     }
-    scoreFetchGuestSimple({ amount, username, ID}) {
+    scoreFetchGuestSimple({ amount, username, ID }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreFetchGuestEx(
-          ID,
-          username,
-          amount,
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.scores, err.last] =
-                [pResponse.message, pResponse.message];
-              data.scores = undefined;
-              resolve();
-              return;
-            }
-            data.scores = pResponse.scores;
-            err.scores = undefined;
+        GameJolt.ScoreFetchGuestEx(ID, username, amount, (pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.scores, err.last] = [pResponse.message, pResponse.message];
+            data.scores = undefined;
             resolve();
+            return;
           }
-        )
+          data.scores = pResponse.scores;
+          err.scores = undefined;
+          resolve();
+        })
       );
     }
     scoreFetchGuest({ ID, username, amount, betterOrWorse, value }) {
@@ -2748,8 +2692,7 @@
           value,
           (pResponse) => {
             if (pResponse.success != trueStr) {
-              [err.scores, err.last] =
-                [pResponse.message, pResponse.message];
+              [err.scores, err.last] = [pResponse.message, pResponse.message];
               data.scores = undefined;
               resolve();
               return;
@@ -2777,56 +2720,49 @@
     }
     scoreGetRank({ ID, value }) {
       return new Promise((resolve) =>
-        GameJolt.ScoreGetRank(
-          ID,
-          value,
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              err.last = pResponse.message;
-              resolve(err.get("last"));
-              return;
-            }
-            resolve(pResponse.rank);
+        GameJolt.ScoreGetRank(ID, value, (pResponse) => {
+          if (pResponse.success != trueStr) {
+            err.last = pResponse.message;
+            resolve(err.get("last"));
+            return;
           }
-        )
+          resolve(pResponse.rank);
+        })
       );
     }
     scoreGetTables({ index, tableDataType }) {
-      GameJolt.ScoreGetTables(
-        (pResponse) => {
-          if (pResponse.success != trueStr) {
-            err.tables = pResponse.message;
-            return;
-          }
-          data.tables = pResponse.tables;
+      GameJolt.ScoreGetTables((pResponse) => {
+        if (pResponse.success != trueStr) {
+          err.tables = pResponse.message;
+          return;
         }
-      );
+        data.tables = pResponse.tables;
+      });
       if (!data.tables) return err.get("tables");
       if (!data.tables[index]) return err.get("noIndex");
       return data.tables[index][tableDataType] || err.get("noData");
     }
     scoreFetchTables() {
       return new Promise((resolve) =>
-        GameJolt.ScoreGetTables(
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.tables, err.last] =
-                [pResponse.message, pResponse.message];
-              data.tables = undefined;
-              resolve();
-              return;
-            }
-            data.tables = pResponse.tables;
-            err.tables = undefined;
+        GameJolt.ScoreGetTables((pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.tables, err.last] = [pResponse.message, pResponse.message];
+            data.tables = undefined;
             resolve();
+            return;
           }
-        )
+          data.tables = pResponse.tables;
+          err.tables = undefined;
+          resolve();
+        })
       );
     }
     scoreReturnTables({ tableDataType, index }) {
       if (!data.tables) return err.get("tables");
       if (!data.tables[Math.floor(index)]) return err.get("noIndex");
-      return !data.tables[Math.floor(index)][tableDataType] || err.get("noData");
+      return (
+        !data.tables[Math.floor(index)][tableDataType] || err.get("noData")
+      );
     }
     scoreReturnTablesJson() {
       return JSON.stringify(data.tables) || err.get("tables") || "{}";
@@ -2836,10 +2772,9 @@
         GameJolt.DataStoreSet(
           globalOrPerUser == trueStr,
           key,
-          data, 
+          data,
           (pResponse) => {
-            if (pResponse.success != trueStr)
-              err.last = pResponse.message;
+            if (pResponse.success != trueStr) err.last = pResponse.message;
             resolve();
           }
         )
@@ -2918,39 +2853,34 @@
       return data.keys[index].key || err.get("noData");
     }
     dataStoreFetchKeys({ globalOrPerUser }) {
-      return new Promise((resolve) => 
-        GameJolt.DataStoreGetKeys(
-          globalOrPerUser == trueStr,
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.keys, err.last] =
-                [pResponse.message, pResponse.message];
-              data.keys = undefined;
-              resolve();
-              return;
-            }
-            if (!pResponse.keys) {
-              data.keys = undefined;
-              err.keys = err.noIndex;
-              resolve();
-              return;
-            }
-            data.keys = pResponse.keys;
-            err.keys = undefined;
+      return new Promise((resolve) =>
+        GameJolt.DataStoreGetKeys(globalOrPerUser == trueStr, (pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.keys, err.last] = [pResponse.message, pResponse.message];
+            data.keys = undefined;
             resolve();
+            return;
           }
-        )
+          if (!pResponse.keys) {
+            data.keys = undefined;
+            err.keys = err.noIndex;
+            resolve();
+            return;
+          }
+          data.keys = pResponse.keys;
+          err.keys = undefined;
+          resolve();
+        })
       );
     }
     dataStoreFetchPatternKeys({ globalOrPerUser, pattern }) {
-      return new Promise((resolve) => 
+      return new Promise((resolve) =>
         GameJolt.DataStoreGetKeysEx(
           globalOrPerUser == trueStr,
           pattern,
           (pResponse) => {
             if (pResponse.success != trueStr) {
-              [err.keys, err.last] =
-                [pResponse.message, pResponse.message];
+              [err.keys, err.last] = [pResponse.message, pResponse.message];
               data.keys = undefined;
               resolve();
               return;
@@ -2979,33 +2909,29 @@
     timeFetch({ timeType }) {
       return new Promise((resolve) =>
         GameJolt.TimeFetch((pResponse) => {
-            if (pResponse.success != trueStr) {
-              err.last = pResponse.message;
-              resolve(err.get("last"));
-            }
-            resolve(pResponse[timeType]);
+          if (pResponse.success != trueStr) {
+            err.last = pResponse.message;
+            resolve(err.get("last"));
           }
-        )
+          resolve(pResponse[timeType]);
+        })
       );
     }
     timeFetchNew() {
       return new Promise((resolve) =>
-        GameJolt.TimeFetch(
-          (pResponse) => {
-            if (pResponse.success != trueStr) {
-              [err.time, err.last] =
-                [pResponse.message, pResponse.message];
-              data.time = undefined;
-              resolve();
-              return;
-            }
-            data.time = pResponse;
-            data.time.success = undefined;
-            data.time.message = undefined;
-            err.time = undefined;
+        GameJolt.TimeFetch((pResponse) => {
+          if (pResponse.success != trueStr) {
+            [err.time, err.last] = [pResponse.message, pResponse.message];
+            data.time = undefined;
             resolve();
+            return;
           }
-        )
+          data.time = pResponse;
+          data.time.success = undefined;
+          data.time.message = undefined;
+          err.time = undefined;
+          resolve();
+        })
       );
     }
     timeReturn({ timeType }) {
@@ -3038,17 +2964,19 @@
     batchCall({ parameter }) {
       return new Promise((resolve) =>
         GameJolt.SendBatchRequest(
-          data.batchRequests
-          .map(
-            (I) => `/${I.namespace.split("/").map((i) => encodeURIComponent(i)).join("/")}/` +
-                   `?game_id=${GameJolt.iGameID}` +
-                   `&${new URLSearchParams(I.parameters).toString()}`
+          data.batchRequests.map(
+            (I) =>
+              `/${I.namespace
+                .split("/")
+                .map((i) => encodeURIComponent(i))
+                .join("/")}/` +
+              `?game_id=${GameJolt.iGameID}` +
+              `&${new URLSearchParams(I.parameters).toString()}`
           ),
           parameter,
           (pResponse) => {
             if (pResponse.success != trueStr) {
-              [err.batch, err.last] =
-                [pResponse.message, pResponse.message];
+              [err.batch, err.last] = [pResponse.message, pResponse.message];
               data.batch = undefined;
               resolve();
               return;
@@ -3058,7 +2986,7 @@
             resolve();
           }
         )
-      )
+      );
     }
     batchReturnJson() {
       return JSON.stringify(data.batch) || err.get("batch") || "{}";

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -3018,18 +3018,16 @@
       data.batchRequests = undefined;
     }
     batchJson() {
-      return JSON.stringify(data.batchRequests) || err.get("batch") || "{}";
+      return JSON.stringify(data.batchRequests) || err.get("noData") || "{}";
     }
     batchCall({ parameter }) {
       return new Promise((resolve) =>
         GameJolt.SendBatchRequest(
           data.batchRequests
           .map(
-            (I) => `
-              /${I.namespace.split("/").map((i) => encodeURIComponent(i)).join("/")}/
-              ?game_id=${GameJolt.iGameID}
-              &${new URLSearchParams(I.parameters).toString()}
-            `
+            (I) => `/${I.namespace.split("/").map((i) => encodeURIComponent(i)).join("/")}/` +
+                   `?game_id=${GameJolt.iGameID}` +
+                   `&${new URLSearchParams(I.parameters).toString()}`
           ),
           parameter,
           (pResponse) => {

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -355,7 +355,7 @@
             break;
 
           default:
-            pCallback(sResponse);
+            if (typeof pCallback == "function") pCallback(sResponse);
         }
       });
     };
@@ -424,7 +424,7 @@
           window.addEventListener("beforeunload", GJAPI.SessionClose, false);
         }
 
-        pCallback(pResponse);
+        if (typeof pCallback == "function") pCallback(pResponse);
       });
     };
 
@@ -2613,7 +2613,7 @@
               resolve();
               return;
             }
-            data.trophies = pResponse.trophies[0];
+            data.trophies = pResponse.trophies;
             err.trophies = undefined;
             resolve();
           }
@@ -2626,7 +2626,7 @@
       return data.trophies[Math.floor(index)][trophyDataType] || err.get("noData");
     }
     trophyReturnJson() {
-      return JSON.stringify(data.trohies) || err.get("trophies") || "{}";
+      return JSON.stringify(data.trophies) || err.get("trophies") || "{}";
     }
     scoreAdd({ ID, value, text, extraData }) {
       return new Promise((resolve) =>

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -2139,7 +2139,7 @@
           },
           {
             blockType: Scratch.BlockType.LABEL,
-            text: "Batch Blocks (For Developers)",
+            text: "Batch Blocks",
           },
           {
             opcode: "batchAdd",


### PR DESCRIPTION
### Changes

- Added docs.
- Replaced some blocks with more efficient ones, replaced blocks marked as deprecated.
- Added batch blocks.
  There isn't any way to independently test them without a game so we'll need people that are devs on GJ,
here are the [api docs](https://gamejolt.com/game-api/doc), they cover what fields and params namespaces have, and the extension got rest of the URL construction covered.
- Added debug mode and debug blocks, debug mode solves error messages being interpreted as a valid response, on by default to prevent significant block behaviour change.
- Unwrapped some resolves to put the error message into `err.last` for the `Last API error` block to work properly, solves people improperly using non-returning blocks and telling me that the extension is not working instead of opening the console to see the errors. Thought of doing this with alerts but that would significantly change most existing projects' behaviour.
- Changed text on blocks and some error messages to be more readable.
- Changed GameJolt to Game Jolt because apparently Game Jolt with a space is their actual name, didn't check if this breaks something because it shouldn't (IDs and ID-like stuff untouched)

### And most importantly
- The `bool` object is now just `trueStr`.

### Wrapping up

Lint will probably complain about `data.stuff = undefined;`.
It is there to make blocks not skip errors.
![scratchblocks (2)](https://github.com/TurboWarp/extensions/assets/100989385/9b28ec3a-1d30-4d09-898d-7091a40d9320)

Should be it.