### PR TITLE
Lily/Video: Add new 'frame of video (my video) at (0) seconds' block

### DIFF
--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -5,7 +5,7 @@
 // License: MIT AND LGPL-3.0
 
 // Attribution is not required, but greatly appreciated.
-// Frame Block Added By SharkPool
+
 (function (Scratch) {
   "use strict";
 
@@ -240,6 +240,7 @@
             },
           },
           {
+            // Frame Block Added By SharkPool
             opcode: "getFrame",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("frame of video [NAME] at [TIME] seconds"),

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -5,7 +5,7 @@
 // License: MIT AND LGPL-3.0
 
 // Attribution is not required, but greatly appreciated.
-
+// Frame Block Added By SharkPool
 (function (Scratch) {
   "use strict";
 
@@ -239,6 +239,21 @@
               },
             },
           },
+          {
+            opcode: "getFrame",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("frame of video [NAME] at [TIME] seconds"),
+            arguments: {
+              TIME: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0,
+              },
+              NAME: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "my video",
+              },
+            },
+          },
           "---",
           {
             opcode: "pause",
@@ -464,6 +479,29 @@
         default:
           return 0;
       }
+    }
+
+    getFrame(args) {
+      const time = Cast.toString(args.TIME);
+      const videoName = Cast.toString(args.NAME);
+      const videoSkin = this.videos[videoName];
+      if (!videoSkin) return "";
+
+      const videoElement = videoSkin.videoElement;
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d");
+      return new Promise((resolve, reject) => {
+        if (videoElement.readyState >= 1) {
+          canvas.width = videoElement.videoWidth;
+          canvas.height = videoElement.videoHeight;
+          videoElement.currentTime = time;
+          videoElement.addEventListener("seeked", function onSeeked() {
+            context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+            resolve(canvas.toDataURL());
+            videoElement.removeEventListener("seeked", onSeeked);
+          }, { once: true });
+        }
+      });
     }
 
     pause(args) {


### PR DESCRIPTION
New block for the Lily/Video extension that adds a block 'frame of video (my video) at (0) seconds' where it returns the data:URI of the frame of the video at a given time in the video. Can be useful for trying to draw videos in 3D space (using Pen+) making video editing projects similar to CapCut or PowerDirector.

Let me just make it clear that @SharkPool-SP made this extension, not me (the only JavaScript I know is JSON tbh lol). He gave me permission: https://github.com/TurboWarp/extensions/pull/1536#issuecomment-2161864709

`This is my first PR i need this so bad`