### PR TITLE
Don't use window.vm

### DIFF
--- a/extensions/.eslintrc.js
+++ b/extensions/.eslintrc.js
@@ -100,6 +100,10 @@ module.exports = {
       {
         selector: 'MethodDefinition[key.name=getInfo] Property[key.name=opcode][value.callee.property.name=translate]',
         message: 'Do not translate block opcode'
+      },
+      {
+        selector: 'MemberExpression[object.name=window][property.name=vm]',
+        message: 'Use Scratch.vm instead of window.vm'
       }
     ]
   }


### PR DESCRIPTION
`vm` is already banned as it is not in globals, but window.vm was a workaround. Happens in practice in https://github.com/TurboWarp/extensions/pull/1336