### PR TITLE
Add BSD-3-Clause to licenses

### DIFF
--- a/extensions/penplus.js
+++ b/extensions/penplus.js
@@ -2,7 +2,7 @@
 // ID: betterpen
 // Description: Replaced by Pen Plus V7.
 // By: ObviousAlexC <https://scratch.mit.edu/users/pinksheep2917/>
-// License: MIT
+// License: MIT AND BSD-3-Clause
 
 /* eslint-disable no-empty-pattern */
 /* eslint-disable no-prototype-builtins */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/TurboWarp/extensions.git"
   },
-  "license": "MIT AND LGPL-3.0-only AND GPL-3.0-only AND CC-BY-SA-4.0 AND CC-BY-4.0 AND CC-BY-2.5 AND CC0-1.0 AND Apache-2.0 AND MPL-2.0",
+  "license": "MIT AND LGPL-3.0-only AND GPL-3.0-only AND CC-BY-SA-4.0 AND CC-BY-4.0 AND CC-BY-2.5 AND CC0-1.0 AND Apache-2.0 AND MPL-2.0 AND BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/TurboWarp/extensions/issues"
   },


### PR DESCRIPTION
Resolves #1551

This adds `BSD-3-Clause` to the `package.json`.

I didn't add the license text into `licenses/` because none of the TurboWarp extensions contributors wrote code that they voluntarily released under a BSD-3-Clause license and all code that has a BSD-3-Clause includes a comment with the license text, but let me know if you want me to add that, or anything else for that matter.