### PR TITLE
Lily/SoundExpanded: fix "change project volume" block

### DIFF
--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -530,7 +530,9 @@
 
     setProjectVolume(args) {
       const value = Scratch.Cast.toNumber(args.VALUE);
-      const newVolume = this._wrapClamp(value / 100, 0, 1);
+      const newVolume = Scratch.Cast.toNumber(
+        Math.max(Math.min(value, 1), 0)
+      );
       runtime.audioEngine.inputNode.gain.value = newVolume;
     }
 
@@ -538,7 +540,7 @@
       const value = Scratch.Cast.toNumber(args.VALUE) / 100;
       const volume = runtime.audioEngine.inputNode.gain.value;
       const newVolume = Scratch.Cast.toNumber(
-        Math.min(Math.max(volume + value, 1), 0)
+        Math.max(Math.min(volume + value, 1), 0)
       );
       runtime.audioEngine.inputNode.gain.value = newVolume;
     }

--- a/extensions/Lily/SoundExpanded.js
+++ b/extensions/Lily/SoundExpanded.js
@@ -530,9 +530,7 @@
 
     setProjectVolume(args) {
       const value = Scratch.Cast.toNumber(args.VALUE);
-      const newVolume = Scratch.Cast.toNumber(
-        Math.max(Math.min(value, 1), 0)
-      );
+      const newVolume = Scratch.Cast.toNumber(Math.max(Math.min(value, 1), 0));
       runtime.audioEngine.inputNode.gain.value = newVolume;
     }
 


### PR DESCRIPTION
Lily messed up the clamping, so it used to just always set the volume to 0. This fixes it.
This also makes the set volume block be clamped to 0-100 instead of being wrapped around 0-199, which I think makes more sense and is consistent with the vanilla set volume block. Though I'm not sure if it wrapping around 199 instead of 100 (or 99) was a mistake or not, or if it'll break projects.