### PR TITLE
Xeltalliv/simple3D: Feature update v1.2.0

### DIFF
--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -736,7 +736,7 @@
 
     "partial list update enabled": (mesh) => mesh.uploadOffset >= 0,
   };
-  const workerSrc = `
+  let workerSrc = `
   class OffModelImporter {
     constructor(dataRaw) {
       const dataStr = dataRaw.map(str => str.split("#")[0].replaceAll("\t", " ").trim()).filter(str => str.length);
@@ -905,8 +905,8 @@
     }
     decode(type, array, importMatrix) {
       return new Promise((resolve) => {
-	      this.queue.push({ data: { type, array, importMatrix }, resolve });
-          this.tryMoveQueue();
+        this.queue.push({ data: { type, array, importMatrix }, resolve });
+        this.tryMoveQueue();
       });
     }
     tryMoveQueue() {
@@ -929,7 +929,7 @@
       this.tryMoveQueue();
     }
     clear() {
-      for(const { resolve } of this.queue) {
+      for (const { resolve } of this.queue) {
         resolve({});
       }
       this.queue = [];
@@ -1068,7 +1068,7 @@
     }
     publicApi.redraw = null;
   }
-  const vshSrc = `
+  let vshSrc = `
 #ifdef MSAA_CENTROID
 #define INTERPOLATION centroid
 #endif
@@ -1241,7 +1241,7 @@ void main() {
 #endif
 }
 `;
-  const fshSrc = `
+  let fshSrc = `
 #ifdef MSAA_CENTROID
 #define INTERPOLATION centroid
 #endif
@@ -2401,7 +2401,10 @@ void main() {
         }
         if (myData.bonesOrig) {
           const diff = [];
-          const end = Math.min(myData.bonesCurr.length, myData.bonesOrig.length);
+          const end = Math.min(
+            myData.bonesCurr.length,
+            myData.bonesOrig.length
+          );
           let i = 0;
           for (; i < end; i++) {
             diff.push(m4.multiply(myData.bonesCurr[i], myData.bonesOrig[i]));
@@ -3182,7 +3185,10 @@ void main() {
         }
         if (mesh.buffers.instanceTransforms) {
           let instanceCount = mesh.buffers.instanceTransforms.length;
-          if (mesh.data.maxInstances && mesh.data.maxInstances < instanceCount) {
+          if (
+            mesh.data.maxInstances &&
+            mesh.data.maxInstances < instanceCount
+          ) {
             instanceCount = mesh.data.maxInstances;
           }
           if (mesh.buffers.indices) {
@@ -4191,7 +4197,7 @@ void main() {
         );
         if (!list) return;
         if (!currentRenderTarget.checkIfValid()) return;
-        const {x, y, w, h} = currentRenderTarget.readarea;
+        const { x, y, w, h } = currentRenderTarget.readarea;
         if (w == 0 || h == 0) return;
         const pixels = new Uint8ClampedArray(w * h * 4);
         gl.readPixels(x, y, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
@@ -4225,7 +4231,7 @@ void main() {
           return currentRenderTarget.hasDepthBuffer;
         if (PROPERTY == "image as data URI") {
           if (!currentRenderTarget.checkIfValid()) return "";
-          const {x, y, w, h} = currentRenderTarget.readarea;
+          const { x, y, w, h } = currentRenderTarget.readarea;
           if (w == 0 || h == 0) return "";
           const pixels = new Uint8ClampedArray(w * h * 4);
           gl.readPixels(x, y, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
@@ -4699,12 +4705,8 @@ void main() {
       },
       boxType: {
         acceptReporters: false,
-        items: [
-          "viewport box",
-          "clipping box",
-          "readback box",
-        ],
-      }
+        items: ["viewport box", "clipping box", "readback box"],
+      },
     },
   };
 
@@ -4814,7 +4816,9 @@ void main() {
   gl.__proto__ = ogl; //*/
 
   publicApi.i_will_not_ask_for_help_when_these_break = () => {
-    console.warn("WARNING: You are accessing Simple3D internals. Expect them to change frequently with no regard to backwards compatibility. WHEN your code breaks, do not expect help.\n\nProper stable APIs will be added later.");
+    console.warn(
+      "WARNING: You are accessing Simple3D internals. Expect them to change frequently with no regard to backwards compatibility. WHEN your code breaks, do not expect help.\n\nProper stable APIs will be added later."
+    );
     return {
       canvas,
       gl,
@@ -4824,21 +4828,31 @@ void main() {
       modelDecoder,
       uploadBuffer,
       getFshSrc: () => fshSrc,
-      setFshSrc: (src) => {vshSrc = src},
-      getVshSrc: () => fshSrc,
-      setVshSrc: (src) => {vshSrc = src},
+      setFshSrc: (src) => {
+        fshSrc = src;
+      },
+      getVshSrc: () => vshSrc,
+      setVshSrc: (src) => {
+        vshSrc = src;
+      },
       canvasRenderTarget,
       resetEverything,
       getTransforms: () => transforms,
-      setTransforms: (t) => {transforms = t},
+      setTransforms: (t) => {
+        transforms = t;
+      },
       getSelectedTransform: () => selectedTransform,
-      setSelectedTransform: (t) => {selectedTransform = t},
+      setSelectedTransform: (t) => {
+        selectedTransform = t;
+      },
       getWorkerSrc: () => workerSrc,
-      setWorkerSrc: (src) => {workerSrc = src},
+      setWorkerSrc: (src) => {
+        workerSrc = src;
+      },
       extInfo,
       Extension,
       Blendings,
-    }
+    };
   };
 
   Scratch.extensions.register(new Extension());

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -733,6 +733,8 @@
       mesh.data.drawRange && mesh.data.drawRange[0] + mesh.data.drawRange[1],
     "vertex draw range length": (mesh) =>
       mesh.data.drawRange && mesh.data.drawRange[1],
+    "instance draw limit": (mesh) =>
+      mesh.data.maxInstances ?? Infinity,
 
     "partial list update enabled": (mesh) => mesh.uploadOffset >= 0,
   };

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1825,8 +1825,10 @@ void main() {
           gl.clear(ClearLayers[LAYERS]);
           gl.depthMask(false);
         }
-        renderer.dirty = true; //TODO: only do this when rendering to
-        runtime.requestRedraw(); //TODO: main canvas, not to framebuffers
+        if (currentRenderTarget === canvasRenderTarget) {
+          renderer.dirty = true;
+          runtime.requestRedraw();
+        }
       },
     },
     {
@@ -3281,8 +3283,10 @@ void main() {
             gl.drawArrays(mesh.data.primitives ?? gl.TRIANGLES, start, amount);
           }
         }
-        renderer.dirty = true; //TODO: only do this when rendering to
-        runtime.requestRedraw(); //TODO: main canvas, not to framebuffers
+        if (currentRenderTarget === canvasRenderTarget) {
+          renderer.dirty = true;
+          runtime.requestRedraw();
+        }
 
         if (mesh.buffers.colors) {
           gl.disableVertexAttribArray(program.aloc.a_color);

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1587,7 +1587,7 @@ void main() {
     let value = [];
     let restarts = [];
     for (let i = 0; i < list.value.length; i++) {
-      let num = Cast.toNumber(list.value[i]) - 1;
+      let num = Math.floor(Cast.toNumber(list.value[i]) - 1);
       if (num < 0) {
         restarts.push(i);
       } else if (num > maxNum) {
@@ -1596,6 +1596,9 @@ void main() {
       value.push(num);
     }
     let restartIndex, typedArray;
+    if (maxNum > 4294967294) {
+      alert(`Simple3D error: Found vertex index ${maxNum}. The maximum supported value is 4294967295.`);
+    }
     if (maxNum > 65534) {
       typedArray = Uint32Array;
       restartIndex = 4294967295;

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -67,66 +67,111 @@
         0, 0, b, 1
       ];
     },
-    translation(tx, ty, tz) {
-      return [
-        1,  0,  0,  0,
-        0,  1,  0,  0,
-        0,  0,  1,  0,
-        tx, ty, tz, 1,
-      ];
-    },
-    xRotation(angleInRadians) {
-      const c = Math.cos(angleInRadians);
-      const s = Math.sin(angleInRadians);
-      return [
-        1, 0, 0, 0,
-        0, c, s, 0,
-        0, -s, c, 0,
-        0, 0, 0, 1,
-      ];
-    },
-    yRotation(angleInRadians) {
-      const c = Math.cos(angleInRadians);
-      const s = Math.sin(angleInRadians);
-      return [
-        c, 0, -s, 0,
-        0, 1, 0, 0,
-        s, 0, c, 0,
-        0, 0, 0, 1,
-      ];
-    },
-    zRotation(angleInRadians) {
-      const c = Math.cos(angleInRadians);
-      const s = Math.sin(angleInRadians);
-      return [
-        c,  s, 0, 0,
-        -s, c, 0, 0,
-        0,  0, 1, 0,
-        0,  0, 0, 1,
-      ];
-    },
-    scaling(sx, sy, sz) {
-      return [
-        sx, 0,  0,  0,
-        0, sy,  0,  0,
-        0,  0, sz,  0,
-        0,  0,  0,  1,
-      ];
-    },
     translate(m, tx, ty, tz) {
-      return m4.multiply(m, m4.translation(tx, ty, tz));
+      return [
+        m[0],
+        m[1],
+        m[2],
+        m[3],
+        m[4],
+        m[5],
+        m[6],
+        m[7],
+        m[8],
+        m[9],
+        m[10],
+        m[11],
+        tx * m[0] + ty * m[4] + tz * m[8] + m[12],
+        tx * m[1] + ty * m[5] + tz * m[9] + m[13],
+        tx * m[2] + ty * m[6] + tz * m[10] + m[14],
+        tx * m[3] + ty * m[7] + tz * m[11] + m[15],
+      ];
     },
     xRotate(m, angleInRadians) {
-      return m4.multiply(m, m4.xRotation(angleInRadians));
+      const c = Math.cos(angleInRadians);
+      const s = Math.sin(angleInRadians);
+      return [
+        m[0],
+        m[1],
+        m[2],
+        m[3],
+        c * m[4] + s * m[8],
+        c * m[5] + s * m[9],
+        c * m[6] + s * m[10],
+        c * m[7] + s * m[11],
+        c * m[8]  - s * m[4],
+        c * m[9]  - s * m[5],
+        c * m[10] - s * m[6],
+        c * m[11] - s * m[7],
+        m[12],
+        m[13],
+        m[14],
+        m[15],
+      ];
     },
     yRotate(m, angleInRadians) {
-      return m4.multiply(m, m4.yRotation(angleInRadians));
+      const c = Math.cos(angleInRadians);
+      const s = Math.sin(angleInRadians);
+      return [
+        c * m[0] - s * m[8],
+        c * m[1] - s * m[9],
+        c * m[2] - s * m[10],
+        c * m[3] - s * m[11],
+        m[4],
+        m[5],
+        m[6],
+        m[7],
+        s * m[0] + c * m[8],
+        s * m[1] + c * m[9],
+        s * m[2] + c * m[10],
+        s * m[3] + c * m[11],
+        m[12],
+        m[13],
+        m[14],
+        m[15],
+      ];
     },
     zRotate(m, angleInRadians) {
-      return m4.multiply(m, m4.zRotation(angleInRadians));
+      const c = Math.cos(angleInRadians);
+      const s = Math.sin(angleInRadians);
+      return [
+        c * m[0] + s * m[4],
+        c * m[1] + s * m[5],
+        c * m[2] + s * m[6],
+        c * m[3] + s * m[7],
+        c * m[4] - s * m[0],
+        c * m[5] - s * m[1],
+        c * m[6] - s * m[2],
+        c * m[7] - s * m[3],
+        m[8],
+        m[9],
+        m[10],
+        m[11],
+        m[12],
+        m[13],
+        m[14],
+        m[15],
+      ];
     },
     scale(m, sx, sy, sz) {
-      return m4.multiply(m, m4.scaling(sx, sy, sz));
+      return [
+        sx * m[0],
+        sx * m[1],
+        sx * m[2],
+        sx * m[3],
+        sy * m[4],
+        sy * m[5],
+        sy * m[6],
+        sy * m[7],
+        sz * m[8],
+        sz * m[9],
+        sz * m[10],
+        sz * m[11],
+        m[12],
+        m[13],
+        m[14],
+        m[15],
+      ];
     },
     multiply(a, b) {
       const a00 = a[0 * 4 + 0];
@@ -197,10 +242,10 @@
       const a31 = a[3 * 4 + 1];
       const a32 = a[3 * 4 + 2];
       const a33 = a[3 * 4 + 3];
-      const b00 = b[0 * 4 + 0];
-      const b01 = b[0 * 4 + 1];
-      const b02 = b[0 * 4 + 2];
-      const b03 = b[0 * 4 + 3];
+      const b00 = b[0];
+      const b01 = b[1];
+      const b02 = b[2];
+      const b03 = b[3];
       return [
         b00 * a00 + b01 * a10 + b02 * a20 + b03 * a30,
         b00 * a01 + b01 * a11 + b02 * a21 + b03 * a31,
@@ -225,23 +270,24 @@
       ];
     },
     inverse: function(m) {
-      const inv = m4.zero();
-      inv[0]  =  m[5] * m[10] * m[15] - m[5]  * m[11] * m[14] - m[9]  * m[6] * m[15] + m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10];
-      inv[4]  = -m[4] * m[10] * m[15] + m[4]  * m[11] * m[14] + m[8]  * m[6] * m[15] - m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10];
-      inv[8]  =  m[4] * m[9]  * m[15] - m[4]  * m[11] * m[13] - m[8]  * m[5] * m[15] + m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9];
-      inv[12] = -m[4] * m[9]  * m[14] + m[4]  * m[10] * m[13] + m[8]  * m[5] * m[14] - m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9];
-      inv[1]  = -m[1] * m[10] * m[15] + m[1]  * m[11] * m[14] + m[9]  * m[2] * m[15] - m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10];
-      inv[5]  =  m[0] * m[10] * m[15] - m[0]  * m[11] * m[14] - m[8]  * m[2] * m[15] + m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10];
-      inv[9]  = -m[0] * m[9]  * m[15] + m[0]  * m[11] * m[13] + m[8]  * m[1] * m[15] - m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9];
-      inv[13] =  m[0] * m[9]  * m[14] - m[0]  * m[10] * m[13] - m[8]  * m[1] * m[14] + m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9];
-      inv[2]  =  m[1] * m[6]  * m[15] - m[1]  * m[7]  * m[14] - m[5]  * m[2] * m[15] + m[5] * m[3] * m[14] + m[13] * m[2] * m[7]  - m[13] * m[3] * m[6];
-      inv[6]  = -m[0] * m[6]  * m[15] + m[0]  * m[7]  * m[14] + m[4]  * m[2] * m[15] - m[4] * m[3] * m[14] - m[12] * m[2] * m[7]  + m[12] * m[3] * m[6];
-      inv[10] =  m[0] * m[5]  * m[15] - m[0]  * m[7]  * m[13] - m[4]  * m[1] * m[15] + m[4] * m[3] * m[13] + m[12] * m[1] * m[7]  - m[12] * m[3] * m[5];
-      inv[14] = -m[0] * m[5]  * m[14] + m[0]  * m[6]  * m[13] + m[4]  * m[1] * m[14] - m[4] * m[2] * m[13] - m[12] * m[1] * m[6]  + m[12] * m[2] * m[5];
-      inv[3]  = -m[1] * m[6]  * m[11] + m[1]  * m[7]  * m[10] + m[5]  * m[2] * m[11] - m[5] * m[3] * m[10] - m[9]  * m[2] * m[7]  + m[9]  * m[3] * m[6];
-      inv[7]  =  m[0] * m[6]  * m[11] - m[0]  * m[7]  * m[10] - m[4]  * m[2] * m[11] + m[4] * m[3] * m[10] + m[8]  * m[2] * m[7]  - m[8]  * m[3] * m[6];
-      inv[11] = -m[0] * m[5]  * m[11] + m[0]  * m[7]  * m[9]  + m[4]  * m[1] * m[11] - m[4] * m[3] * m[9]  - m[8]  * m[1] * m[7]  + m[8]  * m[3] * m[5];
-      inv[15] =  m[0] * m[5]  * m[10] - m[0]  * m[6]  * m[9]  - m[4]  * m[1] * m[10] + m[4] * m[2] * m[9]  + m[8]  * m[1] * m[6]  - m[8]  * m[2] * m[5];
+      const inv = [
+         m[5] * m[10] * m[15] - m[5]  * m[11] * m[14] - m[9]  * m[6] * m[15] + m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10],
+        -m[1] * m[10] * m[15] + m[1]  * m[11] * m[14] + m[9]  * m[2] * m[15] - m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10],
+         m[1] * m[6]  * m[15] - m[1]  * m[7]  * m[14] - m[5]  * m[2] * m[15] + m[5] * m[3] * m[14] + m[13] * m[2] * m[7]  - m[13] * m[3] * m[6],
+        -m[1] * m[6]  * m[11] + m[1]  * m[7]  * m[10] + m[5]  * m[2] * m[11] - m[5] * m[3] * m[10] - m[9]  * m[2] * m[7]  + m[9]  * m[3] * m[6],
+        -m[4] * m[10] * m[15] + m[4]  * m[11] * m[14] + m[8]  * m[6] * m[15] - m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10],
+         m[0] * m[10] * m[15] - m[0]  * m[11] * m[14] - m[8]  * m[2] * m[15] + m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10],
+        -m[0] * m[6]  * m[15] + m[0]  * m[7]  * m[14] + m[4]  * m[2] * m[15] - m[4] * m[3] * m[14] - m[12] * m[2] * m[7]  + m[12] * m[3] * m[6],
+         m[0] * m[6]  * m[11] - m[0]  * m[7]  * m[10] - m[4]  * m[2] * m[11] + m[4] * m[3] * m[10] + m[8]  * m[2] * m[7]  - m[8]  * m[3] * m[6],
+         m[4] * m[9]  * m[15] - m[4]  * m[11] * m[13] - m[8]  * m[5] * m[15] + m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9],
+        -m[0] * m[9]  * m[15] + m[0]  * m[11] * m[13] + m[8]  * m[1] * m[15] - m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9],
+         m[0] * m[5]  * m[15] - m[0]  * m[7]  * m[13] - m[4]  * m[1] * m[15] + m[4] * m[3] * m[13] + m[12] * m[1] * m[7]  - m[12] * m[3] * m[5],
+        -m[0] * m[5]  * m[11] + m[0]  * m[7]  * m[9]  + m[4]  * m[1] * m[11] - m[4] * m[3] * m[9]  - m[8]  * m[1] * m[7]  + m[8]  * m[3] * m[5],
+        -m[4] * m[9]  * m[14] + m[4]  * m[10] * m[13] + m[8]  * m[5] * m[14] - m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9],
+         m[0] * m[9]  * m[14] - m[0]  * m[10] * m[13] - m[8]  * m[1] * m[14] + m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9],
+        -m[0] * m[5]  * m[14] + m[0]  * m[6]  * m[13] + m[4]  * m[1] * m[14] - m[4] * m[2] * m[13] - m[12] * m[1] * m[6]  + m[12] * m[2] * m[5],
+         m[0] * m[5]  * m[10] - m[0]  * m[6]  * m[9]  - m[4]  * m[1] * m[10] + m[4] * m[2] * m[9]  + m[8]  * m[1] * m[6]  - m[8]  * m[2] * m[5]
+      ];
       const det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
       if (det == 0) return m4.zero();
       const invDet = 1 / det;

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1007,7 +1007,9 @@
       }
     }
     restartWorker() {
-      console.warn("Simple3D: Worker took too long to decode the model and was terminated");
+      console.warn(
+        "Simple3D: Worker took too long to decode the model and was terminated"
+      );
       this.destroyWorker();
       this.tryMoveQueue();
     }

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -4800,5 +4800,33 @@ void main() {
   }
   gl.__proto__ = ogl; //*/
 
+  publicApi.i_will_not_ask_for_help_when_these_break = () => {
+    console.warn("WARNING: You are accessing Simple3D internals. Expect them to change frequently with no regard to backwards compatibility. WHEN your code breaks, do not expect help.\n\nProper stable APIs will be added later.");
+    return {
+      canvas,
+      gl,
+      definitions,
+      meshes,
+      programs,
+      modelDecoder,
+      uploadBuffer,
+      getFshSrc: () => fshSrc,
+      setFshSrc: (src) => {vshSrc = src},
+      getVshSrc: () => fshSrc,
+      setVshSrc: (src) => {vshSrc = src},
+      canvasRenderTarget,
+      resetEverything,
+      getTransforms: () => transforms,
+      setTransforms: (t) => {transforms = t},
+      getSelectedTransform: () => selectedTransform,
+      setSelectedTransform: (t) => {selectedTransform = t},
+      getWorkerSrc: () => workerSrc,
+      setWorkerSrc: (src) => {workerSrc = src},
+      extInfo,
+      Extension,
+      Blendings,
+    }
+  };
+
   Scratch.extensions.register(new Extension());
 })(Scratch);

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -779,8 +779,7 @@
       mesh.data.drawRange && mesh.data.drawRange[0] + mesh.data.drawRange[1],
     "vertex draw range length": (mesh) =>
       mesh.data.drawRange && mesh.data.drawRange[1],
-    "instance draw limit": (mesh) =>
-      mesh.data.maxInstances ?? Infinity,
+    "instance draw limit": (mesh) => mesh.data.maxInstances ?? Infinity,
 
     "partial list update enabled": (mesh) => mesh.uploadOffset >= 0,
   };

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1094,8 +1094,10 @@
     }
 
     publicApi.redraw = function () {
-      skin.updateContent(canvas);
-      runtime.requestRedraw();
+      if (canvasDirty) {
+        skin.updateContent(canvas);
+        canvasDirty = false;
+      }
     };
     publicApi.redraw();
   }
@@ -1635,6 +1637,7 @@ void main() {
   const runtime = vm.runtime;
 
   const extensionId = "xeltallivSimple3D";
+  let canvasDirty = true;
   let canvas = document.createElement("canvas");
   let gl = canvas.getContext("webgl2");
   if (!gl)
@@ -1760,6 +1763,7 @@ void main() {
     meshes.clear();
     programs.clear();
     modelDecoder.clear();
+    canvasDirty = true;
     renderer.dirty = true;
     runtime.requestRedraw();
   }
@@ -1826,8 +1830,9 @@ void main() {
           gl.depthMask(false);
         }
         if (currentRenderTarget === canvasRenderTarget) {
-          renderer.dirty = true;
-          runtime.requestRedraw();
+          canvasDirty = true; // Telling extension to update texture
+          renderer.dirty = true; // Telling renderer to redraw the screen
+          runtime.requestRedraw(); // Telling sequencer to yield in loops
         }
       },
     },
@@ -3284,8 +3289,9 @@ void main() {
           }
         }
         if (currentRenderTarget === canvasRenderTarget) {
-          renderer.dirty = true;
-          runtime.requestRedraw();
+          canvasDirty = true; // Telling extension to update texture
+          renderer.dirty = true; // Telling renderer to redraw the screen
+          runtime.requestRedraw(); // Telling sequencer to yield in loops
         }
 
         if (mesh.buffers.colors) {

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -2915,9 +2915,9 @@ void main() {
           if (fogSpace == "model space") flags.push("FOG_IN_MODEL_SPACE");
           if (fogPosition) flags.push("FOG_POS");
         }
-        if (mesh.buffers.boneIndices && mesh.bonesDiff) {
+        if (mesh.buffers.boneIndices && mesh.data.bonesDiff) {
           flags.push(`SKINNING ${mesh.buffers.boneIndices.size}`);
-          flags.push(`BONE_COUNT ${mesh.bonesDiff.length / 16}`);
+          flags.push(`BONE_COUNT ${mesh.data.bonesDiff.length / 16}`);
         }
         if (mesh.data.interpolation) flags.push(mesh.data.interpolation);
         if (mesh.data.alphaTest > 0) flags.push("ALPHATEST");
@@ -3149,8 +3149,8 @@ void main() {
           gl.uniform1f(program.uloc.u_alpha_threshold, mesh.data.alphaTest);
         }
 
-        if (mesh.bonesDiff) {
-          gl.uniformMatrix4fv(program.uloc.u_bones, false, mesh.bonesDiff);
+        if (mesh.data.bonesDiff) {
+          gl.uniformMatrix4fv(program.uloc.u_bones, false, mesh.data.bonesDiff);
         }
         if (mesh.data.uvOffset) {
           gl.uniform2fv(program.uloc.u_uvOffset, mesh.data.uvOffset);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4478d675-cea1-40b4-bf72-cd0ae6d7de03)

**This update:**
Changes the way bone transforms blocks handle cases when not supplied all the necessary data or the data mismatches in length. Technically not backwards compatible, but considering both the fact that no-one seems to know how to use this and the fact it only changes what happens when the feature is misused, this should be fine.
Makes bone transforms inheritable, which they weren't due to an oversight.
In the documentation adds an external link to the tutorial.
Adds a block for limiting amount of drawn instances.
Adds 2 blocks for specifying and clearing viewport, clipping and pixel readback boxes.
Adds 3 new options into mesh property reported for estimating VRAM usage.
Adds a warning for exceeding vertex index limit.
Speeds up m4.js
Removes unnecessary screen refreshes.
Adds a 90 second limit for model decoder. After that, it gets restarted.
Cancels all the queued model importing upon the call to "reset everything" .
Adds it's own `i_will_not_ask_for_help_when_these_break` exports.