### PR TITLE
Add get_lines and get_line to Text.js

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -130,13 +130,13 @@
             arguments: {
               LINE: {
                 type: Scratch.ArgumentType.NUMBER,
-                  defaultValue: 1,
-                },
-                STRING: {
-                  type: Scratch.ArgumentType.STRING,
-                  defaultValue: "Hello, world!\nGoodbye, world!",
-                },
+                defaultValue: 1,
               },
+              STRING: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "Hello, world!\nGoodbye, world!",
+              },
+            },
           },
           {
             opcode: "get_lines",
@@ -144,22 +144,22 @@
             text: "get lines [FROM] to [TO] from [STRING]",
             arguments: {
               FROM: {
-                  type: Scratch.ArgumentType.NUMBER,
-                  defaultValue: 1,
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 1,
               },
               TO: {
-                  type: Scratch.ArgumentType.NUMBER,
-                  defaultValue: 3,
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 3,
               },
               STRING: {
-                  type: Scratch.ArgumentType.STRING,
-                  defaultValue: "Hello, world!\nHey!\nHi!\nI'm excluded!",
-                },
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "Hello, world!\nHey!\nHi!\nI'm excluded!",
               },
+            },
           },
 
           "---",
-          
+
           {
             opcode: "replace",
             blockType: Scratch.BlockType.REPORTER,
@@ -221,7 +221,7 @@
           },
 
           "---",
-          
+
           {
             opcode: "replaceRegex",
             blockType: Scratch.BlockType.REPORTER,
@@ -472,7 +472,13 @@
       const maxLines = Math.floor(args.TO);
       const text = args.STRING;
       const lines = text.split("\n");
-      if (minLines < 1 || minLines > lines.length || maxLines < 1 || maxLines > lines.length || minLines > maxLines) {
+      if (
+        minLines < 1 ||
+        minLines > lines.length ||
+        maxLines < 1 ||
+        maxLines > lines.length ||
+        minLines > maxLines
+      ) {
         return "";
       }
       return lines.slice(minLines - 1, maxLines).join("\n");


### PR DESCRIPTION
I've added `get_lines` and `get_line` which allows to get a specific line from a bit of text. I found this helpful when I'm using Animated Text's `displayed text` block, and the `add line` block.

# Added Blocks
> [!NOTE]
> The purple blocks used here are from an extension called 'Animated Text'
## `get_line`
![get_line](https://github.com/TurboWarp/extensions/assets/69256931/ddd84b8a-44f9-4fbb-b9b8-4003359297bb)

## `get_lines`
![get_lines](https://github.com/TurboWarp/extensions/assets/69256931/db25fa88-d3f0-422a-8adb-0eb0d591d97f)
> [!NOTE]
> For `get_lines`, you can see I put the output all on one line. When running this block, it would be split onto seperate lines.
> Unfortunately, the comment would look ugly if I split the text across lines, so I didn't do that. However, the output would look like this in Scratch:
> ```
> Hello!
> Meow!
> Woof!
> ```