### PR TITLE
NG: Cast medalID inputs for medal arguments

### DIFF
--- a/extensions/obviousAlexC/newgroundsIO.js
+++ b/extensions/obviousAlexC/newgroundsIO.js
@@ -9286,7 +9286,7 @@
             text: Scratch.translate("unlock medal [medalID]"),
             arguments: {
               medalID: {
-                type: Scratch.ArgumentType.STRING,
+                type: Scratch.ArgumentType.NUMBER,
                 defaultValue: Scratch.translate("MedalID"),
               },
             },

--- a/extensions/obviousAlexC/newgroundsIO.js
+++ b/extensions/obviousAlexC/newgroundsIO.js
@@ -9672,7 +9672,7 @@
         if (loggedIn) {
           NGIO.keepSessionAlive();
         }
-        NGIO.unlockMedal(medalID);
+        NGIO.unlockMedal(Scratch.Cast.toNumber(medalID));
       }
     }
 
@@ -9682,7 +9682,7 @@
         if (loggedIn) {
           NGIO.keepSessionAlive();
         }
-        return NGIO.getMedal(medalID).unlocked;
+        return NGIO.getMedal(Scratch.Cast.toNumber(medalID)).unlocked;
       } else {
         return false;
       }


### PR DESCRIPTION
This can cause weird issues where the medal ID is a string and therefore technically does not exist:
![image](https://github.com/user-attachments/assets/59b8768f-3304-4124-81bb-e226c7d59cd2)

This also fixes the input type from STRING to NUMBER since the other block for medals uses NUMBER as well.