### PR TITLE
utilities: fix some blocks breaking if specific costumes exist

### DIFF
--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -317,9 +317,9 @@
       MIN = Scratch.Cast.toNumber(MIN);
       MAX = Scratch.Cast.toNumber(MAX);
       if (MIN > MAX) {
-        return Scratch.Cast.toNumber(Math.min(Math.max(INPUT, MAX), MIN));
+        return Math.min(Math.max(INPUT, MAX), MIN);
       } else {
-        return Scratch.Cast.toNumber(Math.min(Math.max(INPUT, MIN), MAX));
+        return Math.min(Math.max(INPUT, MIN), MAX);
       }
     }
 

--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -311,6 +311,9 @@
     }
 
     clamp({ INPUT, MIN, MAX }) {
+      INPUT = Scratch.Cast.toNumber(INPUT);
+      MIN = Scratch.Cast.toNumber(MIN);
+      MAX = Scratch.Cast.toNumber(MAX);
       if (MIN > MAX) {
         return Scratch.Cast.toNumber(Math.min(Math.max(INPUT, MAX), MIN));
       } else {

--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -279,11 +279,11 @@
     }
 
     isLessOrEqual({ A, B }) {
-      return A <= B;
+      return Scratch.Cast.compare(A, B) <= 0;
     }
 
     isMoreOrEqual({ A, B }) {
-      return A >= B;
+      return Scratch.Cast.compare(A, B) >= 0;
     }
 
     trueBlock() {
@@ -295,6 +295,8 @@
     }
 
     exponent({ A, B }) {
+      A = Scratch.Cast.toNumber(A);
+      B = Scratch.Cast.toNumber(B);
       return Math.pow(A, B);
     }
 


### PR DESCRIPTION
Resolves [#Clamp bug](https://discord.com/channels/837024174865776680/1168243452899774494)

For some weird, inexplicable reason that I do not know why it happens, ArgumentType.NUMBER arguments are auto-casted to number, but _only_ if a costume with that name does not exist.
This breaks a few math-related blocks in Utilities under specific circumstances (for example, `clamp 30 between 25 and 100` returns `25` if costumes named 25 and 100 exist).
This PR fixes that, by casting the arguments to numbers in `clamp` and using Scratch.Cast.compare on `isLessOrEqual` and `isMoreOrEqual`. `exponent`'s arguments are also casted now just to be safe.