### PR TITLE
fix: downloadBlob isn't working properly on some old browsers

### DIFF
--- a/extensions/files.js
+++ b/extensions/files.js
@@ -232,7 +232,10 @@
   const downloadBlob = (blob, file) => {
     const url = URL.createObjectURL(blob);
     downloadURL(url, file);
-    (requestIdleCallback ?? setTimeout)(() => URL.revokeObjectURL(url)); // Some old browsers process Blob URLs asynchronously
+    // Some old browsers process Blob URLs asynchronously
+    setTimeout(() => {
+      URL.revokeObjectURL(url)
+    }, 1000);
   };
 
   /**

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -234,7 +234,7 @@
     downloadURL(url, file);
     // Some old browsers process Blob URLs asynchronously
     setTimeout(() => {
-      URL.revokeObjectURL(url)
+      URL.revokeObjectURL(url);
     }, 1000);
   };
 

--- a/extensions/files.js
+++ b/extensions/files.js
@@ -232,7 +232,7 @@
   const downloadBlob = (blob, file) => {
     const url = URL.createObjectURL(blob);
     downloadURL(url, file);
-    URL.revokeObjectURL(url);
+    (requestIdleCallback ?? setTimeout)(() => URL.revokeObjectURL(url)); // Some old browsers process Blob URLs asynchronously
   };
 
   /**


### PR DESCRIPTION
Affected browsers:
- Android WebView in mark.via (92.0.4515.105)