### PR TITLE
encoding: Fix unicode base64 encode/decode

### DIFF
--- a/extensions/encoding.js
+++ b/extensions/encoding.js
@@ -76,7 +76,7 @@
     function md5cmn(q, a, b, x, s, t) {
       return safeAdd(
         bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s),
-        b
+        b,
       );
     }
     /**
@@ -475,7 +475,7 @@
             opcode: "Conversioncodes",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "convert the character [string] to [CodeList]"
+              "convert the character [string] to [CodeList]",
             ),
             arguments: {
               string: {
@@ -493,7 +493,7 @@
             opcode: "Restorecode",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "[string] corresponding to the [CodeList] character"
+              "[string] corresponding to the [CodeList] character",
             ),
             arguments: {
               string: {
@@ -514,7 +514,7 @@
             opcode: "Randomstrings",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "randomly generated [position] character string"
+              "randomly generated [position] character string",
             ),
             arguments: {
               position: {
@@ -527,7 +527,7 @@
             opcode: "Fontgenerationstring",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "use [wordbank] to generate a random [position] character string"
+              "use [wordbank] to generate a random [position] character string",
             ),
             arguments: {
               wordbank: {

--- a/extensions/encoding.js
+++ b/extensions/encoding.js
@@ -76,7 +76,7 @@
     function md5cmn(q, a, b, x, s, t) {
       return safeAdd(
         bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s),
-        b,
+        b
       );
     }
     /**
@@ -475,7 +475,7 @@
             opcode: "Conversioncodes",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "convert the character [string] to [CodeList]",
+              "convert the character [string] to [CodeList]"
             ),
             arguments: {
               string: {
@@ -493,7 +493,7 @@
             opcode: "Restorecode",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "[string] corresponding to the [CodeList] character",
+              "[string] corresponding to the [CodeList] character"
             ),
             arguments: {
               string: {
@@ -514,7 +514,7 @@
             opcode: "Randomstrings",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "randomly generated [position] character string",
+              "randomly generated [position] character string"
             ),
             arguments: {
               position: {
@@ -527,7 +527,7 @@
             opcode: "Fontgenerationstring",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate(
-              "use [wordbank] to generate a random [position] character string",
+              "use [wordbank] to generate a random [position] character string"
             ),
             arguments: {
               wordbank: {
@@ -639,7 +639,7 @@
     _btoa(unicode) {
       let bytes = new TextEncoder().encode(unicode);
       let binString = Array.from(bytes, (byte) =>
-        String.fromCodePoint(byte),
+        String.fromCodePoint(byte)
       ).join("");
       return btoa(binString);
     }

--- a/extensions/encoding.js
+++ b/extensions/encoding.js
@@ -443,7 +443,7 @@
             arguments: {
               string: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: btoa("apple"), // don't translate because btoa() will error in Chinese ...
+                defaultValue: this._btoa("apple"),
               },
               code: {
                 type: Scratch.ArgumentType.STRING,
@@ -572,7 +572,7 @@
       string = Scratch.Cast.toString(string);
       switch (code) {
         case "Base64":
-          return btoa(string);
+          return this._btoa(string);
         case "URL":
           return encodeURIComponent(string);
       }
@@ -583,7 +583,7 @@
       switch (code) {
         case "Base64":
           try {
-            return atob(string);
+            return this._atob(string);
           } catch (error) {
             console.error("invalid base 64", error);
             return "";
@@ -635,6 +635,18 @@
         string += t.charAt(Math.floor(Math.random() * a));
       }
       return string;
+    }
+    _btoa(unicode) {
+      let bytes = new TextEncoder().encode(unicode);
+      let binString = Array.from(bytes, (byte) =>
+        String.fromCodePoint(byte),
+      ).join("");
+      return btoa(binString);
+    }
+    _atob(base64) {
+      let binString = atob(base64);
+      let bytes = Uint8Array.from(binString, (m) => m.codePointAt(0));
+      return new TextDecoder().decode(bytes);
     }
   }
   Scratch.extensions.register(new Encoding());


### PR DESCRIPTION
Fixes https://github.com/TurboWarp/extensions/issues/1166

Previously, encodings outside the Latin range were not supported.
[Base64 - "The Unicode Problem"](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem)