### PR TITLE
Update ShovelUtils (importImage) to support SVG

### DIFF
--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -202,6 +202,62 @@
     }
 
     importImage({ TEXT, NAME }) {
+      //Updated to support SVG. (0znzw)
+      //Some notes: it returns a "error code" for debugging.
+      /* -2: Invalid format from URL
+         -1: Invalid format in dataURL
+          1: Ran succesfully
+      */
+      let url = Scratch.Cast.toString(TEXT), costume_name = Scratch.Cast.toString(NAME);
+      const storage = vm.runtime.storage;
+      function get_url_extension(uri) {
+          var len = uri.split('/');
+          return(len[len.length-1].split('.')[1].split(/[#\?]/gi)[0]);
+      }
+      let dataType = '', dataFormat = '';
+      if (url.startsWith('data:image/')) {
+          url = url.replace('data:image/', '');
+          if (url.startsWith('svg')) dataType = 'svg', dataFormat = storage.DataFormat.SVG;
+          if (url.startsWith('png')) dataType = 'png', dataFormat = storage.DataFormat.PNG;
+          if (url.startsWith('jpg')) dataType = 'jpg', dataFormat = storage.DataFormat.JPG;
+          if (url.startsWith('jpeg')) dataType = 'jpg', dataFormat = storage.DataFormat.JPG;
+          if (dataType == '') return -1;
+          url = `data:image/${url}`;
+      } else {
+          dataType = get_url_extension(url);
+          dataType = dataType.toLowerCase();
+          switch(dataType) {
+              case 'svg':
+                  dataFormat = storage.DataFormat.SVG;
+                  break;
+              case 'png':
+                  dataFormat = storage.DataFormat.PNG;
+                  break;
+              default:
+                  // *cough* to many jpg formats
+                  if ([
+                    'jpg', 'jpeg', 'jfif' /* etc, etc.. */
+                  ].includes(dataType)) {
+                    dataFormat = storage.DataFormat.JPG;
+                    break;
+                  }
+                  return -2;
+          }
+      }
+      dataType = dataType.toLowerCase();
+      Scratch.fetch(url)
+          .then((r) => r.arrayBuffer())
+          .then((arrayBuffer) => {
+            const storage = vm.runtime.storage;
+            vm.addCostume(costume_name + `.${dataType.toUpperCase()}`, {
+              name: costume_name + '',
+              asset: new storage.Asset(
+                (dataType == 'svg' ? storage.AssetType.ImageVector : storage.AssetType.ImageBitmap),
+                null, dataFormat, new Uint8Array(arrayBuffer), true
+              ),
+            });
+          });
+      return 1; // ignore the below, its only here for reference
       Scratch.fetch(TEXT)
         .then((r) => r.arrayBuffer())
         .then((arrayBuffer) => {

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -212,7 +212,7 @@
       const storage = vm.runtime.storage;
       function get_url_extension(uri) {
           var len = uri.split('/');
-          return(len[len.length-1].split('.')[1].split(/[#\?]/gi)[0]);
+          return(len[len.length-1].split('.')[1].split(/[#?]/gi)[0]);
       }
       let dataType = '', dataFormat = '';
       if (url.startsWith('data:image/')) {
@@ -258,6 +258,7 @@
             });
           });
       return 1; // ignore the below, its only here for reference
+      /* eslint-disable no-unreachable */
       Scratch.fetch(TEXT)
         .then((r) => r.arrayBuffer())
         .then((arrayBuffer) => {
@@ -273,6 +274,7 @@
             ),
           });
         });
+        /* eslint-enable no-unreachable */
     }
 
     importSprite({ TEXT }) {

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -268,25 +268,7 @@
             ),
           });
         });
-      return 1; // ignore the below, its only here for reference
-      /* eslint-disable no-unreachable */
-      Scratch.fetch(TEXT)
-        .then((r) => r.arrayBuffer())
-        .then((arrayBuffer) => {
-          const storage = vm.runtime.storage;
-          // @ts-expect-error
-          vm.addCostume(NAME + ".PNG", {
-            name: NAME + "",
-            asset: new storage.Asset(
-              storage.AssetType.ImageBitmap,
-              null, // asset id, doesn't need to be set here because of `true` at the end will make Scratch generate it for you
-              storage.DataFormat.PNG,
-              new Uint8Array(arrayBuffer),
-              true
-            ),
-          });
-        });
-      /* eslint-enable no-unreachable */
+      return 1;
     }
 
     importSprite({ TEXT }) {

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -204,65 +204,77 @@
     importImage({ TEXT, NAME }) {
       //Updated to support SVG. (0znzw)
       //Some notes: it returns a "error code" for debugging.
-      /* -2: Invalid format from URL
-         -1: Invalid format in dataURL
-          1: Ran succesfully
+      /*  -2: Invalid format from URL
+          -1: Invalid format in dataURL
+          1: Ran successfully
       */
-      let url = Scratch.Cast.toString(TEXT), costume_name = Scratch.Cast.toString(NAME);
+      let url = Scratch.Cast.toString(TEXT),
+        costume_name = Scratch.Cast.toString(NAME);
       const storage = vm.runtime.storage;
       function get_url_extension(uri) {
-          var len = uri.split('/');
-          return(len[len.length-1].split('.')[1].split(/[#?]/gi)[0]);
+        var len = uri.split("/");
+        return len[len.length - 1].split(".")[1].split(/[#?]/gi)[0];
       }
-      let dataType = '', dataFormat = '';
-      if (url.startsWith('data:image/')) {
-          url = url.replace('data:image/', '');
-          if (url.startsWith('svg')) dataType = 'svg', dataFormat = storage.DataFormat.SVG;
-          if (url.startsWith('png')) dataType = 'png', dataFormat = storage.DataFormat.PNG;
-          if (url.startsWith('jpg')) dataType = 'jpg', dataFormat = storage.DataFormat.JPG;
-          if (url.startsWith('jpeg')) dataType = 'jpg', dataFormat = storage.DataFormat.JPG;
-          if (dataType == '') return -1;
-          url = `data:image/${url}`;
+      let dataType = "",
+        dataFormat = "";
+      if (url.startsWith("data:image/")) {
+        url = url.replace("data:image/", "");
+        if (url.startsWith("svg"))
+          (dataType = "svg"), (dataFormat = storage.DataFormat.SVG);
+        if (url.startsWith("png"))
+          (dataType = "png"), (dataFormat = storage.DataFormat.PNG);
+        if (url.startsWith("jpg"))
+          (dataType = "jpg"), (dataFormat = storage.DataFormat.JPG);
+        if (url.startsWith("jpeg"))
+          (dataType = "jpg"), (dataFormat = storage.DataFormat.JPG);
+        if (dataType == "") return -1;
+        url = `data:image/${url}`;
       } else {
-          dataType = get_url_extension(url);
-          dataType = dataType.toLowerCase();
-          switch(dataType) {
-              case 'svg':
-                  dataFormat = storage.DataFormat.SVG;
-                  break;
-              case 'png':
-                  dataFormat = storage.DataFormat.PNG;
-                  break;
-              default:
-                  // *cough* to many jpg formats
-                  if ([
-                    'jpg', 'jpeg', 'jfif' /* etc, etc.. */
-                  ].includes(dataType)) {
-                    dataFormat = storage.DataFormat.JPG;
-                    break;
-                  }
-                  return -2;
-          }
+        dataType = get_url_extension(url);
+        dataType = dataType.toLowerCase();
+        switch (dataType) {
+          case "svg":
+            dataFormat = storage.DataFormat.SVG;
+            break;
+          case "png":
+            dataFormat = storage.DataFormat.PNG;
+            break;
+          default:
+            // *cough* to many jpg formats
+            if (["jpg", "jpeg", "jfif" /* etc, etc.. */].includes(dataType)) {
+              dataFormat = storage.DataFormat.JPG;
+              break;
+            }
+            return -2;
+        }
       }
       dataType = dataType.toLowerCase();
       Scratch.fetch(url)
-          .then((r) => r.arrayBuffer())
-          .then((arrayBuffer) => {
-            const storage = vm.runtime.storage;
-            vm.addCostume(costume_name + `.${dataType.toUpperCase()}`, {
-              name: costume_name + '',
-              asset: new storage.Asset(
-                (dataType == 'svg' ? storage.AssetType.ImageVector : storage.AssetType.ImageBitmap),
-                null, dataFormat, new Uint8Array(arrayBuffer), true
-              ),
-            });
+        .then((r) => r.arrayBuffer())
+        .then((arrayBuffer) => {
+          const storage = vm.runtime.storage;
+          //  @ts-expect-error
+          vm.addCostume(costume_name + `.${dataType.toUpperCase()}`, {
+            name: costume_name + "",
+            asset: new storage.Asset(
+              dataType == "svg"
+                ? storage.AssetType.ImageVector
+                : storage.AssetType.ImageBitmap,
+              null,
+              // @ts-expect-error YES IT IS SHUT TS lol
+              dataFormat,
+              new Uint8Array(arrayBuffer),
+              true
+            ),
           });
+        });
       return 1; // ignore the below, its only here for reference
       /* eslint-disable no-unreachable */
       Scratch.fetch(TEXT)
         .then((r) => r.arrayBuffer())
         .then((arrayBuffer) => {
           const storage = vm.runtime.storage;
+          // @ts-expect-error
           vm.addCostume(NAME + ".PNG", {
             name: NAME + "",
             asset: new storage.Asset(
@@ -274,7 +286,7 @@
             ),
           });
         });
-        /* eslint-enable no-unreachable */
+      /* eslint-enable no-unreachable */
     }
 
     importSprite({ TEXT }) {
@@ -319,6 +331,7 @@
             new Uint8Array(arrayBuffer),
             true
           );
+          // @ts-expect-error
           vm.addSound({
             md5: asset.assetId + "." + asset.dataFormat,
             asset: asset,


### PR DESCRIPTION
It lets ShovelUtils import SVG files.
Originally (If you are gud ext dev you prolly know why it did not work with svgs at first).
It always set the dataFormat and type to a form of bitmap in this case it was PNG.
I updated it to change the dataFormat based on the file extension.