### PR TITLE
Various: allowDropAnywhere on some ternary operators.

### DIFF
--- a/extensions/true-fantom/couplers.js
+++ b/extensions/true-fantom/couplers.js
@@ -39,6 +39,7 @@
                 defaultValue: "banana",
               },
             },
+            allowDropAnywhere: true,
           },
           {
             opcode: "boolean_block",

--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -150,6 +150,7 @@
                 defaultValue: "apple",
               },
             },
+            allowDropAnywhere: true,
           },
           {
             opcode: "letters",


### PR DESCRIPTION
I've seen multiple people want this now.