### PR TITLE
PwLDev/vibration: Vibration pattern block

### DIFF
--- a/extensions/PwLDev/vibration.js
+++ b/extensions/PwLDev/vibration.js
@@ -67,7 +67,7 @@
           // Change to array split by ','
           .split(",")
           // Change to numbers in milliseconds
-          .map((val) => Scratch.Cast.toNumber(val.trim()) * 1000);
+          .map((val) => Scratch.Cast.toNumber(val) * 1000);
         navigator.vibrate(pattern);
       }
     }

--- a/extensions/PwLDev/vibration.js
+++ b/extensions/PwLDev/vibration.js
@@ -68,7 +68,6 @@
           .split(",")
           // Change to numbers in milliseconds
           .map((val) => Scratch.Cast.toNumber(val.trim()) * 1000);
-        console.log(pattern);
         navigator.vibrate(pattern);
       }
     }

--- a/extensions/PwLDev/vibration.js
+++ b/extensions/PwLDev/vibration.js
@@ -64,11 +64,11 @@
     startPattern(args) {
       if (navigator.vibrate) {
         const pattern = Scratch.Cast.toString(args.PATTERN)
-          // Change to array split by ','
-          .split(",")
-          // Change to numbers in milliseconds
-          .map((val) => Scratch.Cast.toNumber(val) * 1000);
-        navigator.vibrate(pattern);
+          .match(/[\w\-.]+/g) // Make into array
+          ?.map((val) => Scratch.Cast.toNumber(val) * 1000) // Convert to numbers in milliseconds
+        if (pattern) {
+          navigator.vibrate(pattern);
+        }
       }
     }
 

--- a/extensions/PwLDev/vibration.js
+++ b/extensions/PwLDev/vibration.js
@@ -65,7 +65,7 @@
       if (navigator.vibrate) {
         const pattern = Scratch.Cast.toString(args.PATTERN)
           .match(/[\w\-.]+/g) // Make into array
-          ?.map((val) => Scratch.Cast.toNumber(val) * 1000) // Convert to numbers in milliseconds
+          ?.map((val) => Scratch.Cast.toNumber(val) * 1000); // Convert to numbers in milliseconds
         if (pattern) {
           navigator.vibrate(pattern);
         }

--- a/extensions/PwLDev/vibration.js
+++ b/extensions/PwLDev/vibration.js
@@ -1,6 +1,6 @@
 // Name: Vibration
 // ID: pwldevvibration
-// Description: Control the device's vibration. Only works on Android.
+// Description: Control the device's vibration. Only works on Chrome for Android.
 // By: PwLDev <https://scratch.mit.edu/users/PwLDev/>
 // License: MPL-2.0
 
@@ -22,7 +22,7 @@
         blocks: [
           {
             blockType: Scratch.BlockType.LABEL,
-            text: Scratch.translate("Only works on Android."),
+            text: Scratch.translate("Only works on Chrome for Android."),
           },
           {
             opcode: "start",
@@ -32,6 +32,17 @@
               SECONDS: {
                 type: Scratch.ArgumentType.NUMBER,
                 defaultValue: "2",
+              },
+            },
+          },
+          {
+            opcode: "startPattern",
+            blockType: Scratch.BlockType.COMMAND,
+            text: Scratch.translate("play vibration pattern [PATTERN]"),
+            arguments: {
+              PATTERN: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "1, 0.5, 1, 0.5, 1",
               },
             },
           },
@@ -47,6 +58,18 @@
     start(args) {
       if (navigator.vibrate) {
         navigator.vibrate(Scratch.Cast.toNumber(args.SECONDS) * 1000);
+      }
+    }
+
+    startPattern(args) {
+      if (navigator.vibrate) {
+        const pattern = Scratch.Cast.toString(args.PATTERN)
+          // Change to array split by ','
+          .split(",")
+          // Change to numbers in milliseconds
+          .map((val) => Scratch.Cast.toNumber(val.trim()) * 1000);
+        console.log(pattern);
+        navigator.vibrate(pattern);
       }
     }
 


### PR DESCRIPTION
The `navigator.vibrate()` function isn't limited to just buzzing your phone once for a specific amount of time. You can actually use it to play a pattern where the device alternates between vibrating and not vibrating. You can learn more [on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API#vibration_patterns).

I added a block to bring this functionality to the vibration extension.

Tested on Edge for Android.