### PR TITLE
clipboard: fix clipboard block's result being undefined sometimes

### DIFF
--- a/extensions/clipboard.js
+++ b/extensions/clipboard.js
@@ -107,8 +107,10 @@
       if (navigator.clipboard && navigator.clipboard.readText) {
         return Scratch.canReadClipboard().then((allowed) => {
           if (allowed) {
-            return navigator.clipboard.readText();
+            return navigator.clipboard.readText() ?? "";
           }
+          return "";
+        }).catch(() => {
           return "";
         });
       }

--- a/extensions/clipboard.js
+++ b/extensions/clipboard.js
@@ -105,14 +105,16 @@
 
     clipboard() {
       if (navigator.clipboard && navigator.clipboard.readText) {
-        return Scratch.canReadClipboard().then((allowed) => {
-          if (allowed) {
-            return navigator.clipboard.readText() ?? "";
-          }
-          return "";
-        }).catch(() => {
-          return "";
-        });
+        return Scratch.canReadClipboard()
+          .then((allowed) => {
+            if (allowed) {
+              return navigator.clipboard.readText() ?? "";
+            }
+            return "";
+          })
+          .catch(() => {
+            return "";
+          });
       }
       return "";
     }


### PR DESCRIPTION
May resolve [a recent conversation in the TurboWarp Discord server](https://discord.com/channels/837024174865776680/1132437506655268926/1215424597730787368)

In some cases, the Clipboard extension's `clipboard` block can return undefined. The most reproducible case I could find is using a browser that supports the block (e.g Chrome), accepting TurboWarp's clipboard permission prompt but *denying* the *browser's* clipboard permission prompt. 
This PR should fix it. (At least, it fixes the reproducible allow+deny behavior.)