### PR TITLE
Preserve SVG rotation centers in exported costume URLs across several extensions

### DIFF
--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -641,7 +641,7 @@
 
       const costume = target.sprite.costumes[costumeIndex];
       switch (attribute) {
-        case "dataURI": { 
+        case "dataURI": {
           if (!requireNonPackagedRuntime("dataURI of costume")) return "";
           const base64 = vm.getExportedCostumeBase64(costume);
           return `data:${costume.asset.assetType.contentType};base64,${base64}`;

--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -641,9 +641,11 @@
 
       const costume = target.sprite.costumes[costumeIndex];
       switch (attribute) {
-        case "dataURI":
+        case "dataURI": { 
           if (!requireNonPackagedRuntime("dataURI of costume")) return "";
-          return costume.asset.encodeDataURI();
+          const base64 = vm.getExportedCostumeBase64(costume);
+          return `data:${costume.asset.assetType.contentType};base64,${base64}`;
+        }
         case "index":
           return costumeIndex + 1;
         case "format":

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -542,7 +542,8 @@
       if (format === "content") {
         return costume.asset.decodeText();
       } else {
-        return costume.asset.encodeDataURI();
+        const base64 = Scratch.vm.getExportedCostumeBase64(costume);
+        return `data:${costume.asset.assetType.contentType};base64,${base64}`;
       }
     }
 

--- a/extensions/Lily/Skins.js
+++ b/extensions/Lily/Skins.js
@@ -321,7 +321,8 @@
       if (costumeIndex === -1) return;
       const costume = util.target.sprite.costumes[costumeIndex];
 
-      const url = costume.asset.encodeDataURI();
+      const base64 = vm.getExportedCostumeBase64(costume);
+      const url = `data:${costume.asset.assetType.contentType};base64,${base64}`;
       const rotationCenterX = costume.rotationCenterX;
       const rotationCenterY = costume.rotationCenterY;
 

--- a/extensions/obviousAlexC/penPlus.js
+++ b/extensions/obviousAlexC/penPlus.js
@@ -4055,9 +4055,9 @@
         Scratch.Cast.toString(costume)
       );
       if (costIndex >= 0) {
-        const curCostume =
-          curTarget.sprite.costumes[costIndex].asset.encodeDataURI();
-        return curCostume || 0;
+        const costume = curTarget.sprite.costumes[costIndex];
+        const base64 = vm.getExportedCostumeBase64(costume);
+        return `data:${costume.asset.assetType.contentType};base64,${base64}` || 0;
       }
     }
 

--- a/extensions/obviousAlexC/penPlus.js
+++ b/extensions/obviousAlexC/penPlus.js
@@ -4057,8 +4057,9 @@
       if (costIndex >= 0) {
         const costume = curTarget.sprite.costumes[costIndex];
         const base64 = vm.getExportedCostumeBase64(costume);
-        return `data:${costume.asset.assetType.contentType};base64,${base64}` || 0;
+        return `data:${costume.asset.assetType.contentType};base64,${base64}`;
       }
+      return "";
     }
 
     getDimensionOf({ dimension, costume }, util) {

--- a/extensions/penplus.js
+++ b/extensions/penplus.js
@@ -1977,8 +1977,9 @@ Other various small fixes
 
   function getspritecostume(util, c) {
     let target = util.target;
-    let dataURI = target.sprite.costumes[c - 1].asset.encodeDataURI();
-    return dataURI;
+    const costume = target.sprite.costumes[c - 1];
+    const base64 = vm.getExportedCostumeBase64(costume);
+    return `data:${costume.asset.assetType.contentType};base64,${base64}`;
   }
 
   async function coolcash(uri, clamp) {


### PR DESCRIPTION
Fixes https://github.com/TurboWarp/extensions/issues/1499

Fixes https://github.com/TurboWarp/extensions/issues/1963