### PR TITLE
NOname-awa/more-comparisons: fix a lot of bugs

### DIFF
--- a/extensions/NOname-awa/more-comparisons.js
+++ b/extensions/NOname-awa/more-comparisons.js
@@ -474,10 +474,16 @@
       return Math.abs(args.a - args.b) <= args.c;
     }
     between(args) {
-      return Scratch.Cast.compare(args.a, args.b) < 0 && Scratch.Cast.compare(args.b, args.c) < 0;
+      return (
+        Scratch.Cast.compare(args.a, args.b) < 0 &&
+        Scratch.Cast.compare(args.b, args.c) < 0
+      );
     }
     betweenEqual(args) {
-      return Scratch.Cast.compare(args.a, args.b) <= 0 && Scratch.Cast.compare(args.b, args.c) <= 0;
+      return (
+        Scratch.Cast.compare(args.a, args.b) <= 0 &&
+        Scratch.Cast.compare(args.b, args.c) <= 0
+      );
     }
     notEqual(args) {
       return args.a != args.b;

--- a/extensions/NOname-awa/more-comparisons.js
+++ b/extensions/NOname-awa/more-comparisons.js
@@ -56,7 +56,7 @@
           {
             opcode: "equal",
             blockType: Scratch.BlockType.BOOLEAN,
-            text: "[a] ⩵ [b]",
+            text: "[a] == [b]",
             arguments: {
               a: {
                 type: Scratch.ArgumentType.STRING,
@@ -105,11 +105,11 @@
             arguments: {
               a: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "1",
               },
               b: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "\n",
+                defaultValue: "2",
               },
             },
           },
@@ -168,7 +168,7 @@
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               b: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -183,7 +183,7 @@
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "",
               },
               b: {
                 type: Scratch.ArgumentType.NUMBER,
@@ -198,15 +198,15 @@
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "1",
               },
               b: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "2",
               },
               c: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "3",
               },
             },
           },
@@ -217,15 +217,15 @@
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "1",
               },
               b: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "2",
               },
               c: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "\n",
+                defaultValue: "3",
               },
             },
           },
@@ -474,10 +474,10 @@
       return Math.abs(args.a - args.b) <= args.c;
     }
     between(args) {
-      return args.a < args.b && args.b < args.c;
+      return Scratch.Cast.compare(args.a, args.b) < 0 && Scratch.Cast.compare(args.b, args.c) < 0;
     }
     betweenEqual(args) {
-      return args.a <= args.b && args.b <= args.c;
+      return Scratch.Cast.compare(args.a, args.b) <= 0 && Scratch.Cast.compare(args.b, args.c) <= 0;
     }
     notEqual(args) {
       return args.a != args.b;
@@ -486,10 +486,10 @@
       return Scratch.Cast.toBoolean(args.a) !== Scratch.Cast.toBoolean(args.b);
     }
     equalOrGreater(args) {
-      return args.a >= args.b;
+      return Scratch.Cast.compare(args.a, args.b) >= 0;
     }
     equalOrLess(args) {
-      return args.a <= args.b;
+      return Scratch.Cast.compare(args.a, args.b) <= 0;
     }
     vertical(args) {
       if (isNaN(args.a) || isNaN(args.b)) {


### PR DESCRIPTION
Almost every block in this extension has subtle inconsistencies but we can't fix a lot of them because that could break projects.

All of the less than / greater than / between blocks were broken when the inputs were strings. This is a pretty clear bug so we can change it without worrying about breaking things that weren't relying on objectively broken behavior.

![image](https://github.com/TurboWarp/extensions/assets/33787854/c4899bc4-f60e-4a88-800e-b633d070e24c)
