### PR TITLE
Lily/AllMenus: hide unused More Events menu and XML escape

### DIFF
--- a/extensions/Lily/AllMenus.js
+++ b/extensions/Lily/AllMenus.js
@@ -14,12 +14,27 @@
     "extension_wedo_tilt_menu",
 
     // Unused menu in More Events that won't be translated
-    "lmsMoreEvents_menu_state"
+    "lmsMoreEvents_menu_state",
   ];
 
-  Scratch.vm.addListener("BLOCKSINFO_UPDATE", refreshMenus);
+  const escapeXML = (text) =>
+    text.replace(/["'&<>]/g, (i) => {
+      switch (i) {
+        case "&":
+          return "&amp;";
+        case '"':
+          return "&apos;";
+        case "'":
+          return "&quot;";
+        case ">":
+          return "&gt;";
+        case "<":
+          return "&lt;";
+      }
+      return "";
+    });
 
-  function refreshMenus() {
+  const refreshMenus = () => {
     if (!window.ScratchBlocks) return;
     Scratch.vm.removeListener("BLOCKSINFO_UPDATE", refreshMenus);
 
@@ -30,12 +45,15 @@
     );
 
     const menuBlocks = allBlocks.map(
-      (item) => '<block id="' + item + '" type="' + item + '"/>'
+      (item) =>
+        '<block id="' + escapeXML(item) + '" type="' + escapeXML(item) + '"/>'
     );
 
     blockXML = menuBlocks.join("");
     Scratch.vm.runtime.extensionManager.refreshBlocks();
-  }
+  };
+
+  Scratch.vm.addListener("BLOCKSINFO_UPDATE", refreshMenus);
 
   class AllMenus {
     constructor() {

--- a/extensions/Lily/AllMenus.js
+++ b/extensions/Lily/AllMenus.js
@@ -7,8 +7,15 @@
 (function (Scratch) {
   "use strict";
 
-  var blockXML;
-  const blacklist = ["looks_costumenumbername", "extension_wedo_tilt_menu"];
+  let blockXML;
+
+  const blocklist = [
+    "looks_costumenumbername",
+    "extension_wedo_tilt_menu",
+
+    // Unused menu in More Events that won't be translated
+    "lmsMoreEvents_menu_state"
+  ];
 
   Scratch.vm.addListener("BLOCKSINFO_UPDATE", refreshMenus);
 
@@ -19,7 +26,7 @@
     let allBlocks = Object.keys(ScratchBlocks.Blocks);
 
     allBlocks = allBlocks.filter(
-      (item) => item.includes("menu") && !blacklist.includes(item)
+      (item) => item.includes("menu") && !blocklist.includes(item)
     );
 
     const menuBlocks = allBlocks.map(


### PR DESCRIPTION
Related to https://github.com/TurboWarp/extensions/issues/1530

XML escaping prevents extension from breaking if menu opcodes have weird characters but should not have any actual security impact since this is Blockly XML. It doesn't get fed directly into innerHTML = ...