### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build for production
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build/
 
@@ -42,4 +42,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves these warnings from https://github.com/TurboWarp/extensions/actions/runs/11374283156/job/31642649008

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/deploy-pages@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

> The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "github-pages".
> Please update your workflow to use v4 of the artifact actions.
> Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
