### PR TITLE
Lily/Skins: fix `delete all skins` not deleting the renderer skins

### DIFF
--- a/extensions/Lily/Skins.js
+++ b/extensions/Lily/Skins.js
@@ -40,7 +40,7 @@
   const renderer = runtime.renderer;
   const Cast = Scratch.Cast;
 
-  var createdSkins = [];
+  var createdSkins = {};
 
   class Skins {
     constructor() {
@@ -371,9 +371,9 @@
 
     deleteAllSkins() {
       this._refreshTargets();
-      for (let i = 0; i < createdSkins.length; i++)
-        renderer.destroySkin(createdSkins[i]);
-      createdSkins = [];
+      for (const skinName in createdSkins)
+        renderer.destroySkin(createdSkins[skinName]);
+      createdSkins = {};
     }
 
     restoreTargets(args) {


### PR DESCRIPTION
The code intended to delete the skins from the renderer when running the "delete all skins" block, but since it tried to iterate through the object like an array instead of iterating through the keys, it didn't work.
This fixes a memory leak in the Skins extension.

(Also changes the `createdSkins` variable from an array into an object, since it's used with string keys.)