### PR TITLE
Lily/Hitboxes: Add Hitboxes extension.

### DIFF
--- a/extensions/Lily/Hitboxes.js
+++ b/extensions/Lily/Hitboxes.js
@@ -5,7 +5,7 @@
   const runtime = vm.runtime;
   const renderer = vm.renderer;
 
-  class TurboCanvas {
+  class Hitboxes {
     constructor() {
       runtime.on("BEFORE_EXECUTE", () => {
         runtime.targets.forEach((target) => {
@@ -89,5 +89,5 @@
     }
   }
 
-  Scratch.extensions.register(new TurboCanvas());
+  Scratch.extensions.register(new Hitboxes());
 })(Scratch);

--- a/extensions/Lily/Hitboxes.js
+++ b/extensions/Lily/Hitboxes.js
@@ -1,0 +1,89 @@
+(function (Scratch) {
+  "use strict";
+  
+  const vm = Scratch.vm;
+  const runtime = vm.runtime;
+  const renderer = vm.renderer;
+
+  class TurboCanvas {
+    constructor() {
+      runtime.on("BEFORE_EXECUTE", () => {
+        runtime.targets.forEach((target) => {
+          if (typeof target.hitboxSkin === "undefined") return;
+          const drawableID = target.drawableID;
+          const drawable = renderer._allDrawables[drawableID];
+          target.originalSkin = drawable.skin;
+          drawable.skin = target.hitboxSkin;
+        });
+      });
+      runtime.on("AFTER_EXECUTE", () => {
+        runtime.targets.forEach((target) => {
+          if (typeof target.originalSkin === "undefined") return;
+          const drawableID = target.drawableID;
+          const drawable = renderer._allDrawables[drawableID];
+          drawable.skin = target.originalSkin;
+        });
+      });
+    }
+
+    getInfo() {
+      return {
+        id: "lmsHitbox",
+        name: "Hitboxes",
+        blocks: [
+          {
+            opcode: "setHitbox",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "set hitbox to [COSTUME]",
+            arguments: {
+              COSTUME: {
+                type: Scratch.ArgumentType.COSTUME
+              },
+            },
+          },
+          {
+            opcode: "removeHitbox",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "remove hitbox",
+            arguments: {
+              NAME: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "layer1",
+              },
+            },
+          },
+          {
+            opcode: "currentHitbox",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "current hitbox",
+            allowDropAnywhere: true,
+            disableMonitor: true,
+          },
+        ],
+      };
+    }
+
+    setHitbox(args, util) {
+      const target = util.target;
+      const costumeName = Scratch.Cast.toString(args.COSTUME);
+      const costume = target.getCostumeIndexByName(costumeName);
+      if (!costume) return;
+
+      const skinId = target.getCostumes()[costume].skinId;
+      target.hitboxSkin = renderer._allSkins[skinId];
+    }
+
+    removeHitbox(args, util) {
+      const target = util.target;
+      delete target.hitboxSkin;
+      target.updateAllDrawableProperties();
+    }
+
+    currentHitbox(args, util) {
+      const target = util.target;
+      return target.hitboxSkin ?? "";
+    }
+  }
+
+  Scratch.extensions.register(new TurboCanvas());
+})(Scratch);

--- a/extensions/Lily/Hitboxes.js
+++ b/extensions/Lily/Hitboxes.js
@@ -71,6 +71,10 @@
 
       const skinId = target.getCostumes()[costume].skinId;
       target.hitboxSkin = renderer._allSkins[skinId];
+
+      const drawableID = target.drawableID;
+      const drawable = renderer._allDrawables[drawableID];
+      drawable.skin = target.originalSkin;
     }
 
     removeHitbox(args, util) {

--- a/extensions/Lily/Hitboxes.js
+++ b/extensions/Lily/Hitboxes.js
@@ -1,6 +1,6 @@
 (function (Scratch) {
   "use strict";
-  
+
   const vm = Scratch.vm;
   const runtime = vm.runtime;
   const renderer = vm.renderer;
@@ -37,7 +37,7 @@
             text: "set hitbox to [COSTUME]",
             arguments: {
               COSTUME: {
-                type: Scratch.ArgumentType.COSTUME
+                type: Scratch.ArgumentType.COSTUME,
               },
             },
           },


### PR DESCRIPTION
A small extension for setting the hitboxes of targets.
![image](https://github.com/TurboWarp/extensions/assets/127533508/b7959a9c-6abb-4b30-9d58-e8409d4b68a5)

I might put this on the gallery if/when I add a few more blocks.