### PR TITLE
Xeltalliv/clippingblending: Fix effect resetting on stopping project and incorrect clipping box inheritance by clones

### DIFF
--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -152,6 +152,8 @@
       const proto = vm.runtime.targets[0].__proto__;
       const osa = proto.onStopAll;
       proto.onStopAll = function () {
+        this.clipbox = null;
+        this.blendMode = "default";
         this.renderer.updateDrawableClipBox.call(
           renderer,
           this.drawableID,

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -170,7 +170,9 @@
       proto.makeClone = function () {
         const newTarget = mc.call(this);
         if (this.clipbox || this.blendMode) {
-          newTarget.clipbox = this.clipbox ? Object.assign({}, this.clipbox) : null;
+          newTarget.clipbox = this.clipbox
+            ? Object.assign({}, this.clipbox)
+            : null;
           newTarget.blendMode = this.blendMode;
           renderer.updateDrawableClipBox.call(
             renderer,

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -170,7 +170,7 @@
       proto.makeClone = function () {
         const newTarget = mc.call(this);
         if (this.clipbox || this.blendMode) {
-          newTarget.clipbox = Object.assign({}, this.clipbox);
+          newTarget.clipbox = this.clipbox ? Object.assign({}, this.clipbox) : null;
           newTarget.blendMode = this.blendMode;
           renderer.updateDrawableClipBox.call(
             renderer,


### PR DESCRIPTION
1. In the past, stopping the project would visually reset effects, but they were still there internally, causing clones to inherit them.
2. In the past, creating clone would always result in a clone with clipping box. If the original sprite/clone did not have it, the newly created clipping box would be represented as an empty object (instead of null), which meant all of the required values were undefined. This caused clone to turn invisible. [Originally reported on discord by @ cas_thekid](https://discord.com/channels/837024174865776680/1169100193749291008) 