### PR TITLE
Lily/LooksPlus: Optimize restore content block

### DIFF
--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -470,7 +470,10 @@
       const content = args.CONTENT;
       if (contentType === "SVG") {
         try {
-          renderer.updateSVGSkin(costume.skinId, Scratch.Cast.toString(content));
+          renderer.updateSVGSkin(
+            costume.skinId,
+            Scratch.Cast.toString(content)
+          );
           renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
         } catch (e) {
           console.error(e);

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -469,8 +469,12 @@
       const contentType = args.TYPE;
       const content = args.CONTENT;
       if (contentType === "SVG") {
-        renderer.updateSVGSkin(costume.skinId, Scratch.Cast.toString(content));
-        renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
+        try {
+          renderer.updateSVGSkin(costume.skinId, Scratch.Cast.toString(content));
+          renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
+        } catch (e) {
+          console.error(e);
+        }
       } else {
         console.error("Options other than SVG are currently unavailable");
       }
@@ -500,14 +504,18 @@
         return;
       }
 
-      const content = costume.asset.decodeText();
-      const rotationCenterX = costume.rotationCenterX;
-      const rotationCenterY = costume.rotationCenterY;
-      renderer.updateSVGSkin(costume.skinId, content, [
-        rotationCenterX,
-        rotationCenterY,
-      ]);
-      renderer._allSkins[costume.skinId].doesNotMatchAsset = false;
+      try {
+        const content = costume.asset.decodeText();
+        const rotationCenterX = costume.rotationCenterX;
+        const rotationCenterY = costume.rotationCenterY;
+        renderer.updateSVGSkin(costume.skinId, content, [
+          rotationCenterX,
+          rotationCenterY,
+        ]);
+        renderer._allSkins[costume.skinId].doesNotMatchAsset = false;
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     costumeContent(args, util) {

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -473,9 +473,7 @@
         renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
       } else {
         console.error("Options other than SVG are currently unavailable");
-        return;
       }
-      Scratch.vm.emitTargetsUpdate();
     }
 
     restoreCostumeContent(args, util) {

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -33,6 +33,8 @@
     return util.runtime.getSpriteTargetByName(nameString);
   };
 
+  const renderer = Scratch.vm.runtime.renderer;
+
   class LooksPlus {
     getInfo() {
       return {
@@ -380,7 +382,7 @@
       const drawableID = target.drawableID;
       const layerOrder = target.getLayerOrder();
       const newLayer = args.LAYER - layerOrder;
-      target.renderer.setDrawableOrder(drawableID, newLayer, "sprite", true);
+      renderer.setDrawableOrder(drawableID, newLayer, "sprite", true);
     }
 
     spriteLayerNumber(args, util) {
@@ -442,7 +444,7 @@
 
     snapshotStage(args, util) {
       return new Promise((resolve) => {
-        Scratch.vm.runtime.renderer.requestSnapshot((uri) => {
+        renderer.requestSnapshot((uri) => {
           resolve(uri);
         });
       });
@@ -467,10 +469,8 @@
       const contentType = args.TYPE;
       const content = args.CONTENT;
       if (contentType === "SVG") {
-        Scratch.vm.runtime.renderer.updateSVGSkin(
-          costume.skinId,
-          Scratch.Cast.toString(content)
-        );
+        renderer.updateSVGSkin(costume.skinId, Scratch.Cast.toString(content));
+        renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
       } else {
         console.error("Options other than SVG are currently unavailable");
         return;
@@ -490,21 +490,26 @@
         return;
       }
 
-      //This is here to ensure no changes are made to bitmap costumes, as changes are irreversible
-      //Check will be removed when it's possible to edit bitmap skins
+      // This is here to ensure no changes are made to bitmap costumes, as changes are irreversible
+      // Check will be removed when it's possible to edit bitmap skins
       const format = costume.asset.assetType.runtimeFormat;
       if (format !== "svg") {
         console.error("Costume is not vector");
         return;
       }
 
+      if (!renderer._allSkins[costume.skinId].doesNotMatchAsset) {
+        return;
+      }
+
       const content = costume.asset.decodeText();
       const rotationCenterX = costume.rotationCenterX;
       const rotationCenterY = costume.rotationCenterY;
-      util.target.renderer.updateSVGSkin(costume.skinId, content, [
+      renderer.updateSVGSkin(costume.skinId, content, [
         rotationCenterX,
         rotationCenterY,
       ]);
+      renderer._allSkins[costume.skinId].doesNotMatchAsset = false;
     }
 
     costumeContent(args, util) {

--- a/extensions/Lily/LooksPlus.js
+++ b/extensions/Lily/LooksPlus.js
@@ -474,7 +474,7 @@
             costume.skinId,
             Scratch.Cast.toString(content)
           );
-          renderer._allSkins[costume.skinId].doesNotMatchAsset = true;
+          renderer._allSkins[costume.skinId].differsFromAsset = true;
         } catch (e) {
           console.error(e);
         }
@@ -503,7 +503,7 @@
         return;
       }
 
-      if (!renderer._allSkins[costume.skinId].doesNotMatchAsset) {
+      if (!renderer._allSkins[costume.skinId].differsFromAsset) {
         return;
       }
 
@@ -515,7 +515,7 @@
           rotationCenterX,
           rotationCenterY,
         ]);
-        renderer._allSkins[costume.skinId].doesNotMatchAsset = false;
+        renderer._allSkins[costume.skinId].differsFromAsset = false;
       } catch (e) {
         console.error(e);
       }

--- a/extensions/Lily/lmsutils.js
+++ b/extensions/Lily/lmsutils.js
@@ -1356,10 +1356,10 @@
 
     setSpriteSVG(args, util) {
       try {
-        Scratch.vm.runtime.renderer.updateSVGSkin(
-          util.target.sprite.costumes[args.INPUTA - 1].skinId,
-          args.INPUTB
-        );
+        const skinId = util.target.sprite.costumes[args.INPUTA - 1].skinId;
+        const renderer = Scratch.vm.runtime.renderer;
+        renderer.updateSVGSkin(skinId, Scratch.Cast.toString(args.INPUTB));
+        renderer._allSkins[skinId].doesNotMatchAsset = true;
       } catch (error) {
         return;
       }

--- a/extensions/Lily/lmsutils.js
+++ b/extensions/Lily/lmsutils.js
@@ -1359,7 +1359,7 @@
         const skinId = util.target.sprite.costumes[args.INPUTA - 1].skinId;
         const renderer = Scratch.vm.runtime.renderer;
         renderer.updateSVGSkin(skinId, Scratch.Cast.toString(args.INPUTB));
-        renderer._allSkins[skinId].doesNotMatchAsset = true;
+        renderer._allSkins[skinId].differsFromAsset = true;
       } catch (error) {
         console.error(error);
       }

--- a/extensions/Lily/lmsutils.js
+++ b/extensions/Lily/lmsutils.js
@@ -1361,9 +1361,8 @@
         renderer.updateSVGSkin(skinId, Scratch.Cast.toString(args.INPUTB));
         renderer._allSkins[skinId].doesNotMatchAsset = true;
       } catch (error) {
-        return;
+        console.error(error);
       }
-      Scratch.vm.emitTargetsUpdate();
     }
 
     alertBlock(args) {


### PR DESCRIPTION
 - restore content block: do nothing if the costume wasn't changed
 - remove unnecessary emitTargetsUpdate
 - try/catch invalid SVGs
