### PR TITLE
Xeltalliv/simple3D: Feature update v1.1.0

### DIFF
--- a/docs/Xeltalliv/simple3D.md
+++ b/docs/Xeltalliv/simple3D.md
@@ -177,7 +177,7 @@ draw to the screen at X,Y. Use Z for depth check.
 And now it's time to make some actual Simple3D scratch blocks code.
 In Simple3D those transformations are combined into 1 big transformation, and all the steps have to be specified in reverse.
 ```scratch
-start with perspective FOV (90) near (0.01) far (1000) :: sensing
+start with perspective FOV (90) near (0.1) far (1000) :: sensing
 rotate around [X v] by ((0) - (camRotX)) degrees :: sensing
 rotate around [Y v] by ((0) - (camRotY)) degrees :: sensing
 move X ((0) - (camX)) Y ((0) - (camY)) Z ((0) - (camZ)) :: sensing
@@ -190,7 +190,7 @@ draw mesh [my mesh] :: sensing
 
 Doing all of those steps again for every mesh you want to draw is inefficient. This is where doing steps in reverse becomes helpful. Combined with wrapper block, which saves the transformation when entering it, and restores it when exiting it, it is possible to do this:
 ```scratch
-start with perspective FOV (90) near (0.01) far (1000) :: sensing
+start with perspective FOV (90) near (0.1) far (1000) :: sensing
 rotate around [X v] by ((0) - (camRotX)) degrees :: sensing
 rotate around [Y v] by ((0) - (camRotY)) degrees :: sensing
 move X ((0) - (camX)) Y ((0) - (camY)) Z ((0) - (camZ)) :: sensing
@@ -209,7 +209,7 @@ This will work and it is efficient, however this extension also provides advance
 And when you create one large transformation by youself, it has no way of doing that. Which is why, currently the correct way to setup transformations is like this:
 ```scratch
 configure [to projected from view space v] transformation :: sensing
-start with perspective FOV (90) near (0.01) far (1000) :: sensing
+start with perspective FOV (90) near (0.1) far (1000) :: sensing
 
 configure [to view space from world space v] transformation :: sensing
 start with no transformation :: sensing
@@ -715,7 +715,7 @@ Transformation `custom` does not affect anything. Use it for your own calculatio
 
 ---
 ```scratch
-start with perspective FOV (90) near (0.01) far (1000) :: sensing
+start with perspective FOV (90) near (0.1) far (1000) :: sensing
 ```
 Overwrites currently active transformation with the viewspace to clipspace conversion transformation for perspective projection.
 **Camera is assumed to be facing negative Z.**
@@ -734,7 +734,7 @@ when resolution changes :: sensing hat
 
 ---
 ```scratch
-start with orthographic near (0.01) far (1000) :: sensing
+start with orthographic near (0.1) far (1000) :: sensing
 ```
 Overwrites currently active transformation with the viewspace to clipspace conversion transformation for orthographic projection.
 **Camera is assumed to be facing negative Z.**

--- a/docs/Xeltalliv/simple3D.md
+++ b/docs/Xeltalliv/simple3D.md
@@ -458,6 +458,22 @@ When setting one of the transforms, while the other one is not defined or has di
 
 ---
 ```scratch
+set [my mesh] interleaved [XY positions v] [list v] :: sensing
+```
+
+Used for setting vertex data. Does the same as those blocks:
+```scratch
+set [my mesh] positions XY [listX v] [listY v] :: sensing
+set [my mesh] positions XYZ [listX v] [listY v] [listZ v] :: sensing
+set [my mesh] colors RGB [listR v] [listG v] [listB v] :: sensing
+set [my mesh] colors RGBA [listR v] [listG v] [listB v] [listA v] :: sensing
+set [my mesh] texture coordinates UV [listU v] [listV v] :: sensing
+set [my mesh] texture coordinates UVW [listU v] [listV v] [listW v] :: sensing
+```
+but from a single list with all the components interleaved.
+
+---
+```scratch
 set [my mesh] instance [transfroms v] [list v] :: sensing
 ```
 Used for setting data for instancing: drawing the same mesh many times (can be over a million) in multiple locations.

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1181,7 +1181,7 @@ precision mediump float;
 #define INTERPOLATION
 #endif
 
-centroid in vec4 v_color;
+INTERPOLATION in vec4 v_color;
 #ifdef TEXTURES
 #if TEXTURES == 2
 INTERPOLATION in vec2 v_uv;

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -924,7 +924,10 @@
       this.resizeCanvas();
     }
     dispose() {
-      renderer.removeListener("NativeSizeChanged", this._boundOnNativeSizeChanged);
+      renderer.removeListener(
+        "NativeSizeChanged",
+        this._boundOnNativeSizeChanged
+      );
       if (this._texture) {
         this._renderer.gl.deleteTexture(this._texture);
         this._texture = null;
@@ -994,10 +997,10 @@
     renderer.updateDrawableSkinId(drawableId, skinId);
 
     // Detect resizing
-    drawable.setHighQuality = function(...args) {
+    drawable.setHighQuality = function (...args) {
       Object.getPrototypeOf(this).setHighQuality(...args);
       this.skin.resizeCanvas();
-    }
+    };
 
     // Support for SharkPool's Layer Control extension
     drawable.customDrawableName = "Simple3D Layer";
@@ -1023,7 +1026,8 @@
     const index = renderer._groupOrdering.indexOf("simple3D");
     if (index == -1) return;
     const start = renderer._layerGroups["simple3D"].drawListOffset;
-    const end = renderer._layerGroups[renderer._groupOrdering[index+1]].drawListOffset;
+    const end =
+      renderer._layerGroups[renderer._groupOrdering[index + 1]].drawListOffset;
     if (start !== end) return;
     renderer._groupOrdering.splice(index, 1);
     delete renderer._layerGroups["simple3D"];
@@ -1554,8 +1558,7 @@ void main() {
     gl.getExtension("EXT_texture_filter_anisotropic") ||
     gl.getExtension("MOZ_EXT_texture_filter_anisotropic") ||
     gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
-  const ext_smi =
-    gl.getExtension("OES_shader_multisample_interpolation");
+  const ext_smi = gl.getExtension("OES_shader_multisample_interpolation");
   gl.enable(gl.DEPTH_TEST);
   gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
   // prettier-ignore
@@ -1761,7 +1764,7 @@ void main() {
         },
       },
       def: function ({ RED, GREEN, BLUE, ALPHA }) {
-        const alpha = Cast.toNumber(ALPHA)
+        const alpha = Cast.toNumber(ALPHA);
         gl.clearColor(
           Cast.toNumber(RED) * alpha,
           Cast.toNumber(GREEN) * alpha,
@@ -2730,8 +2733,10 @@ void main() {
         const mesh = meshes.get(Cast.toString(NAME));
         if (!mesh) return;
         if (MODE === "once at pixel center") mesh.myData.interpolation = "";
-        if (MODE === "once at midpoint of covered samples") mesh.myData.interpolation = "MSAA_CENTROID";
-        if (MODE === "separately for each sample" && ext_smi) mesh.myData.interpolation = "MSAA_SAMPLE";
+        if (MODE === "once at midpoint of covered samples")
+          mesh.myData.interpolation = "MSAA_CENTROID";
+        if (MODE === "separately for each sample" && ext_smi)
+          mesh.myData.interpolation = "MSAA_SAMPLE";
         mesh.update();
       },
     },
@@ -2834,8 +2839,7 @@ void main() {
           flags.push(`SKINNING ${mesh.buffers.boneIndices.size}`);
           flags.push(`BONE_COUNT ${mesh.bonesDiff.length / 16}`);
         }
-        if (mesh.data.interpolation)
-          flags.push(mesh.data.interpolation);
+        if (mesh.data.interpolation) flags.push(mesh.data.interpolation);
         if (mesh.data.alphaTest > 0) flags.push("ALPHATEST");
         if (mesh.data.makeOpaque) flags.push("MAKE_OPAQUE");
         if (mesh.data.billboarding) flags.push("BILLBOARD");
@@ -3354,9 +3358,13 @@ void main() {
           ctx.font = FONT;
           const m = ctx.measureText(TEXT);
           canv.width =
-            m.actualBoundingBoxLeft + m.actualBoundingBoxRight + 2 * BORDERSIZECEIL;
+            m.actualBoundingBoxLeft +
+            m.actualBoundingBoxRight +
+            2 * BORDERSIZECEIL;
           canv.height =
-            m.fontBoundingBoxAscent + m.fontBoundingBoxDescent + 2 * BORDERSIZECEIL;
+            m.fontBoundingBoxAscent +
+            m.fontBoundingBoxDescent +
+            2 * BORDERSIZECEIL;
           ctx.clearRect(0, 0, canv.width, canv.height);
           ctx.font = FONT;
           ctx.lineWidth = BORDERSIZE;
@@ -4526,8 +4534,8 @@ void main() {
         items: [
           "once at pixel center",
           "once at midpoint of covered samples",
-          "separately for each sample"
-        ]
+          "separately for each sample",
+        ],
       },
     },
   };

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1733,11 +1733,12 @@ void main() {
         },
       },
       def: function ({ RED, GREEN, BLUE, ALPHA }) {
+        const alpha = Cast.toNumber(ALPHA)
         gl.clearColor(
-          Cast.toNumber(RED),
-          Cast.toNumber(GREEN),
-          Cast.toNumber(BLUE),
-          Cast.toNumber(ALPHA)
+          Cast.toNumber(RED) * alpha,
+          Cast.toNumber(GREEN) * alpha,
+          Cast.toNumber(BLUE) * alpha,
+          alpha
         );
       },
     },

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -2645,7 +2645,7 @@ void main() {
         if (!mesh) return;
         if (MODE === "once at pixel center") mesh.myData.interpolation = "";
         if (MODE === "once at midpoint of covered samples") mesh.myData.interpolation = "MSAA_CENTROID";
-        if (MODE === "separately for each sample") mesh.myData.interpolation = ext_smi ? "MSAA_SAMPLE" : "";
+        if (MODE === "separately for each sample" && ext_smi) mesh.myData.interpolation = "MSAA_SAMPLE";
         mesh.update();
       },
     },

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1537,6 +1537,7 @@ void main() {
   const Blendings = {
     "overwrite color (fastest for opaque)": [false],
     "default": [true, gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.FUNC_ADD],
+    "default behind": [true, gl.ONE_MINUS_DST_ALPHA, gl.ONE, gl.ONE_MINUS_DST_ALPHA, gl.ONE, gl.FUNC_ADD],
     "additive": [true, gl.ONE, gl.ONE, gl.ZERO, gl.ONE, gl.FUNC_ADD],
     "subtractive": [true, gl.ONE, gl.ONE, gl.ZERO, gl.ONE, gl.FUNC_REVERSE_SUBTRACT],
     "multiply": [true, gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.FUNC_ADD],

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -3474,7 +3474,7 @@ void main() {
         },
         NEAR: {
           type: ArgumentType.NUMBER,
-          defaultValue: 0.01,
+          defaultValue: 0.1,
         },
         FAR: {
           type: ArgumentType.NUMBER,
@@ -3497,7 +3497,7 @@ void main() {
       arguments: {
         NEAR: {
           type: ArgumentType.NUMBER,
-          defaultValue: 0.01,
+          defaultValue: 0.1,
         },
         FAR: {
           type: ArgumentType.NUMBER,

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1483,6 +1483,7 @@ void main() {
     target = gl.ARRAY_BUFFER
   ) {
     if (!mesh || !value) return;
+    if (value.length % size !== 0) return;
     if (mesh.uploadOffset < 0) {
       const buffer =
         mesh.myBuffers[name] ?? (mesh.myBuffers[name] = new Buffer(type));
@@ -2330,6 +2331,62 @@ void main() {
         }
         mesh.bonesDiff = diff.flat();
         mesh.update();
+      },
+    },
+    {
+      opcode: "setMeshInterleaved",
+      blockType: BlockType.COMMAND,
+      text: "set [NAME] interleaved [PROPERTY] [SRCLIST]",
+      arguments: {
+        NAME: {
+          type: ArgumentType.STRING,
+          defaultValue: "my mesh",
+        },
+        PROPERTY: {
+          type: ArgumentType.STRING,
+          menu: "interleavedProperty",
+        },
+        SRCLIST: {
+          type: ArgumentType.STRING,
+          menu: "lists",
+        },
+      },
+      def: function ({ NAME, PROPERTY, SRCLIST }, { target }) {
+        let bufferName, size, type;
+        if (PROPERTY == "XY positions") {
+          bufferName = "position";
+          size = 2;
+          type = Float32Array;
+        }
+        if (PROPERTY == "XYZ positions") {
+          bufferName = "position";
+          size = 3;
+          type = Float32Array;
+        }
+        if (PROPERTY == "RGB colors") {
+          bufferName = "colors";
+          size = 3;
+          type = Uint8Array;
+        }
+        if (PROPERTY == "RGBA colors") {
+          bufferName = "colors";
+          size = 4;
+          type = Uint8Array;
+        }
+        if (PROPERTY == "UV texture coordinates") {
+          bufferName = "texCoords";
+          size = 2;
+          type = Float32Array;
+        }
+        if (PROPERTY == "UVW texture coordinates") {
+          bufferName = "texCoords";
+          size = 3;
+          type = Float32Array;
+        }
+        if (!bufferName) return;
+        const mesh = meshes.get(Cast.toString(NAME));
+        const value = compact(target, [SRCLIST], type);
+        uploadBuffer(mesh, bufferName, value, size, 0);
       },
     },
     {
@@ -4395,6 +4452,17 @@ void main() {
           "RGBA colors",
           "UV offsets",
           "UV offsets and sizes",
+        ],
+      },
+      interleavedProperty: {
+        acceptReporters: false,
+        items: [
+          "XY positions",
+          "XYZ positions",
+          "RGB colors",
+          "RGBA colors",
+          "UV texture coordinates",
+          "UVW texture coordinates",
         ],
       },
       renderTargetProperty: {

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -11,7 +11,8 @@
   /*
    * A modified version of m4 library based on one of the earlier lessons on webglfundamentals.org
    * All lessons can be found on https://github.com/gfxfundamentals/webgl-fundamentals/tree/master
-   * licensed under BSD 3-Clause license
+   * licensed under BSD 3-Clause license.
+   * Only this section of the code is BSD 3-Clause. The rest of the extension is MPL-2.0.
    */
 
   /*

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -3,7 +3,7 @@
 // Description: Make GPU accelerated 3D projects easily.
 // By: Vadik1 <https://scratch.mit.edu/users/Vadik1/>
 // License: MPL-2.0 AND BSD-3-Clause
-// Version: 1.0.4
+// Version: 1.1.0
 
 (function (Scratch) {
   "use strict";

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -3262,6 +3262,7 @@ void main() {
         COLOR = Cast.toRgbColorObject(COLOR);
         BORDERSIZE = Cast.toNumber(BORDERSIZE);
         BORDERCOLOR = Cast.toRgbColorObject(BORDERCOLOR);
+        const BORDERSIZECEIL = Math.ceil(BORDERSIZE);
         imageSourceSync = null;
         imageSource = new Promise((resolve, reject) => {
           const canv = document.createElement("canvas");
@@ -3269,9 +3270,9 @@ void main() {
           ctx.font = FONT;
           const m = ctx.measureText(TEXT);
           canv.width =
-            m.actualBoundingBoxLeft + m.actualBoundingBoxRight + 2 * BORDERSIZE;
+            m.actualBoundingBoxLeft + m.actualBoundingBoxRight + 2 * BORDERSIZECEIL;
           canv.height =
-            m.fontBoundingBoxAscent + m.fontBoundingBoxDescent + 2 * BORDERSIZE;
+            m.fontBoundingBoxAscent + m.fontBoundingBoxDescent + 2 * BORDERSIZECEIL;
           ctx.clearRect(0, 0, canv.width, canv.height);
           ctx.font = FONT;
           ctx.lineWidth = BORDERSIZE;
@@ -3279,13 +3280,13 @@ void main() {
           ctx.strokeStyle = `rgba(${BORDERCOLOR.r},${BORDERCOLOR.g},${BORDERCOLOR.b},${(BORDERCOLOR.a ?? 255) / 255})`;
           ctx.fillText(
             TEXT,
-            m.actualBoundingBoxLeft + BORDERSIZE,
-            m.fontBoundingBoxAscent + BORDERSIZE
+            m.actualBoundingBoxLeft + BORDERSIZECEIL,
+            m.fontBoundingBoxAscent + BORDERSIZECEIL
           );
           ctx.strokeText(
             TEXT,
-            m.actualBoundingBoxLeft + BORDERSIZE,
-            m.fontBoundingBoxAscent + BORDERSIZE
+            m.actualBoundingBoxLeft + BORDERSIZECEIL,
+            m.fontBoundingBoxAscent + BORDERSIZECEIL
           );
           imageSourceSync = {
             width: canv.width,
@@ -3457,6 +3458,7 @@ void main() {
         if (DIR == "down") return lastTextMeasurement.fontBoundingBoxDescent;
         if (DIR == "left") return lastTextMeasurement.actualBoundingBoxLeft;
         if (DIR == "right") return lastTextMeasurement.actualBoundingBoxRight;
+        if (DIR == "x step") return lastTextMeasurement.width;
         return 0;
       },
     },
@@ -4418,7 +4420,7 @@ void main() {
       },
       directions: {
         acceptReporters: true,
-        items: ["up", "down", "left", "right"],
+        items: ["up", "down", "left", "right", "x step"],
       },
       bufferUsage: {
         acceptReporters: true,

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -992,6 +992,9 @@
     renderer.updateDrawableSkinId(drawableId, skinId);
     redraw();
 
+    // Support for SharkPool's Layer Control extension
+    renderer._allDrawables[drawableId].customDrawableName = "Simple3D Layer";
+
     const drawOriginal = renderer.draw;
     renderer.draw = function () {
       if (this.dirty) redraw();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/aebc2c8e-284b-4990-8511-0311d208a275)

Adds support for SharkPool's "Layer Control" extension.
Fixes bug where it was always using centroid interpolation for `v_color`.
Fixes [set clear color R:() G:() B:() A:()] to take premultiplied alpha into a count. 
Adds 2 new blocks.
Adds new blending mode for drawing behind what is already drawn.
Adds ability to measure text's horizontal advance distance, which is different from text's bounding box width.
Adds Math.ceil to text borders to prevent text from jumping around when smoothly scaling border.
Adds PenguinMod and Snail IDE extension removal support.
Clarifies which parts are MPL-2.0 and which are BSD-3-Clause.
Changes default near plane to be further to reduce Z-fighting.
