### PR TITLE
Reacquire wake lock as needed

### DIFF
--- a/extensions/DNin/wake-lock.js
+++ b/extensions/DNin/wake-lock.js
@@ -100,6 +100,13 @@
           .then(() => navigator.wakeLock.request("screen"))
           .then((sentinel) => {
             wakeLock = sentinel;
+            wakeLock.addEventListener("release", () => {
+              if (document.visibilityState === "visible") {
+                // If the document is hidden, wake lock should be reacquired when it's visible again.
+                wakeLock = null;
+                latestEnabled = false;
+              }
+            });
           })
           .catch((error) => {
             console.error(error);


### PR DESCRIPTION
Resolves #1120

Currently, if you request a wake lock with the Wake Lock extension and then navigate away from the page, the wake lock gets released in the background because wake locks are automatically released when the document gets hidden, plus, the extension isn't aware of when this happens, so you have no way of knowing. 

This change makes the extension automatically request another wake lock when the document regains visibility after having been hidden. It still reports to the project that the wake lock is enabled when this happens, therefore projects will act like nothing happened but the wake lock will still be there as long as you come back. I also considered the possibility of projects enabling or disabling wake lock when the document is hidden and now handle it properly.

I tested these changes in Edge to the best of my ability.