### PR TITLE
Xeltalliv/simple3D: fix bugs with transform direction block, model importing, invalid mesh drawing

### DIFF
--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -3,7 +3,7 @@
 // Description: Make GPU accelerated 3D projects easily.
 // By: Vadik1 <https://scratch.mit.edu/users/Vadik1/>
 // License: MPL-2.0 AND BSD-3-Clause
-// Version: 1.0.1
+// Version: 1.0.2
 
 (function (Scratch) {
   "use strict";
@@ -3829,6 +3829,9 @@ void main() {
         let totalMat = lookup2[from];
         for (let i = from + 1; i < to; i++) {
           totalMat = m4.multiply(lookup2[i], totalMat);
+        }
+        if (from + 1 == to) {
+          totalMat = totalMat.slice();
         }
         totalMat[12] = totalMat[13] = totalMat[14] = 0;
         if (swapped) totalMat = m4.inverse(totalMat);

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -634,6 +634,7 @@
     }
     checkIfValid() {
       if (currentRenderTarget.getMesh() == this) return false;
+      if (!this.buffers.position) return false;
       let length = -1;
       let lengthIns = -1;
       for (const name in this.buffers) {
@@ -2642,6 +2643,7 @@ void main() {
         if (!mesh) return;
         if (!currentRenderTarget.checkIfValid()) return;
         if (currentRenderTarget.getMesh() == mesh) return;
+        if (!mesh.buffers.position) return;
 
         // TODO: only recompute this after one or more buffers were changed
         let length = -1;

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -755,7 +755,7 @@
     addVertex(idx, fallback) {
       const v = this.vertices[idx];
       this.output.xyz.push(v[0], v[1], v[2]);
-      this.output.rgba.push(v[3] ?? fallback[0], v[4] ?? fallback[1] ?? 1, v[5] ?? fallback[2] ?? 1, v[6] ?? fallback[3] ?? 1);
+      this.output.rgba.push(v[3] ?? fallback[0] ?? 1, v[4] ?? fallback[1] ?? 1, v[5] ?? fallback[2] ?? 1, v[6] ?? fallback[3] ?? 1);
     }
   }
   class ObjModelImporter {
@@ -790,7 +790,7 @@
           materialLast = arr[1];
           materials[materialLast] = [1,1,1,1];
         }
-        if (arr[0] == "Ka") {
+        if (arr[0] == "Kd") {
           const color = materials[materialLast];
           color[0] = +arr[1];
           color[1] = +arr[2];

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -846,9 +846,12 @@
         const a = importMatrix;
         if (needsScaling) {
           for(let i=0; i<xyz.length; i+=3) {
-            xyz[i  ] = xyz[i] * a[0] + xyz[i+1] * a[4] + xyz[i+2] * a[8] + a[12];
-            xyz[i+1] = xyz[i] * a[1] + xyz[i+1] * a[5] + xyz[i+2] * a[9] + a[13];
-            xyz[i+2] = xyz[i] * a[2] + xyz[i+1] * a[6] + xyz[i+2] * a[10] + a[14];
+            const x = xyz[i];
+            const y = xyz[i+1];
+            const z = xyz[i+2];
+            xyz[i  ] = x * a[0] + y * a[4] + z * a[8] + a[12];
+            xyz[i+1] = x * a[1] + y * a[5] + z * a[9] + a[13];
+            xyz[i+2] = x * a[2] + y * a[6] + z * a[10] + a[14];
           }
         }
       }


### PR DESCRIPTION
- If `transform direction from to` has to directly use 1 existing matrix instead of creating a new one, it ends up zero-ing out 13th-15th (12th-14th) elements of it which are responsible for offset. This block wasn't meant to have any side-effects on the input data. [Example](https://turbowarp.org/editor?project_url=https://xeltalliv.github.io/simple3d-extension-examples/projects/manualTransforms/controllerSimple.sb3) https://github.com/TurboWarp/extensions/commit/b1af7dbe10def059bb6829d183d54c8d82d82e4f
- Mesh without vertex positions is considered valid for drawing and trying to draw it throws an error. [Example](https://turbowarp.org/editor?project_url=https://xeltalliv.github.io/simple3d-extension-examples/projects/meshMistakes/mistakeNoPositions.sb3) https://github.com/TurboWarp/extensions/commit/a4c328f76ded1c649d66dcb267be6a3bbab804e3
- In OBJ importer, material colors do not work, because extension is looking for `Ka` (ambient) tags instead of `Kd` (diffuse) tags. [Example](https://turbowarp.org/editor?project_url=https://xeltalliv.github.io/simple3d-extension-examples/projects/import/import4.sb3) https://github.com/TurboWarp/extensions/commit/b13092434f6fe01806a172f3416a0c09e47a7fe4
- In OFF importer, default value for red was missing. https://github.com/TurboWarp/extensions/commit/b13092434f6fe01806a172f3416a0c09e47a7fe4
- In OFF importer, colors are not parsed correctly. They can be provided as integers 0 to 255 or as floats 0.0 to 1.0, but currently everything is treated as floats. That is why OFF [example from the Wikipedia](https://en.wikipedia.org/wiki/OFF_(file_format)#Example) doesn't work. Can be tested in [this](https://turbowarp.org/editor?project_url=https://xeltalliv.github.io/simple3d-extension-examples/projects/import/import4.sb3). https://github.com/TurboWarp/extensions/commit/8343bd00b49b67205f223598a94ebcc6c17fea53
- import from file transform is wrong and distorted, because I didn't copy values before modifying them, so ended up using already processed values mid-computation for the remaining ones. [Example](https://turbowarp.org/editor?project_url=https://xeltalliv.github.io/simple3d-extension-examples/projects/import/importTransform.sb3) https://github.com/TurboWarp/extensions/commit/d008f028a62b6c09738a83a519c10c76297a5862
