### PR TITLE
Update runtime-options.js

### DIFF
--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -143,17 +143,6 @@
               },
             },
           },
-          {
-            opcode: "setCloneLimitValue",
-            text: Scratch.translate("set clone limit to [limit]"),
-            blockType: Scratch.BlockType.COMMAND,
-            arguments: {
-              limit: {
-                type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "500",
-              },
-            },
-          },
 
           "---",
 
@@ -391,12 +380,6 @@
       return Scratch.vm.runtime.runtimeOptions.maxClones;
     }
     setCloneLimit({ limit }) {
-      limit = Scratch.Cast.toNumber(limit);
-      Scratch.vm.setRuntimeOptions({
-        maxClones: limit,
-      });
-    }
-    setCloneLimitValue({ limit }) {
       limit = Scratch.Cast.toNumber(limit);
       Scratch.vm.setRuntimeOptions({
         maxClones: limit,

--- a/extensions/runtime-options.js
+++ b/extensions/runtime-options.js
@@ -143,6 +143,17 @@
               },
             },
           },
+          {
+            opcode: "setCloneLimitValue",
+            text: Scratch.translate("set clone limit to [limit]"),
+            blockType: Scratch.BlockType.COMMAND,
+            arguments: {
+              limit: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "500",
+              },
+            },
+          },
 
           "---",
 
@@ -209,7 +220,7 @@
           {
             opcode: "whenChange",
             blockType: Scratch.BlockType.EVENT,
-            text: "when [WHAT] changed",
+            text: Scratch.translate("when [WHAT] changed"),
             isEdgeActivated: false,
             arguments: {
               WHAT: { type: Scratch.ArgumentType.STRING, menu: "changeable" },
@@ -379,8 +390,13 @@
     getCloneLimit() {
       return Scratch.vm.runtime.runtimeOptions.maxClones;
     }
-
     setCloneLimit({ limit }) {
+      limit = Scratch.Cast.toNumber(limit);
+      Scratch.vm.setRuntimeOptions({
+        maxClones: limit,
+      });
+    }
+    setCloneLimitValue({ limit }) {
       limit = Scratch.Cast.toNumber(limit);
       Scratch.vm.setRuntimeOptions({
         maxClones: limit,


### PR DESCRIPTION
Allow the upper limit of clones to be freely modified and increase the translation of monitoring blocks.