### PR TITLE
lab/text: add with/without word wrap option to # of lines block

### DIFF
--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -875,6 +875,14 @@
           {
             opcode: "getLines",
             blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("# of lines"),
+            hideFromPalette: true,
+            disableMonitor: true,
+            extensions: ["colours_looks"],
+          },
+          {
+            opcode: "getLinesV2",
+            blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("# of lines [WITH_WORDWRAP]"),
             hideFromPalette: compatibilityMode,
             arguments: {
@@ -1389,6 +1397,16 @@
     }
 
     getLines(args, util) {
+      const drawableID = util.target.drawableID;
+      const skin = renderer._allDrawables[drawableID].skin;
+      if (!(skin instanceof TextCostumeSkin)) return 0;
+
+      const state = this._getState(util.target);
+      const text = state.skin.text;
+      return text.split("\n").length;
+    }
+
+    getLinesV2(args, util) {
       const drawableID = util.target.drawableID;
       const skin = renderer._allDrawables[drawableID].skin;
       if (!(skin instanceof TextCostumeSkin)) return 0;

--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -875,8 +875,14 @@
           {
             opcode: "getLines",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("# of lines"),
+            text: Scratch.translate("# of lines [WITH_WORDWRAP]"),
             hideFromPalette: compatibilityMode,
+            arguments: {
+              WITH_WORDWRAP: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "twWordwrap",
+              },
+            },
             disableMonitor: true,
             extensions: ["colours_looks"],
           },
@@ -1179,6 +1185,16 @@
             acceptReporters: true,
             items: "getFonts",
           },
+          twWordwrap: {
+            acceptReporters: true,
+            items: [{
+              text: Scratch.translate('with wordwrap'),
+              value: 'with wordwrap',
+            }, {
+              text: Scratch.translate('without wordwrap'),
+              value: 'without wordwrap',
+            }]
+          },
         },
       };
     }
@@ -1378,7 +1394,8 @@
       if (!(skin instanceof TextCostumeSkin)) return 0;
 
       const state = this._getState(util.target);
-      const text = state.skin.text;
+      const text = state.skin.text, lines = state.skin.lines;
+      if (Scratch.Cast.toString(args.WITH_WORDWRAP) == 'with wordwrap') return lines.length;
       return text.split("\n").length;
     }
 

--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -883,12 +883,16 @@
           {
             opcode: "getLinesV2",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("# of lines [WITH_WORDWRAP]"),
+            text: Scratch.translate({
+              default: "# of lines [WITH_WORD_WRAP]",
+              description:
+                "[WITH_WORD_WRAP] is a menu with choices 'with word wrap' and 'without word wrap'",
+            }),
             hideFromPalette: compatibilityMode,
             arguments: {
-              WITH_WORDWRAP: {
+              WITH_WORD_WRAP: {
                 type: Scratch.ArgumentType.STRING,
-                menu: "twWordwrap",
+                menu: "twWordWrap",
               },
             },
             disableMonitor: true,
@@ -1193,15 +1197,18 @@
             acceptReporters: true,
             items: "getFonts",
           },
-          twWordwrap: {
+          twWordWrap: {
             acceptReporters: true,
-            items: [{
-              text: Scratch.translate('with wordwrap'),
-              value: 'with wordwrap',
-            }, {
-              text: Scratch.translate('without wordwrap'),
-              value: 'without wordwrap',
-            }]
+            items: [
+              {
+                text: Scratch.translate("with word wrap"),
+                value: "with word wrap",
+              },
+              {
+                text: Scratch.translate("without word wrap"),
+                value: "without word wrap",
+              },
+            ],
           },
         },
       };
@@ -1412,9 +1419,10 @@
       if (!(skin instanceof TextCostumeSkin)) return 0;
 
       const state = this._getState(util.target);
-      const text = state.skin.text, lines = state.skin.lines;
-      if (Scratch.Cast.toString(args.WITH_WORDWRAP) == 'with wordwrap') return lines.length;
-      return text.split("\n").length;
+      if (Scratch.Cast.toString(args.WITH_WORD_WRAP) === "with word wrap") {
+        return state.skin.lines.length;
+      }
+      return state.skin.text.split("\n").length;
     }
 
     setAlignment(args, util) {


### PR DESCRIPTION
Self explanatory (the translations need to be made + updated sorry)
![image](https://github.com/TurboWarp/extensions/assets/161080149/5f9b6a6b-db9b-4584-95ab-8373954181a9)

This change allows us to circumvent having to reverse the math and do some stupid stuff.
![image](https://github.com/TurboWarp/extensions/assets/161080149/5779bd26-e0aa-40b1-9ab0-310ae872d1a2)

