### PR TITLE
Various: Fix compatibility for old VM builds

### DIFF
--- a/extensions/cursor.js
+++ b/extensions/cursor.js
@@ -5,6 +5,12 @@
 (function (Scratch) {
   "use strict";
 
+  // For older versions of TurboWarp.
+  // https://experiments.turbowarp.org/
+  if (typeof Scratch.translate === "undefined") {
+    Scratch.translate = (text) => { return text };
+  }
+
   if (!Scratch.extensions.unsandboxed) {
     throw new Error("MouseCursor extension must be run unsandboxed");
   }

--- a/extensions/gamepad.js
+++ b/extensions/gamepad.js
@@ -8,6 +8,12 @@
 (function (Scratch) {
   "use strict";
 
+  // For older versions of TurboWarp.
+  // https://experiments.turbowarp.org/
+  if (typeof Scratch.translate === "undefined") {
+    Scratch.translate = (text) => { return text };
+  }
+
   const AXIS_DEADZONE = 0.1;
   const BUTTON_DEADZONE = 0.05;
 

--- a/extensions/stretch.js
+++ b/extensions/stretch.js
@@ -5,6 +5,12 @@
 (function (Scratch) {
   "use strict";
 
+  // For older versions of TurboWarp.
+  // https://experiments.turbowarp.org/
+  if (typeof Scratch.translate === "undefined") {
+    Scratch.translate = (text) => { return text };
+  }
+
   const STRETCH_X = Symbol("stretch.x");
   const STRETCH_Y = Symbol("stretch.y");
 


### PR DESCRIPTION
Scratch.translate is now a required function in a lot of the original few custom extensions that are listed in older versions of the vm, when extensions were recently introduced.

However, those builds do not have access to Scratch.translate, and neither do many forks of those builds. This makes the extensions completely unusable. (See https://experiments.turbowarp.org/)
![image](https://github.com/TurboWarp/extensions/assets/127533508/98c125db-2802-46dd-ba83-1b9153d35d69)


For the sake of compatibility I think a good compromise is to include a few lines to the main 3 extensions to fix this.