### PR TITLE
merge-upstream / use actual category colours when applicable

### DIFF
--- a/extensions/Lily/ClonesPlus.js
+++ b/extensions/Lily/ClonesPlus.js
@@ -68,6 +68,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "createCloneWithVar",
@@ -84,6 +85,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -103,6 +105,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "touchingMainSprite",
@@ -110,6 +113,7 @@
             text: "touching main sprite?",
             filter: [Scratch.TargetType.SPRITE],
             disableMonitor: true,
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -137,6 +141,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "getVariableOfClone",
@@ -158,6 +163,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "setVariableOfMainSprite",
@@ -174,6 +180,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "getVariableOfMainSprite",
@@ -187,6 +194,7 @@
                 menu: "variablesMenu",
               },
             },
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -206,6 +214,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "getThingOfClone",
@@ -228,6 +237,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "getThingOfMainSprite",
@@ -242,6 +252,7 @@
                 menu: "thingOfMenu",
               },
             },
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -256,6 +267,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "stopScriptsInClone",
@@ -272,12 +284,14 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "stopScriptsInMainSprite",
             blockType: Scratch.BlockType.COMMAND,
             text: "stop scripts in main sprite",
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -292,6 +306,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "deleteCloneWithVar",
@@ -308,6 +323,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -318,6 +334,7 @@
             text: "is clone?",
             filter: [Scratch.TargetType.SPRITE],
             disableMonitor: true,
+            extensions: ["colours_control"],
           },
 
           "---",
@@ -326,6 +343,7 @@
             opcode: "cloneCount",
             blockType: Scratch.BlockType.REPORTER,
             text: "clone count",
+            extensions: ["colours_control"],
           },
           {
             opcode: "spriteCloneCount",
@@ -338,6 +356,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_control"],
           },
         ],
         menus: {

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -52,6 +52,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "hideSprite",
@@ -63,6 +64,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "spriteVisible",
@@ -74,6 +76,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
 
           "---",
@@ -92,6 +95,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "spriteLayerNumber",
@@ -103,6 +107,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "effectValue",
@@ -119,6 +124,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
 
           "---",
@@ -133,6 +139,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "costumeAttribute",
@@ -147,6 +154,7 @@
                 type: Scratch.ArgumentType.COSTUME,
               },
             },
+            extensions: ["colours_looks"],
           },
 
           "---",
@@ -156,6 +164,7 @@
             blockType: Scratch.BlockType.REPORTER,
             text: "snapshot stage",
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
 
           "---",
@@ -178,6 +187,7 @@
                 defaultValue: "<svg />",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "restoreCostumeContent",
@@ -188,6 +198,7 @@
                 type: Scratch.ArgumentType.COSTUME,
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "costumeContent",
@@ -208,6 +219,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_looks"],
           },
 
           "---",
@@ -230,6 +242,7 @@
                 defaultValue: "<svg />",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "colorHex",
@@ -241,6 +254,7 @@
                 defaultValue: "#FFD983",
               },
             },
+            extensions: ["colours_looks"],
           },
         ],
         menus: {

--- a/extensions/Lily/MoreEvents.js
+++ b/extensions/Lily/MoreEvents.js
@@ -225,12 +225,14 @@
                 dataURI: stopIcon,
               },
             },
+            extensions: ["colours_event"],
           },
           {
             opcode: "forever",
             blockType: Scratch.BlockType.EVENT,
             text: "forever",
             isEdgeActivated: false,
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -249,6 +251,7 @@
                 menu: "boolean",
               },
             },
+            extensions: ["colours_event"],
           },
           {
             opcode: "whileTrueFalse",
@@ -264,6 +267,7 @@
                 menu: "boolean",
               },
             },
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -281,6 +285,7 @@
                 type: null,
               },
             },
+            extensions: ["colours_event"],
           },
           {
             opcode: "everyDuration",
@@ -293,6 +298,7 @@
                 defaultValue: 3,
               },
             },
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -313,6 +319,7 @@
                 menu: "action",
               },
             },
+            extensions: ["colours_event"],
           },
           {
             opcode: "whileKeyPressed",
@@ -326,6 +333,7 @@
                 menu: "keyboardButtons",
               },
             },
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -344,6 +352,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
           {
             opcode: "broadcastToTargetAndWait",
@@ -359,6 +368,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -376,6 +386,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
           {
             opcode: "broadcastDataAndWait",
@@ -390,6 +401,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
           {
             blockType: Scratch.BlockType.XML,
@@ -401,6 +413,7 @@
             text: "received data",
             disableMonitor: true,
             allowDropAnywhere: true,
+            extensions: ["colours_event"],
           },
 
           "---",
@@ -423,6 +436,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
           {
             opcode: "broadcastDataToTargetAndWait",
@@ -442,6 +456,7 @@
               },
             },
             hideFromPalette: true,
+            extensions: ["colours_event"],
           },
           {
             blockType: Scratch.BlockType.XML,
@@ -454,6 +469,7 @@
             text: "before project saves",
             shouldRestartExistingThreads: true,
             isEdgeActivated: false,
+            extensions: ["colours_event"],
           },
           {
             blockType: Scratch.BlockType.EVENT,
@@ -461,6 +477,7 @@
             text: "after project saves",
             shouldRestartExistingThreads: true,
             isEdgeActivated: false,
+            extensions: ["colours_event"],
           },
         ],
         menus: {

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -32,6 +32,7 @@
                 defaultValue: 0,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "stopLooping",
@@ -42,6 +43,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "isLooping",
@@ -52,6 +54,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
 
           "---",
@@ -65,6 +68,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "pauseSounds",
@@ -75,6 +79,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "resumeSounds",
@@ -85,6 +90,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
 
           "---",
@@ -98,6 +104,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "attributeOfSound",
@@ -112,6 +119,7 @@
                 type: Scratch.ArgumentType.SOUND,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "getSoundEffect",
@@ -127,6 +135,7 @@
                 menu: "targets",
               },
             },
+            extensions: ["colours_sound"],
           },
           "---",
           {
@@ -139,6 +148,7 @@
                 defaultValue: 100,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "changeProjectVolume",
@@ -150,11 +160,13 @@
                 defaultValue: -10,
               },
             },
+            extensions: ["colours_sound"],
           },
           {
             opcode: "getProjectVolume",
             blockType: Scratch.BlockType.REPORTER,
             text: "project volume",
+            extensions: ["colours_sound"],
           },
         ],
         menus: {

--- a/extensions/NexusKitten/controlcontrols.js
+++ b/extensions/NexusKitten/controlcontrols.js
@@ -71,6 +71,7 @@
                 menu: "OPTION",
               },
             },
+            extensions: ["colours_control"],
           },
           {
             opcode: "hideOption",
@@ -82,6 +83,7 @@
                 menu: "OPTION",
               },
             },
+            extensions: ["colours_control"],
           },
           "---",
           {
@@ -94,6 +96,7 @@
                 menu: "OPTION",
               },
             },
+            extensions: ["colours_control"],
           },
           "---",
           {
@@ -106,6 +109,7 @@
                 menu: "OPTION",
               },
             },
+            extensions: ["colours_control"],
           },
         ],
         menus: {

--- a/extensions/NexusKitten/moremotion.js
+++ b/extensions/NexusKitten/moremotion.js
@@ -45,6 +45,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -61,6 +62,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -68,6 +70,7 @@
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("rotation style"),
             disableMonitor: true,
+            extensions: ["colours_motion"],
           },
           "---",
           {
@@ -79,6 +82,7 @@
               description:
                 "This blocks forces the sprite to be onscreen if it moved offscreen.",
             }),
+            extensions: ["colours_motion"],
           },
           "---",
           {
@@ -100,6 +104,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -122,6 +127,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           "---",
           {
@@ -139,6 +145,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -155,6 +162,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -185,6 +193,7 @@
                 defaultValue: "0",
               },
             },
+            extensions: ["colours_motion"],
           },
           {
             filter: [Scratch.TargetType.SPRITE],
@@ -211,6 +220,7 @@
                 defaultValue: "100",
               },
             },
+            extensions: ["colours_motion"],
           },
         ],
         menus: {

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -308,12 +308,14 @@
               },
             },
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_looks"],
           },
           {
             opcode: "clearClipbox",
             blockType: Scratch.BlockType.COMMAND,
             text: "clear clipping box",
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getClipbox",
@@ -327,6 +329,7 @@
               },
             },
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -341,6 +344,7 @@
               },
             },
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getBlend",
@@ -348,6 +352,7 @@
             text: "blending",
             filter: [Scratch.TargetType.SPRITE],
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -363,6 +368,7 @@
             },
             filter: [Scratch.TargetType.SPRITE],
             hideFromPalette: true,
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getAdditiveBlend",
@@ -371,6 +377,7 @@
             filter: [Scratch.TargetType.SPRITE],
             hideFromPalette: true,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
         ],
         menus: {

--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -615,6 +615,7 @@
                 defaultValue: Scratch.translate("Welcome to my project!"),
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "animateText",
@@ -631,11 +632,13 @@
                 defaultValue: Scratch.translate("Here we go!"),
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "clearText",
             blockType: Scratch.BlockType.COMMAND,
             text: Scratch.translate("show sprite"),
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -648,6 +651,7 @@
                 menu: "font",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "setColor",
@@ -658,6 +662,7 @@
                 type: Scratch.ArgumentType.COLOR,
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "setWidth",
@@ -673,6 +678,7 @@
                 menu: "align",
               },
             },
+            extensions: ["colours_looks"],
           },
           "---",
 
@@ -686,11 +692,13 @@
             blockType: Scratch.BlockType.BUTTON,
             text: Scratch.translate("Enable Non-Scratch Lab Features"),
             hideFromPalette: !compatibilityMode,
+            extensions: ["colours_looks"],
           },
           {
             blockType: Scratch.BlockType.LABEL,
             text: Scratch.translate("Incompatible with Scratch Lab:"),
             hideFromPalette: compatibilityMode,
+            extensions: ["colours_looks"],
           },
           {
             opcode: "setAlignment",
@@ -703,6 +711,7 @@
                 menu: "twAlign",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             // why is the other block called "setWidth" :(
@@ -716,12 +725,14 @@
                 defaultValue: 200,
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "resetWidth",
             blockType: Scratch.BlockType.COMMAND,
             text: Scratch.translate("reset text width"),
             hideFromPalette: compatibilityMode,
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -735,6 +746,7 @@
                 defaultValue: Scratch.translate("Hello!"),
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getLines",
@@ -742,6 +754,7 @@
             text: Scratch.translate("# of lines"),
             hideFromPalette: compatibilityMode,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -756,6 +769,7 @@
                 defaultValue: "rainbow",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "animateUntilDone",
@@ -769,6 +783,7 @@
                 defaultValue: "rainbow",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "isAnimating",
@@ -776,6 +791,7 @@
             text: Scratch.translate("is animating?"),
             hideFromPalette: compatibilityMode,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -794,6 +810,7 @@
                 defaultValue: 3,
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "resetAnimateDuration",
@@ -807,6 +824,7 @@
                 defaultValue: "rainbow",
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getAnimateDuration",
@@ -820,6 +838,7 @@
                 defaultValue: "rainbow",
               },
             },
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -833,12 +852,14 @@
                 defaultValue: 0.1,
               },
             },
+            extensions: ["colours_looks"],
           },
           {
             opcode: "resetTypeDelay",
             blockType: Scratch.BlockType.COMMAND,
             text: Scratch.translate("reset typing delay"),
             hideFromPalette: compatibilityMode,
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getTypeDelay",
@@ -846,6 +867,7 @@
             text: Scratch.translate("typing delay"),
             hideFromPalette: compatibilityMode,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           "---",
           {
@@ -854,6 +876,7 @@
             text: Scratch.translate("is showing text?"),
             hideFromPalette: compatibilityMode,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getDisplayedText",
@@ -861,6 +884,7 @@
             text: Scratch.translate("displayed text"),
             hideFromPalette: compatibilityMode,
             disableMonitor: true,
+            extensions: ["colours_looks"],
           },
           {
             opcode: "getTextAttribute",
@@ -874,6 +898,7 @@
             },
             disableMonitor: true,
             hideFromPalette: compatibilityMode,
+            extensions: ["colours_looks"],
           },
         ],
         menus: {

--- a/extensions/obviousAlexC/SensingPlus.js
+++ b/extensions/obviousAlexC/SensingPlus.js
@@ -304,6 +304,7 @@
             text: "Supports touches?",
             blockIconURI: touchIco,
             arguments: {},
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getMaxTouches",
@@ -311,6 +312,7 @@
             text: "# of simultaneous possible",
             blockIconURI: touchIco,
             arguments: {},
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getFingersTouching",
@@ -318,6 +320,7 @@
             text: "# of fingers down",
             blockIconURI: touchIco,
             arguments: {},
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "isFingerDown",
@@ -330,6 +333,7 @@
                 menu: "fingerIDMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "touchingFinger",
@@ -339,6 +343,7 @@
             filter: [Scratch.TargetType.SPRITE],
             arguments: {},
             disableMonitor: true,
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "touchingSpecificFinger",
@@ -352,6 +357,7 @@
                 menu: "fingerIDMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getTouchingFingerID",
@@ -361,6 +367,7 @@
             filter: [Scratch.TargetType.SPRITE],
             blockIconURI: touchIco,
             arguments: {},
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "fingerPosition",
@@ -377,6 +384,7 @@
                 menu: "coordmenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getFingerSpeed",
@@ -389,6 +397,7 @@
                 menu: "fingerIDMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -406,6 +415,7 @@
                 menu: "listMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "lengthOfListInSprite",
@@ -419,6 +429,7 @@
                 menu: "listMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "listContains",
@@ -435,6 +446,7 @@
                 menu: "listMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "itemNumberInList",
@@ -451,6 +463,7 @@
                 menu: "listMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -465,6 +478,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "touchingClone",
@@ -478,6 +492,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "clonesOfSprite",
@@ -491,6 +506,7 @@
                 menu: "spriteMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -505,6 +521,7 @@
                 menu: "effectMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "isHidden",
@@ -513,6 +530,7 @@
             blockIconURI: effectIco,
             filter: [Scratch.TargetType.SPRITE],
             disableMonitor: true,
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getRotationStyle",
@@ -521,6 +539,7 @@
             blockIconURI: rotationIco,
             disableMonitor: true,
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getSpriteLayer",
@@ -529,6 +548,7 @@
             blockIconURI: layerIco,
             disableMonitor: true,
             filter: [Scratch.TargetType.SPRITE],
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -537,6 +557,7 @@
             text: "Copied Contents",
             blockIconURI: clipboardIco,
             disableMonitor: true,
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "setClipBoard",
@@ -549,6 +570,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -556,6 +578,7 @@
             blockIconURI: packagedIco,
             blockType: Scratch.BlockType.BOOLEAN,
             text: "Is Packaged?",
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -573,18 +596,21 @@
                 menu: "toggleMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "returnWords",
             blockType: Scratch.BlockType.REPORTER,
             text: "Recognized Words",
             blockIconURI: speechIco,
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "isrecording",
             blockType: Scratch.BlockType.BOOLEAN,
             text: "Recording?",
             blockIconURI: speechIco,
+            extensions: ["colours_sensing"],
           },
           "---",
           {
@@ -602,6 +628,7 @@
                 menu: "deviceMenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
           {
             opcode: "getDeviceSpeed",
@@ -619,6 +646,7 @@
                 menu: "axismenu",
               },
             },
+            extensions: ["colours_sensing"],
           },
         ],
         menus: {

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -122,6 +122,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "root_block",
@@ -137,6 +138,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "negative_block",
@@ -148,6 +150,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -164,6 +167,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "less_or_equal_block",
@@ -179,6 +183,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "not_equal_block",
@@ -194,6 +199,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "exactly_equal_block",
@@ -209,6 +215,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "not_exactly_equal_block",
@@ -224,6 +231,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "almost_equal_block",
@@ -239,6 +247,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "not_almost_equal_block",
@@ -254,6 +263,7 @@
                 defaultValue: 50,
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -268,6 +278,7 @@
                 type: Scratch.ArgumentType.BOOLEAN,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "nor_block",
@@ -281,6 +292,7 @@
                 type: Scratch.ArgumentType.BOOLEAN,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "xor_block",
@@ -294,6 +306,7 @@
                 type: Scratch.ArgumentType.BOOLEAN,
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "xnor_block",
@@ -307,6 +320,7 @@
                 type: Scratch.ArgumentType.BOOLEAN,
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -323,6 +337,7 @@
                 defaultValue: "a",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -343,6 +358,7 @@
                 defaultValue: "100",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "scale_block",
@@ -370,6 +386,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -386,6 +403,7 @@
                 defaultValue: "1",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "trunc_block",
@@ -397,6 +415,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -413,6 +432,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -429,22 +449,26 @@
                 defaultValue: 10,
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
             opcode: "pi_block",
             blockType: Scratch.BlockType.REPORTER,
             text: "𝜋",
+            extensions: ["colours_operators"],
           },
           {
             opcode: "e_block",
             blockType: Scratch.BlockType.REPORTER,
             text: "𝘦",
+            extensions: ["colours_operators"],
           },
           {
             opcode: "infinity_block",
             blockType: Scratch.BlockType.REPORTER,
             text: "∞",
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -457,6 +481,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           "---",
           {
@@ -469,6 +494,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "is_int_block",
@@ -480,6 +506,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
           {
             opcode: "is_float_block",
@@ -491,6 +518,7 @@
                 defaultValue: "",
               },
             },
+            extensions: ["colours_operators"],
           },
         ],
       };


### PR DESCRIPTION
With the introduction of High Contrast mode, extensions like Looks Plus should use the actual category colours by default so their high contrast colours match.