### PR TITLE
Revert "Migrate to esm"

### DIFF
--- a/development/build-production.js
+++ b/development/build-production.js
@@ -1,10 +1,8 @@
-import pathUtil from "node:path";
-import urlUtil from "node:url";
-import Builder from "./builder.js";
+const pathUtil = require("path");
+const Builder = require("./builder");
 
-const dirname = pathUtil.dirname(urlUtil.fileURLToPath(import.meta.url));
-const outputDirectory = pathUtil.join(dirname, "../build");
-const l10nOutput = pathUtil.join(dirname, "../build-l10n");
+const outputDirectory = pathUtil.join(__dirname, "../build");
+const l10nOutput = pathUtil.join(__dirname, "../build-l10n");
 
 const builder = new Builder("production");
 const build = builder.build();

--- a/development/colors.js
+++ b/development/colors.js
@@ -1,9 +1,9 @@
 const enableColor = !process.env.NO_COLOR;
 const color = (i) => (enableColor ? i : "");
 
-const RESET = color("\x1b[0m");
-const BOLD = color("\x1b[1m");
-const RED = color("\x1b[31m");
-const GREEN = color("\x1b[32m");
-
-export { RESET, BOLD, RED, GREEN };
+module.exports = {
+  RESET: color("\x1b[0m"),
+  BOLD: color("\x1b[1m"),
+  RED: color("\x1b[31m"),
+  GREEN: color("\x1b[32m"),
+};

--- a/development/compatibility-aliases.js
+++ b/development/compatibility-aliases.js
@@ -10,4 +10,4 @@ const extensions = {
   "/LukeManiaStudios/TempVariables2.js": "/Lily/TempVariables2.js",
 };
 
-export default extensions;
+module.exports = extensions;

--- a/development/fs-utils.js
+++ b/development/fs-utils.js
@@ -1,5 +1,5 @@
-import fs from "node:fs";
-import pathUtil from "node:path";
+const fs = require("fs");
+const pathUtil = require("path");
 
 /**
  * Recursively read a directory.
@@ -47,7 +47,7 @@ const mkdirp = (directory) => {
   }
 };
 
-export default {
+module.exports = {
   recursiveReadDirectory,
   mkdirp,
 };

--- a/development/get-credits-for-gui.js
+++ b/development/get-credits-for-gui.js
@@ -1,9 +1,8 @@
-import fs from "node:fs";
-import pathUtil from "node:path";
-import urlUtil from "node:url";
-import https from "node:https";
-import fsUtils from "./fs-utils.js";
-import parseMetadata from "./parse-extension-metadata.js";
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const fsUtils = require("./fs-utils");
+const parseMetadata = require("./parse-extension-metadata");
 
 class AggregatePersonInfo {
   /** @param {Person} person */
@@ -63,8 +62,7 @@ const run = async () => {
    */
   const aggregate = new Map();
 
-  const dirname = pathUtil.dirname(urlUtil.fileURLToPath(import.meta.url));
-  const extensionRoot = pathUtil.resolve(dirname, "../extensions/");
+  const extensionRoot = path.resolve(__dirname, "../extensions/");
   for (const [name, absolutePath] of fsUtils.recursiveReadDirectory(
     extensionRoot
   )) {

--- a/development/parse-extension-metadata.js
+++ b/development/parse-extension-metadata.js
@@ -111,4 +111,4 @@ const parseMetadata = (extensionCode) => {
   return metadata;
 };
 
-export default parseMetadata;
+module.exports = parseMetadata;

--- a/development/parse-extension-translations.js
+++ b/development/parse-extension-translations.js
@@ -1,6 +1,6 @@
-import * as espree from "espree";
-import esquery from "esquery";
-import parseMetadata from "./parse-extension-metadata.js";
+const espree = require("espree");
+const esquery = require("esquery");
+const parseMetadata = require("./parse-extension-metadata");
 
 /**
  * @fileoverview Parses extension code to find calls to Scratch.translate() and statically
@@ -120,4 +120,4 @@ const parseTranslations = (js) => {
   return result;
 };
 
-export default parseTranslations;
+module.exports = parseTranslations;

--- a/development/render-docs.js
+++ b/development/render-docs.js
@@ -1,7 +1,6 @@
-import pathUtil from "node:path";
-import urlUtil from "node:url";
-import MarkdownIt from "markdown-it";
-import renderTemplate from "./render-template.js";
+const path = require("path");
+const MarkdownIt = require("markdown-it");
+const renderTemplate = require("./render-template");
 
 const md = new MarkdownIt({
   html: true,
@@ -64,8 +63,7 @@ const renderDocs = (markdownSource, slug) => {
 
   const bodyHTML = md.renderer.render(tokens, md.options, env);
 
-  const dirname = pathUtil.dirname(urlUtil.fileURLToPath(import.meta.url));
-  return renderTemplate(pathUtil.join(dirname, "docs-template.ejs"), {
+  return renderTemplate(path.join(__dirname, "docs-template.ejs"), {
     slug,
     headerHTML,
     headerText,
@@ -74,4 +72,4 @@ const renderDocs = (markdownSource, slug) => {
   });
 };
 
-export default renderDocs;
+module.exports = renderDocs;

--- a/development/render-template.js
+++ b/development/render-template.js
@@ -1,5 +1,5 @@
-import fs from "node:fs";
-import ejs from "ejs";
+const fs = require("fs");
+const ejs = require("ejs");
 
 // TODO: Investigate the value of removing dependency on `ejs` and possibly writing our own DSL.
 
@@ -9,4 +9,4 @@ const renderTemplate = (path, data) => {
   return outputHTML;
 };
 
-export default renderTemplate;
+module.exports = renderTemplate;

--- a/development/server.js
+++ b/development/server.js
@@ -1,5 +1,5 @@
-import express from "express";
-import Builder from "./builder.js";
+const express = require("express");
+const Builder = require("./builder");
 
 let mostRecentBuild = null;
 const builder = new Builder("development");

--- a/development/validate.js
+++ b/development/validate.js
@@ -1,5 +1,5 @@
-import Builder from "./builder.js";
-import * as Colors from "./colors.js";
+const Builder = require("./builder");
+const Colors = require("./colors");
 
 const builder = new Builder("production");
 const errors = builder.validate();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,15 @@
-import js from '@eslint/js';
-import globals from 'globals';
+const js = require('@eslint/js');
+const globals = require('globals');
 
-export default [
+module.exports = [
   // Base on eslint recommended
   js.configs.recommended,
 
   // Common for all files
   {
     languageOptions: {
-      ecmaVersion: 2022
+      ecmaVersion: 2022,
+      sourceType: 'commonjs'
     },
     rules: {
       // Unused variables commonly indicate logic errors
@@ -75,6 +76,7 @@ export default [
     ],
     languageOptions: {
       globals: {
+        ...globals.commonjs,
         ...globals.node
       }
     }
@@ -86,7 +88,6 @@ export default [
       'extensions/**'
     ],
     languageOptions: {
-      sourceType: 'script',
       globals: {
         ...globals.browser,
         Blockly: 'readonly',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@turbowarp/extensions",
   "version": "0.0.1",
-  "type": "module",
   "description": "Unsandboxed extensions for TurboWarp",
   "scripts": {
     "start": "node development/server.js",


### PR DESCRIPTION
Breaks the extension build process for the desktop app

There was no benefit anyways aside from esm seemingly being the future. Also the lack of a synchronous import() is rather disastrous

Reverts TurboWarp/extensions#1564