### PR TITLE
NexusKitten/controlcontrols: remove revert-layer

### DIFF
--- a/extensions/NexusKitten/controlcontrols.js
+++ b/extensions/NexusKitten/controlcontrols.js
@@ -45,7 +45,7 @@
 
   const highlightAnimation = (outlineColor, backgroundColor) => [
     [
-      { outline: "#0000 2px solid", backgroundColor: "revert-layer" },
+      { outline: "#0000 2px solid" },
       {
         outline: outlineColor + " 2px solid",
         backgroundColor: backgroundColor,
@@ -57,7 +57,7 @@
         outline: outlineColor + " 2px solid",
         backgroundColor: backgroundColor,
       },
-      { outline: "#0000 2px solid", backgroundColor: "revert-layer" },
+      { outline: "#0000 2px solid" },
     ],
     { duration: 1700 },
   ];


### PR DESCRIPTION
this feature only works in Firefox and actually isn't needed anyways