### PR TITLE
XeroName/Deltatime: dont return dt=0

### DIFF
--- a/extensions/XeroName/Deltatime.js
+++ b/extensions/XeroName/Deltatime.js
@@ -21,7 +21,15 @@
 
   vm.runtime.on("BEFORE_EXECUTE", () => {
     const now = performance.now();
-    deltaTime = previousTime === 0 ? 0 : (now - previousTime) / 1000;
+
+    if (previousTime === 0) {
+      // First frame. We used to always return 0 here, but that can break projects that
+      // expect delta time to always be non-zero. Instead we'll make our best guess.
+      deltaTime = 1 / vm.runtime.frameLoop.framerate;
+    } else {
+      deltaTime = (now - previousTime) / 1000;
+    }
+
     previousTime = now;
   });
 


### PR DESCRIPTION
If projects do things like "5 / delta time", they'll break horribly when delta time is 0, so let's not return that.