### PR TITLE
NexusKitten/sgrab: deal with ScratchDB being offline

### DIFF
--- a/extensions/NexusKitten/sgrab.js
+++ b/extensions/NexusKitten/sgrab.js
@@ -266,17 +266,18 @@
     async usergrab2(args) {
       try {
         const response = await Scratch.fetch(
-          "https://scratchdb.lefty.one/v3/user/info/" + args.WHO
+          `https://trampoline.turbowarp.org/api/users/${args.WHO}`
         );
         const jsonData = await response.json();
         if (args.WHAT === "about me") {
-          return jsonData.bio ?? "";
+          return jsonData.profile.bio ?? "";
         } else if (args.WHAT === "wiwo") {
-          return jsonData.work ?? "";
+          return jsonData.profile.status   ?? "";
         } else if (args.WHAT === "location") {
-          return jsonData.country ?? "";
+          return jsonData.profile.country ?? "";
         } else if (args.WHAT === "status") {
-          return jsonData.status ?? "";
+          // ScratchDB would tell us whether they are a New Scratcher but api.scratch.mit.edu doesn't
+          return jsonData.scratchteam ? "Scratch Team" : "Scratcher";
         } else {
           return "";
         }
@@ -287,15 +288,15 @@
     async projectgrab(args) {
       try {
         const response = await Scratch.fetch(
-          "https://scratchdb.lefty.one/v3/project/info/" + args.WHO
+          `https://trampoline.turbowarp.org/api/projects/${args.WHO}`
         );
         const jsonData = await response.json();
         if (args.WHAT === "love") {
-          return jsonData.statistics.loves ?? "";
+          return jsonData.stats.loves ?? "";
         } else if (args.WHAT === "favorite") {
-          return jsonData.statistics.favorites ?? "";
+          return jsonData.stats.favorites ?? "";
         } else if (args.WHAT === "view") {
-          return jsonData.statistics.views ?? "";
+          return jsonData.stats.views ?? "";
         } else {
           return "";
         }
@@ -325,7 +326,7 @@
     async idtoname(args) {
       try {
         const response = await Scratch.fetch(
-          "https://scratchdb.lefty.one/v3/project/info/" + args.WHO
+          `https://trampoline.turbowarp.org/api/projects/${args.WHO}`
         );
         const jsonData = await response.json();
         return jsonData.title ?? "";
@@ -336,10 +337,10 @@
     async idtoowner(args) {
       try {
         const response = await Scratch.fetch(
-          "https://scratchdb.lefty.one/v3/project/info/" + args.WHO
+          `https://trampoline.turbowarp.org/api/projects/${args.WHO}`
         );
         const jsonData = await response.json();
-        return jsonData.username ?? "";
+        return jsonData.author.username ?? "";
       } catch (error) {
         return "";
       }

--- a/extensions/NexusKitten/sgrab.js
+++ b/extensions/NexusKitten/sgrab.js
@@ -24,8 +24,62 @@
         color2: "#EBAF00",
         blocks: [
           {
+            opcode: "usergrab2",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("[WHAT] of user [WHO]"),
+            arguments: {
+              WHAT: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "WHAT5",
+              },
+              WHO: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "john",
+              },
+            },
+          },
+          {
+            opcode: "projectgrab",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("grab [WHAT] count of project id [WHO]"),
+            arguments: {
+              WHAT: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "WHAT3",
+              },
+              WHO: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "717954208",
+              },
+            },
+          },
+          {
+            opcode: "idtoname",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("name of project id [WHO]"),
+            arguments: {
+              WHO: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "717954208",
+              },
+            },
+          },
+          {
+            opcode: "idtoowner",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("creator of project id [WHO]"),
+            arguments: {
+              WHO: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "717954208",
+              },
+            },
+          },
+
+          '---',
+          {
             blockType: Scratch.BlockType.XML,
-            xml: "<sep gap='6'/><label text='S-Grab relies on a third-party API that'/><sep gap='-12'/><label text='is very unreliable. Use this with caution.'/><sep gap='24'/>",
+            xml: "<sep gap='12'/><label text='The blocks below rely on a third-party'/><sep gap='-12'/><label text='API that is currently offline.'/>",
           },
           {
             opcode: "usergrab",
@@ -58,37 +112,6 @@
             },
           },
           {
-            opcode: "usergrab2",
-            blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("[WHAT] of user [WHO]"),
-            arguments: {
-              WHAT: {
-                type: Scratch.ArgumentType.STRING,
-                menu: "WHAT5",
-              },
-              WHO: {
-                type: Scratch.ArgumentType.STRING,
-                defaultValue: "john",
-              },
-            },
-          },
-          "---",
-          {
-            opcode: "projectgrab",
-            blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("grab [WHAT] count of project id [WHO]"),
-            arguments: {
-              WHAT: {
-                type: Scratch.ArgumentType.STRING,
-                menu: "WHAT3",
-              },
-              WHO: {
-                type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
-              },
-            },
-          },
-          {
             opcode: "rankprojectgrab",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
@@ -99,28 +122,6 @@
                 type: Scratch.ArgumentType.STRING,
                 menu: "WHAT4",
               },
-              WHO: {
-                type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
-              },
-            },
-          },
-          {
-            opcode: "idtoname",
-            blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("name of project id [WHO]"),
-            arguments: {
-              WHO: {
-                type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
-              },
-            },
-          },
-          {
-            opcode: "idtoowner",
-            blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("creator of project id [WHO]"),
-            arguments: {
               WHO: {
                 type: Scratch.ArgumentType.STRING,
                 defaultValue: "717954208",

--- a/extensions/NexusKitten/sgrab.js
+++ b/extensions/NexusKitten/sgrab.js
@@ -76,7 +76,7 @@
             },
           },
 
-          '---',
+          "---",
           {
             blockType: Scratch.BlockType.XML,
             xml: "<sep gap='12'/><label text='The blocks below rely on a third-party'/><sep gap='-12'/><label text='API that is currently offline.'/>",
@@ -273,7 +273,7 @@
         if (args.WHAT === "about me") {
           return jsonData.profile.bio ?? "";
         } else if (args.WHAT === "wiwo") {
-          return jsonData.profile.status   ?? "";
+          return jsonData.profile.status ?? "";
         } else if (args.WHAT === "location") {
           return jsonData.profile.country ?? "";
         } else if (args.WHAT === "status") {

--- a/extensions/NexusKitten/sgrab.js
+++ b/extensions/NexusKitten/sgrab.js
@@ -34,7 +34,7 @@
               },
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "john",
+                defaultValue: "griffpatch",
               },
             },
           },
@@ -49,7 +49,7 @@
               },
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
+                defaultValue: "60917032",
               },
             },
           },
@@ -60,7 +60,7 @@
             arguments: {
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
+                defaultValue: "60917032",
               },
             },
           },
@@ -71,7 +71,7 @@
             arguments: {
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
+                defaultValue: "60917032",
               },
             },
           },
@@ -92,7 +92,7 @@
               },
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "john",
+                defaultValue: "griffpatch",
               },
             },
           },
@@ -107,7 +107,7 @@
               },
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "john",
+                defaultValue: "griffpatch",
               },
             },
           },
@@ -124,7 +124,7 @@
               },
               WHO: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: "717954208",
+                defaultValue: "60917032",
               },
             },
           },


### PR DESCRIPTION
 - Half of the blocks can use our trampoline instead
 - Update default values. In particular the default username is now an account that isn't empty
 - Blocks that use ScratchDB are listed separately and with a warning that ScratchDB is currently offline
