### PR TITLE
Longboost/color_channels: Change boolean inputs to menus

### DIFF
--- a/extensions/Longboost/color_channels.js
+++ b/extensions/Longboost/color_channels.js
@@ -30,6 +30,7 @@
             opcode: "true",
             blockType: Scratch.BlockType.BOOLEAN,
             text: "true",
+            hideFromPalette: true,
             disableMonitor: true,
           },
           {
@@ -51,9 +52,29 @@
             },
           },
           {
+            opcode: "drawSelected",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "set colors red:[R]green:[G]blue:[B]",
+            arguments: {
+              R: {
+                type: Scratch.ArgumentType.MENU,
+                menu: "ENABLED_MENU",
+              },
+              G: {
+                type: Scratch.ArgumentType.MENU,
+                menu: "ENABLED_MENU",
+              },
+              B: {
+                type: Scratch.ArgumentType.MENU,
+                menu: "ENABLED_MENU",
+              },
+            },
+          },
+          {
             opcode: "draw",
             blockType: Scratch.BlockType.COMMAND,
             text: "only draw colors:[R]green:[G]blue:[B]",
+            hideFromPalette: true,
             arguments: {
               R: {
                 type: Scratch.ArgumentType.BOOLEAN,
@@ -99,6 +120,19 @@
             acceptReporters: true,
             items: ["red", "green", "blue"],
           },
+          ENABLED_MENU: {
+            acceptReporters: true,
+            items: [
+              {
+                text: "off",
+                value: "false",
+              },
+              {
+                text: "on",
+                value: "true",
+              },
+            ],
+          },
         },
       };
     }
@@ -121,6 +155,22 @@
       } else {
         return false;
       }
+    }
+
+    drawSelected({ R, G, B }) {
+      channel_array = [
+        Scratch.Cast.toBoolean(R),
+        Scratch.Cast.toBoolean(G),
+        Scratch.Cast.toBoolean(B),
+        true,
+      ];
+      gl.colorMask(
+        channel_array[0],
+        channel_array[1],
+        channel_array[2],
+        channel_array[3]
+      );
+      Scratch.vm.renderer.dirty = true;
     }
 
     draw({ R, G, B }) {


### PR DESCRIPTION
![Workspace picture showing true boolean and only draw colors boolean input green boolean input blue input removed and set colors red menu green menu blue menu added](https://github.com/TurboWarp/extensions/assets/106490990/906ad007-96a7-49b5-afaf-1e18a33ec2f5)

(Of course, the old blocks weren't removed, but just hidden from the palette.)