### PR TITLE
Expose tempvars2 on the runtime & minor code changes.

### DIFF
--- a/extensions/Lily/TempVariables2.js
+++ b/extensions/Lily/TempVariables2.js
@@ -22,7 +22,7 @@
       //
       // Object.create(null) prevents "variable [toString]" from returning a function.
       this.runtimeVariables = Object.create(null);
-      
+
       Scratch.vm.runtime.on("PROJECT_START", () => {
         this.resetRuntimeVariables();
       });

--- a/extensions/Lily/TempVariables2.js
+++ b/extensions/Lily/TempVariables2.js
@@ -16,7 +16,7 @@
 
   class TempVars {
     constructor() {
-      // this.resetRntimeVariables would be preferable but,
+      // this.resetRuntimeVariables would be preferable but,
       // its easier on TS when defined in the constructor,
       // and not abstracted out.
       //


### PR DESCRIPTION
Please read the comments I put on the git commit for why stuff was changed.

As per what cst1229 did, for letting others have access to the extension stuff then lets us access the previously accessible runtime variables from another extension.

And the rest is just some minor code changes.