### PR TITLE
Lily/TempVariables2: nitpicking

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -112,6 +112,14 @@ module.exports = [
       'no-restricted-syntax': [
         'error',
         {
+          selector: 'AssignmentExpression[operator="??="]',
+          message: 'x ??= y syntax is too new; use x = x ?? y intead'
+        },
+        {
+          selector: 'MemberExpression[object.name=Object][property.name=hasOwn]',
+          message: 'Object.hasOwn(...) is too new; use Object.prototype.hasOwnProperty.call(...) instead'
+        },
+        {
           selector: 'CallExpression[callee.name=fetch]',
           message: 'Use Scratch.fetch() instead of fetch()'
         },

--- a/extensions/Lily/TempVariables2.js
+++ b/extensions/Lily/TempVariables2.js
@@ -256,7 +256,7 @@
         thread.variables = Object.create(null);
       }
       const vars = thread.variables;
-      if (!Object.prototype.hasOwnProperty.call(util.stackFrame, 'index')) {
+      if (!Object.prototype.hasOwnProperty.call(util.stackFrame, "index")) {
         util.stackFrame.index = 0;
       }
       if (util.stackFrame.index < Number(args.NUM)) {
@@ -291,7 +291,10 @@
     }
 
     runtimeVariableExists(args) {
-      return Object.prototype.hasOwnProperty.call(this.runtimeVariables, args.VAR);
+      return Object.prototype.hasOwnProperty.call(
+        this.runtimeVariables,
+        args.VAR
+      );
     }
 
     listRuntimeVariables(args, util) {

--- a/extensions/Lily/TempVariables2.js
+++ b/extensions/Lily/TempVariables2.js
@@ -217,13 +217,17 @@
 
     setThreadVariable(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
       thread.variables[args.VAR] = args.STRING;
     }
 
     changeThreadVariable(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
       const vars = thread.variables;
       const prev = Scratch.Cast.toNumber(vars[args.VAR]);
       const next = Scratch.Cast.toNumber(args.NUM);
@@ -232,21 +236,29 @@
 
     getThreadVariable(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
       return thread.variables[args.VAR] ?? "";
     }
 
     threadVariableExists(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
-      return Object.hasOwn(thread.variables, args.VAR);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
+      return Object.prototype.hasOwnProperty.call(thread.variables, args.VAR);
     }
 
     forEachThreadVariable(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
       const vars = thread.variables;
-      util.stackFrame.index ??= 0;
+      if (!Object.prototype.hasOwnProperty.call(util.stackFrame, 'index')) {
+        util.stackFrame.index = 0;
+      }
       if (util.stackFrame.index < Number(args.NUM)) {
         util.stackFrame.index++;
         vars[args.VAR] = util.stackFrame.index;
@@ -256,7 +268,9 @@
 
     listThreadVariables(args, util) {
       const thread = util.thread;
-      thread.variables ??= Object.create(null);
+      if (!thread.variables) {
+        thread.variables = Object.create(null);
+      }
       return Object.keys(thread.variables).join(",");
     }
 
@@ -277,7 +291,7 @@
     }
 
     runtimeVariableExists(args) {
-      return Object.hasOwn(this.runtimeVariables, args.VAR);
+      return Object.prototype.hasOwnProperty.call(this.runtimeVariables, args.VAR);
     }
 
     listRuntimeVariables(args, util) {
@@ -292,8 +306,9 @@
       this.runtimeVariables = Object.create(null);
     }
   }
-  // The expose format follows scratch's convention of `ext_${extensionId}`.
+  // The expose format follows TurboWarp's convention of `ext_${extensionId}`.
   // Expose the extension on runtime for others to use.
-  Scratch.vm.runtime.ext_lmsTempVars2 = new TempVars();
-  Scratch.extensions.register(Scratch.vm.runtime.ext_lmsTempVars2);
+  const extension = new TempVars();
+  Scratch.vm.runtime.ext_lmsTempVars2 = extension;
+  Scratch.extensions.register(extension);
 })(Scratch);


### PR DESCRIPTION
Safari 13 and 14 have enough users that they show up in the top 100 user agents on clouddata.turbowarp.org so I'd like to keep as much alive there for as long as possible. Thus avoid using ??= (Safari 14) or Object.hasOwn (Safari 15.4).

Also includes ESLint rules, so that these are detected automatically moving forward

`ext_${extensionId}` is also a turbowarp convention not a Scratch convention

Probably at some point it makes sense to just adopt babel and transpile this stuff down to Safari 12 but for now, avoiding significant transformations is nice