### PR TITLE
lab/text: reflow if needed in getLinesV2

### DIFF
--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -1420,6 +1420,9 @@
 
       const state = this._getState(util.target);
       if (Scratch.Cast.toString(args.WITH_WORD_WRAP) === "with word wrap") {
+        if (state.skin._needsReflow()) {
+          state.skin._reflowText();
+        }
         return state.skin.lines.length;
       }
       return state.skin.text.split("\n").length;


### PR DESCRIPTION
fixes:

![image](https://github.com/TurboWarp/extensions/assets/33787854/d2e73293-14c0-4d27-977e-5aecc4fc4b55)
