### PR TITLE
Lily/Assets: fix addCostume corruption

### DIFF
--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -362,8 +362,14 @@
       const assetType = this._typeIsBitmap(blob.type)
         ? runtime.storage.AssetType.ImageBitmap
         : runtime.storage.AssetType.ImageVector;
+
+      // Bitmap data format is not actually enforced, but setting it to something that isn't in scratch-parser's
+      // known format list will throw an error when someone tries to load the project.
+      // (https://github.com/scratchfoundation/scratch-parser/blob/665f05d739a202d565a4af70a201909393d456b2/lib/sb3_definitions.json#L51)
       const dataType =
-        blob.type === "image/svg+xml" ? "svg" : blob.type.split("/")[1];
+        blob.type === "image/svg+xml"
+          ? runtime.storage.DataFormat.SVG
+          : runtime.storage.DataFormat.PNG;
 
       const arrayBuffer = await new Promise((resolve, reject) => {
         const fr = new FileReader();


### PR DESCRIPTION
sb3fix will recover it enough to load but assets will become ?. time to fix the root problem

possible root cause of https://github.com/TurboWarp/sb3fix/issues/24
