### PR TITLE
encoding: Don't translate apple

### DIFF
--- a/extensions/encoding.js
+++ b/extensions/encoding.js
@@ -444,7 +444,7 @@
             arguments: {
               string: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: btoa(Scratch.translate("apple")),
+                defaultValue: btoa("apple"), // don't translate because btoa() will error in Chinese ...
               },
               code: {
                 type: Scratch.ArgumentType.STRING,
@@ -460,7 +460,7 @@
             arguments: {
               string: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: Scratch.translate("apple"),
+                defaultValue: "apple",
               },
               hash: {
                 type: Scratch.ArgumentType.STRING,


### PR DESCRIPTION
btoa() errors on Chinese characters. The extension should be modified to actually support those properly, but for now not translating apple will avoid an error for Chinese users

https://github.com/TurboWarp/extensions/issues/1166