### PR TITLE
A few fixes

### DIFF
--- a/development/homepage-template.ejs
+++ b/development/homepage-template.ejs
@@ -392,7 +392,7 @@
         -
         <a href="https://github.com/TurboWarp/extensions">GitHub</a>
         -
-        <a href="https://docs.turbowarp.org/development/custom-extensions">Developer Documentation</a>
+        <a href="https://docs.turbowarp.org/development/extensions/introduction">Developer Documentation</a>
       </div>
     </footer>
   </body>

--- a/images/README.md
+++ b/images/README.md
@@ -248,8 +248,8 @@ All images in this folder are licensed under the [GNU General Public License ver
 ## Alestore/nfcwarp.svg
  - Created by [@HamsterCreativity](https://github.com/HamsterCreativity) in https://github.com/TurboWarp/extensions/issues/90#issuecomment-1636726352
 
-## veggiecan/LongmanDictionary.svg 
-- Created by [veggiecan](https://github.com/veggiecan0419)
+## veggiecan/LongmanDictionary.png
+- Created by Veggiecan0419
 - The ship is based on [this](https://www.ldoceonline.com/external/images/logo_home_smartphone.svg?version=1.2.61) logo from the [ldoceonline](https://www.ldoceonline.com/) website
 
 ## Lily/Skins.svg


### PR DESCRIPTION
## Changes made
### images/README.md in the Longman dictionary section
 - Corrected it to say veggiecan/longmanDictonary **.svg** => **.png** 
 - Removed the link to my github profile
 - Changed the "created by" from **veggiecan** => **Veggiecan0419** (like it is for browser fullscreen)
 ### development/homepage-template.ejs
 - Updated the "developer documentation" link