### PR TITLE
box2d: disable physics and simulation rate blocks

### DIFF
--- a/docs/box2d.md
+++ b/docs/box2d.md
@@ -30,6 +30,15 @@ step simulation :: #0FBD8C
 
 Move forward in time by one step. Run this in a loop to keep the physics going.
 
+
+```scratch
+set simulation rate to (30)/s :: #0FBD8C
+```
+
+Set how much simulation steps is considered one second. Usually this should be project's framerate, but can also be used to slow down or speed up time.
+
+You can get the current simulation rate with the (simulation rate) reporter.
+
 ## Sprites
 
 Manipulate individual sprites.
@@ -45,6 +54,13 @@ Make physics apply to this sprite. It can also collide with other sprites that h
  - Enable for all sprites: Enable physics for all sprites.
 
 Precision mode will make the sprite work extra hard to make sure it doesn't overlap with anything. Note that this can decrease performance and even cause the project to get stuck, so use with care.
+
+
+```scratch
+disable physics :: #0FBD8C
+```
+
+Makes physics no longer apply to this sprite.
 
 ---
 

--- a/docs/box2d.md
+++ b/docs/box2d.md
@@ -57,7 +57,7 @@ Precision mode will make the sprite work extra hard to make sure it doesn't over
 
 
 ```scratch
-disable physics :: #0FBD8C
+disable physics for this sprite :: #0FBD8C
 ```
 
 Makes physics no longer apply to this sprite.

--- a/docs/box2d.md
+++ b/docs/box2d.md
@@ -55,6 +55,7 @@ Make physics apply to this sprite. It can also collide with other sprites that h
 
 Precision mode will make the sprite work extra hard to make sure it doesn't overlap with anything. Note that this can decrease performance and even cause the project to get stuck, so use with care.
 
+---
 
 ```scratch
 disable physics for this sprite :: #0FBD8C

--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12675,12 +12675,6 @@
               default: "simulation rate",
               description: "Get the number of physics simulation steps to run per second",
             }),
-            arguments: {
-              rate: {
-                type: ArgumentType.NUMBER,
-                defaultValue: 30,
-              },
-            },
           },
 
           "---",

--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12246,11 +12246,11 @@
 
   const _removeBody = function (id) {
     if (!bodies[id]) return;
-    
+
     world.DestroyBody(bodies[id]);
     delete bodies[id];
     delete prevPos[id];
-  }
+  };
 
   const _applyForce = function (id, ftype, x, y, dir, pow) {
     const body = bodies[id];
@@ -12658,7 +12658,8 @@
             text: Scratch.translate({
               id: "griffpatch.setTickRate",
               default: "set simulation rate to [rate]/s",
-              description: "Set the number of physics simulation steps to run per second",
+              description:
+                "Set the number of physics simulation steps to run per second",
             }),
             arguments: {
               rate: {
@@ -12673,7 +12674,8 @@
             text: Scratch.translate({
               id: "griffpatch.getTickRate",
               default: "simulation rate",
-              description: "Get the number of physics simulation steps to run per second",
+              description:
+                "Get the number of physics simulation steps to run per second",
             }),
           },
 

--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12221,7 +12221,7 @@
       }
       prev = b2Vec;
     }
-  
+
     fixDef.shape.SetAsArray(vertices);
   };
 

--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12221,9 +12221,8 @@
       }
       prev = b2Vec;
     }
-    if (vertices.length < 3) return false;
+  
     fixDef.shape.SetAsArray(vertices);
-    return true;
   };
 
   const _placeBody = function (id, x, y, dir) {
@@ -12453,18 +12452,7 @@
     }
   };
 
-  const _lerp = function(a, b, perc) {
-    return a + (b - a) * perc;
-  };
-
-  // Split an SVG path to the commands and numbers
-  // e,g M123 34 l 1 2 -> M, 123, 34, l, 1, 2
-  // (plus some whitespace which I filter out with array.filter())
-  const svgSplitRegex = /([\d.-]+|[A-Za-z]+)|,/g;
-
   let tickRate = 30;
-
-  const svgUrlHeaderLength = ("data:image/svg+xml;utf8,").length;
 
   const blockIconURI =
     "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiDQoJIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOmE9Imh0dHA6Ly9ucy5hZG9iZS5jb20vQWRvYmVTVkdWaWV3ZXJFeHRlbnNpb25zLzMuMC8iDQoJIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNDBweCIgaGVpZ2h0PSI0MHB4IiB2aWV3Qm94PSItMy43IC0zLjcgNDAgNDAiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgLTMuNyAtMy43IDQwIDQwIg0KCSB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxkZWZzPg0KPC9kZWZzPg0KPHJlY3QgeD0iOC45IiB5PSIxLjUiIGZpbGw9IiNGRkZGRkYiIHN0cm9rZT0iIzE2OUZCMCIgc3Ryb2tlLXdpZHRoPSIzIiB3aWR0aD0iMTQuOCIgaGVpZ2h0PSIxNC44Ii8+DQo8cmVjdCB4PSIxLjUiIHk9IjE2LjMiIGZpbGw9IiNGRkZGRkYiIHN0cm9rZT0iIzE2OUZCMCIgc3Ryb2tlLXdpZHRoPSIzIiB3aWR0aD0iMTQuOCIgaGVpZ2h0PSIxNC44Ii8+DQo8cmVjdCB4PSIxNi4zIiB5PSIxNi4zIiBmaWxsPSIjRkZGRkZGIiBzdHJva2U9IiMxNjlGQjAiIHN0cm9rZS13aWR0aD0iMyIgd2lkdGg9IjE0LjgiIGhlaWdodD0iMTQuOCIvPg0KPC9zdmc+";

--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -12609,7 +12609,7 @@
             blockType: BlockType.COMMAND,
             text: Scratch.translate({
               id: "griffpatch.disablePhysics",
-              default: "disable physics",
+              default: "disable physics for this sprite",
               description: "Disable Physics for this Sprite",
             }),
             arguments: {},


### PR DESCRIPTION
Resolves #1171
Might resolve #925?

Adds 3 new blocks to the Box2D Physics extension:
![image](https://github.com/TurboWarp/extensions/assets/68464103/6c47976a-3cec-47fe-a601-1ab8fd62d8ee)
Disables physics for the sprite.

![image](https://github.com/TurboWarp/extensions/assets/68464103/3775a974-e60e-4f60-87d0-0fdabf8e11a7)
Sets (or gets) the simulation rate; for example, you can set it and the project's framerate to 60 to make the physics run at 60FPS.