### PR TITLE
steamworks: docs update 2

### DIFF
--- a/docs/steamworks.md
+++ b/docs/steamworks.md
@@ -7,17 +7,18 @@ The Steamworks extension lets you use these Steam APIs:
  - DLC
  - Opening URLs in the Steam Overlay
 
+This extension was not created by and is not supported by Valve. This extension should be considered **alpha** until some real games use it.
+
 ## Enabling Steamworks
 
-Steamworks support will be automatically enabled when you [package](https://packager.turbowarp.org/) your project using one of these environments:
+The Steamworks SDK will be automatically downloaded and enabled when a project using the Steamworks extension is put into the [TurboWarp Packager](https://packager.turbowarp.org/). You'll be asked to provide your game's App ID, which you can find on the Steamworks website. If you don't have an App ID yet, [use the demo game](#demo-game). You will also need to select one of these environments:
 
  - Electron Windows application (64-bit)
  - Electron macOS application
+   (Warning: macOS games published on Steam need to be notarized by Apple, which the packager doesn't support. You can still test your game on a Mac, but you won't be able to publish it for macOS yet.)
  - Electron Linux application (64-bit)
 
-The blocks will not work in the editor, 32-bit environments, ARM environments, plain HTML files, WKWebView, or NW.js. You can still run the blocks, they just won't interact with Steam at all.
-
-When you package a project that uses the Steamworks extension, the packager willl ask you to enter your game's App ID, which you can find on the Steamworks website. If you don't have an App ID yet, see the demo game section below.
+You may have to look under "Other environments" to find some of these. The blocks will not work in the editor, 32-bit environments, ARM environments, plain HTML files, WKWebView, or NW.js. You can still run the blocks, they just won't interact with Steam at all.
 
 You can run the packaged executable directly as usual; you don't need to start the game from Steam for the Steamworks extension to function. However there are a couple caveats when doing this:
 
@@ -30,9 +31,9 @@ Using the Steamworks extension will not prevent people from pirating your game.
 
 The Steamworks extension is also inherently client-side, so a cheater could manipulate all of the Steamworks blocks to return whatever they want. You shouldn't use them for things that are security critical.
 
-## Demo game
+## Demo game <a name="demo-game"></a>
 
-To test the Steamworks extension without paying for a Steamworks Partner Program membership, you can use the free Steamworks demo game. It's called Spacewar and its App ID is `480`. You don't need to install Spacewar; rather, you can use its App ID to test various Steamworks APIs.
+To test the Steamworks extension without paying for a Steamworks Partner Program membership, you can use the Steamworks demo game. It's called Spacewar and its App ID is `480`. You don't need to install or run Spacewar; rather, you can use its App ID to test various Steamworks APIs as if you were the Spacewar developers.
 
 Spacewar has achievements with the following API Names, which can used for testing the achievement blocks:
 


### PR DESCRIPTION
notably, document that macOS support is only useful for development because of the notarization requirement