### PR TITLE
Lily/SoundExpanded: add play sound at and loop begin/end blocks

### DIFF
--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -34,7 +34,7 @@
           {
             opcode: "startLoopingBegin",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start looping [SOUND] begin [START]s",
+            text: "start looping [SOUND] loop start [START] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -49,7 +49,7 @@
           {
             opcode: "startLoopingBeginEnd",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start looping [SOUND] begin [START]s end [END]s",
+            text: "start looping [SOUND] loop start [START] secs end [END] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -93,7 +93,7 @@
           {
             opcode: "playSoundAtAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] from [START]s until done",
+            text: "play sound [SOUND] from [START] secs until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -108,7 +108,7 @@
           {
             opcode: "playSoundAt",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] from [START]s",
+            text: "start sound [SOUND] from [START] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -123,7 +123,7 @@
           {
             opcode: "playSoundToAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] from [START]s to [END]s until done",
+            text: "play sound [SOUND] from [START] secs to [END] secs until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -142,7 +142,7 @@
           {
             opcode: "playSoundTo",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] from [START]s to [END]s",
+            text: "start sound [SOUND] from [START] secs to [END] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -34,7 +34,7 @@
           {
             opcode: "startLoopingBegin",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start looping [SOUND] loop start [START] secs",
+            text: "start looping [SOUND] loop start [START] seconds",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -49,7 +49,7 @@
           {
             opcode: "startLoopingBeginEnd",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start looping [SOUND] loop region [START] to [END] secs",
+            text: "start looping [SOUND] loop region [START] to [END] seconds",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -93,7 +93,7 @@
           {
             opcode: "playSoundAtAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] from [START] secs until done",
+            text: "play sound [SOUND] from [START] seconds until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -108,7 +108,7 @@
           {
             opcode: "playSoundAt",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] from [START] secs",
+            text: "start sound [SOUND] from [START] seconds",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -123,7 +123,7 @@
           {
             opcode: "playSoundToAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] from [START] to [END] secs until done",
+            text: "play sound [SOUND] from [START] to [END] seconds until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -142,7 +142,7 @@
           {
             opcode: "playSoundTo",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] from [START] to [END] secs",
+            text: "start sound [SOUND] from [START] to [END] seconds",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -49,7 +49,7 @@
           {
             opcode: "startLoopingBeginEnd",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start looping [SOUND] loop start [START] secs end [END] secs",
+            text: "start looping [SOUND] loop region [START] to [END] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -123,7 +123,7 @@
           {
             opcode: "playSoundToAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] from [START] secs to [END] secs until done",
+            text: "play sound [SOUND] from [START] to [END] secs until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -142,7 +142,7 @@
           {
             opcode: "playSoundTo",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] from [START] secs to [END] secs",
+            text: "start sound [SOUND] from [START] to [END] secs",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -310,11 +310,21 @@
     }
 
     startLoopingBegin(args, util) {
-      this._startLooping(util, args.SOUND, Scratch.Cast.toNumber(args.START), 0);
+      this._startLooping(
+        util,
+        args.SOUND,
+        Scratch.Cast.toNumber(args.START),
+        0
+      );
     }
 
     startLoopingBeginEnd(args, util) {
-      this._startLooping(util, args.SOUND, Scratch.Cast.toNumber(args.START), Scratch.Cast.toNumber(args.END));
+      this._startLooping(
+        util,
+        args.SOUND,
+        Scratch.Cast.toNumber(args.START),
+        Scratch.Cast.toNumber(args.END)
+      );
     }
 
     stopLooping(args, util) {
@@ -349,16 +359,29 @@
         const { sprite } = target;
         const { soundId } = sprite.sounds[index];
         const start = Math.max(Scratch.Cast.toNumber(args.START), 0);
-        const end = args.END == undefined ? undefined : Scratch.Cast.toNumber(args.END);
+        const end =
+          args.END == undefined ? undefined : Scratch.Cast.toNumber(args.END);
         if (sprite.soundBank) {
           if (storeWaiting === true) {
             // @ts-expect-error not typed
-            Scratch.vm.runtime.ext_scratch3_sound._addWaitingSound(target.id, soundId);
+            Scratch.vm.runtime.ext_scratch3_sound._addWaitingSound(
+              target.id,
+              soundId
+            );
           } else {
             // @ts-expect-error not typed
-            Scratch.vm.runtime.ext_scratch3_sound._removeWaitingSound(target.id, soundId);
+            Scratch.vm.runtime.ext_scratch3_sound._removeWaitingSound(
+              target.id,
+              soundId
+            );
           }
-          return this._playSoundBankSound(sprite.soundBank, target, soundId, start, end);
+          return this._playSoundBankSound(
+            sprite.soundBank,
+            target,
+            soundId,
+            start,
+            end
+          );
         }
       }
     }
@@ -387,8 +410,8 @@
     // https://github.com/scratchfoundation/scratch-audio/blob/6fb4b142a5f3198483e4c4f992fb623d5e9d1ed5/src/SoundPlayer.js#L253
     _playSoundPlayer(player, start, end) {
       if (player.isStarting) {
-        player.emit('stop');
-        player.emit('play');
+        player.emit("stop");
+        player.emit("play");
         return;
       }
 
@@ -413,7 +436,7 @@
       const { currentTime, DECAY_DURATION } = player.audioEngine;
       player.startingUntil = currentTime + DECAY_DURATION;
 
-      player.emit('play');
+      player.emit("play");
     }
 
     playSoundAt(args, util) {

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -28,9 +28,39 @@
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
               },
+            },
+            extensions: ["colours_sounds"],
+          },
+          {
+            opcode: "startLoopingBegin",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "start looping [SOUND] begin [START]s",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
               START: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: 0,
+                defaultValue: "2",
+              },
+            },
+            extensions: ["colours_sounds"],
+          },
+          {
+            opcode: "startLoopingBeginEnd",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "start looping [SOUND] begin [START]s end [END]s",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
+              START: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "2",
+              },
+              END: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "5",
               },
             },
             extensions: ["colours_sounds"],
@@ -60,6 +90,74 @@
 
           "---",
 
+          {
+            opcode: "playSoundAtAndWait",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "play sound [SOUND] at [START]s until done",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
+              START: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "2",
+              },
+            },
+            extensions: ["colours_sounds"],
+          },
+          {
+            opcode: "playSoundAt",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "start sound [SOUND] at [START]s",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
+              START: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "2",
+              },
+            },
+            extensions: ["colours_sounds"],
+          },
+          {
+            opcode: "playSoundToAndWait",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "play sound [SOUND] at [START]s to [END]s until done",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
+              START: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "2",
+              },
+              END: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "4",
+              },
+            },
+            extensions: ["colours_sounds"],
+          },
+          {
+            opcode: "playSoundTo",
+            blockType: Scratch.BlockType.COMMAND,
+            text: "start sound [SOUND] at [START]s to [END]s",
+            arguments: {
+              SOUND: {
+                type: Scratch.ArgumentType.SOUND,
+              },
+              START: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "2",
+              },
+              END: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "4",
+              },
+            },
+            extensions: ["colours_sounds"],
+          },
           {
             opcode: "stopSound",
             blockType: Scratch.BlockType.COMMAND,
@@ -187,8 +285,8 @@
       };
     }
 
-    startLooping(args, util) {
-      const index = this._getSoundIndex(args.SOUND, util);
+    _startLooping(util, sound, loopStart, loopEnd) {
+      const index = this._getSoundIndex(sound, util);
       if (index < 0) return 0;
       const target = util.target;
       const sprite = util.target.sprite;
@@ -203,6 +301,20 @@
 
       if (!soundPlayer.outputNode) return;
       soundPlayer.outputNode.loop = true;
+      soundPlayer.outputNode.loopStart = loopStart;
+      soundPlayer.outputNode.loopEnd = loopEnd;
+    }
+
+    startLooping(args, util) {
+      this._startLooping(util, args.SOUND, 0, 0);
+    }
+
+    startLoopingBegin(args, util) {
+      this._startLooping(util, args.SOUND, Scratch.Cast.toNumber(args.START), 0);
+    }
+
+    startLoopingBeginEnd(args, util) {
+      this._startLooping(util, args.SOUND, Scratch.Cast.toNumber(args.START), Scratch.Cast.toNumber(args.END));
     }
 
     stopLooping(args, util) {
@@ -227,6 +339,97 @@
 
       if (!soundPlayer.outputNode) return false;
       return soundPlayer.outputNode.loop;
+    }
+
+    // https://github.com/scratchfoundation/scratch-vm/blob/7c1187cc1fe1c763ef61598875acd4fc9a0c8c2e/src/blocks/scratch3_sound.js#L164
+    _playSoundAt(args, util, storeWaiting) {
+      const index = this._getSoundIndex(args.SOUND, util);
+      if (index >= 0) {
+        const { target } = util;
+        const { sprite } = target;
+        const { soundId } = sprite.sounds[index];
+        const start = Math.max(Scratch.Cast.toNumber(args.START), 0);
+        const end = args.END == undefined ? undefined : Scratch.Cast.toNumber(args.END);
+        if (sprite.soundBank) {
+          if (storeWaiting === true) {
+            // @ts-expect-error not typed
+            Scratch.vm.runtime.ext_scratch3_sound._addWaitingSound(target.id, soundId);
+          } else {
+            // @ts-expect-error not typed
+            Scratch.vm.runtime.ext_scratch3_sound._removeWaitingSound(target.id, soundId);
+          }
+          return this._playSoundBankSound(sprite.soundBank, target, soundId, start, end);
+        }
+      }
+    }
+
+    // https://github.com/scratchfoundation/scratch-audio/blob/6fb4b142a5f3198483e4c4f992fb623d5e9d1ed5/src/SoundBank.js#L89
+    _playSoundBankSound(bank, target, soundId, start, end) {
+      const effects = bank.getSoundEffects(soundId);
+      const player = bank.getSoundPlayer(soundId);
+
+      if (bank.playerTargets.get(soundId) !== target) {
+        // make sure to stop the old sound, effectively "forking" the output
+        // when the target switches before we adjust it's effects
+        player.stop();
+      }
+
+      bank.playerTargets.set(soundId, target);
+      effects.addSoundPlayer(player);
+      effects.setEffectsFromTarget(target);
+      player.connect(effects);
+
+      this._playSoundPlayer(player, start, end);
+
+      return player.finished();
+    }
+
+    // https://github.com/scratchfoundation/scratch-audio/blob/6fb4b142a5f3198483e4c4f992fb623d5e9d1ed5/src/SoundPlayer.js#L253
+    _playSoundPlayer(player, start, end) {
+      if (player.isStarting) {
+        player.emit('stop');
+        player.emit('play');
+        return;
+      }
+
+      if (player.isPlaying) {
+        player.stop();
+      }
+
+      if (player.initialized) {
+        player._createSource();
+      } else {
+        player.initialize();
+      }
+
+      if (end === undefined) {
+        player.outputNode.start(0, start);
+      } else {
+        player.outputNode.start(0, start, Math.max(end - start, 0));
+      }
+
+      player.isPlaying = true;
+
+      const { currentTime, DECAY_DURATION } = player.audioEngine;
+      player.startingUntil = currentTime + DECAY_DURATION;
+
+      player.emit('play');
+    }
+
+    playSoundAt(args, util) {
+      this._playSoundAt(args, util);
+    }
+
+    playSoundAtAndWait(args, util) {
+      return this._playSoundAt(args, util, true);
+    }
+
+    playSoundTo(args, util) {
+      this._playSoundAt(args, util);
+    }
+
+    playSoundToAndWait(args, util) {
+      return this._playSoundAt(args, util, true);
     }
 
     stopSound(args, util) {

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -60,7 +60,7 @@
               },
               END: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: "5",
+                defaultValue: "4",
               },
             },
             extensions: ["colours_sounds"],
@@ -93,7 +93,7 @@
           {
             opcode: "playSoundAtAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] at [START]s until done",
+            text: "play sound [SOUND] from [START]s until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -108,7 +108,7 @@
           {
             opcode: "playSoundAt",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] at [START]s",
+            text: "start sound [SOUND] from [START]s",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -123,7 +123,7 @@
           {
             opcode: "playSoundToAndWait",
             blockType: Scratch.BlockType.COMMAND,
-            text: "play sound [SOUND] at [START]s to [END]s until done",
+            text: "play sound [SOUND] from [START]s to [END]s until done",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,
@@ -142,7 +142,7 @@
           {
             opcode: "playSoundTo",
             blockType: Scratch.BlockType.COMMAND,
-            text: "start sound [SOUND] at [START]s to [END]s",
+            text: "start sound [SOUND] from [START]s to [END]s",
             arguments: {
               SOUND: {
                 type: Scratch.ArgumentType.SOUND,


### PR DESCRIPTION
![image](https://github.com/TurboWarp/extensions/assets/68464103/39f82e05-6e28-4d40-b286-96b58479b59d)

Adds one *very* highly-requested feature and another probably-less-requested but still useful feature. They work pretty much as you'd expect. They were actually pretty straightforward to implement (other than start sound at requiring either function overriding or function duplication, and I went with the latter).