### PR TITLE
Xeltalliv/clippingblending: Fix compatibility with instanced pen rendering

### DIFF
--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -220,7 +220,8 @@
             clipbox.x_max != lastClipbox.x_max ||
             clipbox.y_max != lastClipbox.y_max))
       ) {
-        if (skin.attribute_index || skin.a_lineColorIndex) { // Supporting both before and after https://github.com/TurboWarp/scratch-render/pull/11
+        if (skin.attribute_index || skin.a_lineColorIndex) {
+          // Supporting both before and after https://github.com/TurboWarp/scratch-render/pull/11
           skin._flushLines();
         }
         lastTarget = target;

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -220,7 +220,7 @@
             clipbox.x_max != lastClipbox.x_max ||
             clipbox.y_max != lastClipbox.y_max))
       ) {
-        if (skin.a_lineColorIndex) {
+        if (skin.attribute_index || skin.a_lineColorIndex) { // Supporting both before and after https://github.com/TurboWarp/scratch-render/pull/11
           skin._flushLines();
         }
         lastTarget = target;


### PR DESCRIPTION
https://github.com/TurboWarp/scratch-render/pull/11 changed [this](https://github.com/TurboWarp/scratch-render/commit/ed45bcdac86c83142cec1b519ec5f73a268c6f93#diff-48a7fca714b38b77f34e557a84780eab06fba6f2c8b6026b4cdf0279d1635485L250-R271) which broke Clipping & Blending that relied on [this](https://github.com/TurboWarp/extensions/blob/9edfed5e340847c61521ce9e9cbe72190553fb6f/extensions/Xeltalliv/clippingblending.js#L223)

This problem broke the sample project which divides the screen in 4 parts.