### PR TITLE
Comment Blocks: Minor change

### DIFF
--- a/extensions/Lily/CommentBlocks.js
+++ b/extensions/Lily/CommentBlocks.js
@@ -53,6 +53,7 @@
             opcode: "commentReporter",
             blockType: Scratch.BlockType.REPORTER,
             text: "[INPUT] // [COMMENT]",
+            allowDropAnywhere: true,
             arguments: {
               COMMENT: {
                 type: Scratch.ArgumentType.STRING,


### PR DESCRIPTION
Allow the reporter block to be used anywhere to circumvent using couplers. Mild convenience.