### PR TITLE
mbw/xml: fix bugs, add inner HTML blocks

### DIFF
--- a/extensions/mbw/xml.js
+++ b/extensions/mbw/xml.js
@@ -118,6 +118,32 @@
               },
             },
           },
+          {
+            opcode: "innerHTML",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("inner elements of [XML]"),
+            arguments: {
+              XML: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: '<hello><planet name="world" /></hello>',
+              },
+            },
+          },
+          {
+            opcode: "setInnerHTML",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("set inner elements of [XML] to [VALUE]"),
+            arguments: {
+              XML: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: '<hello><planet name="world" /></hello>',
+              },
+              VALUE: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: '<planet name="mars" />',
+              },
+            },
+          },
           "---",
           {
             opcode: "attributes",
@@ -386,6 +412,40 @@
         return "";
       }
       xml.textContent = Scratch.Cast.toString(VALUE);
+      return this.xmlToString(xml);
+    }
+
+    /**
+     * @param {object} args
+     * @param {unknown} args.XML
+     */
+    innerHTML({ XML }) {
+      const { xml } = this.stringToXml(Scratch.Cast.toString(XML));
+      if (xml === null) {
+        return "";
+      }
+      return xml.innerHTML;
+    }
+
+    /**
+     * @param {object} args
+     * @param {unknown} args.XML
+     * @param {unknown} args.VALUE
+     */
+    setInnerHTML({ XML, VALUE }) {
+      const { xml } = this.stringToXml(Scratch.Cast.toString(XML));
+      if (xml === null) {
+        return "";
+      }
+      const value = Scratch.Cast.toString(VALUE);
+      // there needs to be exactly one parent element
+      const { xml: newXML } = this.stringToXml(
+        "<testElement>" + value + "</testElement>"
+      );
+      if (newXML === null) {
+        return "";
+      }
+      xml.innerHTML = Scratch.Cast.toString(value);
       return this.xmlToString(xml);
     }
 

--- a/extensions/mbw/xml.js
+++ b/extensions/mbw/xml.js
@@ -367,7 +367,7 @@
       if (xml === null) {
         return "";
       }
-      xml.textContent = VALUE;
+      xml.textContent = Scratch.Cast.toString(VALUE);
       return this.xmlToString(xml);
     }
 

--- a/extensions/mbw/xml.js
+++ b/extensions/mbw/xml.js
@@ -28,6 +28,24 @@
     xmlToString(element) {
       return element.outerHTML;
     }
+    /**
+     * @param {Element} element
+     * @param {string} query
+     */
+    resolveQuery(element, query) {
+      return element.matches(query) ? element : element.querySelector(query);
+    }
+    /**
+     * @param {Element} element
+     * @param {string} query
+     */
+    resolveQueryAll(element, query) {
+      const response = [...element.querySelectorAll(query)];
+      if (element.matches(query)) {
+        response.unshift(element);
+      }
+      return response;
+    }
 
     /** @returns {Scratch.Info} */
     getInfo() {
@@ -544,7 +562,7 @@
       if (xml === null) {
         return "";
       }
-      const child = xml.querySelector(Scratch.Cast.toString(QUERY));
+      const child = this.resolveQuery(xml, Scratch.Cast.toString(QUERY));
       return child !== null;
     }
 
@@ -558,7 +576,7 @@
       if (xml === null) {
         return "";
       }
-      const child = xml.querySelector(Scratch.Cast.toString(QUERY));
+      const child = this.resolveQuery(xml, Scratch.Cast.toString(QUERY));
       if (child === null) {
         return "";
       }
@@ -574,7 +592,7 @@
       if (xml === null) {
         return "";
       }
-      const child = xml.querySelectorAll(Scratch.Cast.toString(QUERY));
+      const child = this.resolveQueryAll(xml, Scratch.Cast.toString(QUERY));
       if (child.length === 0) {
         return "";
       }


### PR DESCRIPTION
- Fixes type error in `setTextContent`
- Makes querySelector related blocks also be able to get their parent - e.g. querying `a` on `<a />` will return the expected result
- Adds "inner elements of" and "set inner elements of" blocks for interacting with innerHTML

<details><summary>Report this is based on</summary>

![image](https://github.com/user-attachments/assets/04637250-ee01-4da0-a940-7ac27fb88e26)
</details>