### PR TITLE
Update the AI models' names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Every extension is also covered under [our bug bounty](https://github.com/TurboW
 
 ## On AI language models
 
-**Generative AI language models like ChatGPT, Bing Chat, and Bard DO NOT know how to write proper extensions for TurboWarp.** Remember that the ChatGPT knowledge cutoff is in 2021 while our extension system did not exist until late 2022, thus it *literally can't know*. Pull requests submitting extensions that are made by AI (it's really obvious) will be closed as invalid.
+**Generative AI language models like ChatGPT, Copilot, and Gemini DO NOT know how to write proper extensions for TurboWarp.** Remember that the ChatGPT knowledge cutoff is in 2021 while our extension system did not exist until late 2022, thus it *literally can't know*. Pull requests submitting extensions that are made by AI (it's really obvious) will be closed as invalid.
 
 ## Writing extensions
 


### PR DESCRIPTION
Microsoft Bing Chat was rebranded to Copilot and Google Bard was renamed to Gemini.