### PR TITLE
Revert "fix: downloadBlob isn't working properly on some old browsers"

### DIFF
--- a/extensions/files.js
+++ b/extensions/files.js
@@ -235,10 +235,7 @@
   const downloadBlob = (blob, file) => {
     const url = URL.createObjectURL(blob);
     downloadURL(url, file);
-    // Some old browsers process Blob URLs asynchronously
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 1000);
+    URL.revokeObjectURL(url);
   };
 
   /**


### PR DESCRIPTION
# Proposed Changes

Reverts TurboWarp/extensions#1257.

# Reason for Changes

Adding a delay to `revokeObjectURL` didn't help at all, as the original issue was caused by an internal bug of `mark.via`.

They have fixed the issue in later versions.