### PR TITLE
cst1229/zip: expose extension object

### DIFF
--- a/extensions/CST1229/zip.js
+++ b/extensions/CST1229/zip.js
@@ -21,6 +21,10 @@
       this.zipPaths = Object.create(null);
       this.zip = null;
 
+      // for developers who want to integrate their extensions with this one
+      // @ts-ignore
+      Scratch.vm.runtime.ext_cst1229zip = this;
+
       this.zipError = false;
 
       Scratch.vm.runtime.on("RUNTIME_DISPOSED", () => {


### PR DESCRIPTION
For developers who want to add support for this extension (like Files Expanded and arrayBuffer)

(Pen Plus v7 already does this so I assume it's okay?)