### PR TITLE
Xeltalliv/simple3D: don't ask for permission to open extra resources

### DIFF
--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1841,7 +1841,10 @@ void main() {
       text: "Open extra resources",
       func: "openSite",
       def: function () {
-        Scratch.openWindow("https://xeltalliv.github.io/simple3d-extension/");
+        // Exempted from Scratch.openWindow as initiated by user gesture.
+        // docsURI won't ask for permission so it doesn't make sense for this to either.
+        // eslint-disable-next-line no-restricted-syntax
+        window.open("https://xeltalliv.github.io/simple3d-extension/");
       },
     },
     {


### PR DESCRIPTION
the pen+ V7 docsURI button won't ask for permission so it doesn't make sense for this button to ask either