### PR TITLE
Use SSH deploy key for issue_comment workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Checkout pull request
         run: gh pr checkout "$PR_NUM"
         env:
-          PR_NUM: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ github.token }}
+          PR_NUM: "${{ github.event.issue.number }}"
+          GH_TOKEN: "${{ github.token }}"
       - name: Install Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
@@ -97,12 +97,12 @@ jobs:
           # workflows to run, so any commits it pushes will be stuck in limbo forever waiting
           # for workflows to run that will never run. To workaround this, we use an SSH key
           # instead. It's a GitHub deploy key so it's scoped only to this repository.
-          ssh-key: ${{ secrets.FORMAT_PR_DEPLOY_KEY }}
+          ssh-key: "${{ secrets.FORMAT_PR_DEPLOY_KEY }}"
       - name: Checkout pull request
         run: gh pr checkout "$PR_NUM"
         env:
-          PR_NUM: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ github.token }}
+          PR_NUM: "${{ github.event.issue.number }}"
+          GH_TOKEN: "${{ github.token }}"
       - name: Download formatted code
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -5,6 +5,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   # Handling workflow_dispatch is simple. Just checkout whatever branch it was run on.
   # The workflow will run in that repository's context and thus can safely get write permissions.
@@ -54,7 +56,6 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.user.id == github.event.issue.user.id
       )
-    permissions: {}
     steps:
       - name: Checkout upstream
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -86,8 +87,6 @@ jobs:
   comment-push:
     runs-on: ubuntu-latest
     needs: comment-format-untrusted
-    permissions:
-      contents: write
     steps:
       - name: Checkout upstream
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           # Credentials needed for pushing changes at the end.
           # This is already the default, but for safety we are being explicit about this.
+          # Commits made by workflow_dispatch trigger will trigger new workflows to run,
+          # so don't need to use SSH deploy key.
           persist-credentials: true
       - name: Install Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
@@ -91,8 +93,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: TurboWarp/extensions
-          # Credentials needed at the end to do the push.
-          persist-credentials: true
+          # Commits made using the default token in an issue_comment trigger won't cause more
+          # workflows to run, so any commits it pushes will be stuck in limbo forever waiting
+          # for workflows to run that will never run. To workaround this, we use an SSH key
+          # instead. It's a GitHub deploy key so it's scoped only to this repository.
+          ssh-key: ${{ secrets.FORMAT_PR_DEPLOY_KEY }}
       - name: Checkout pull request
         run: gh pr checkout "$PR_NUM"
         env:

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           # Credentials needed for pushing changes at the end.
           # This is already the default, but for safety we are being explicit about this.
+          persist-credentials: true
           # Commits made by workflow_dispatch trigger will trigger new workflows to run,
           # so don't need to use SSH deploy key.
-          persist-credentials: true
       - name: Install Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
@@ -97,6 +97,9 @@ jobs:
           # for workflows to run that will never run. To workaround this, we use an SSH key
           # instead. It's a GitHub deploy key so it's scoped only to this repository.
           ssh-key: "${{ secrets.FORMAT_PR_DEPLOY_KEY }}"
+          # Credentials needed for pushing changes at the end.
+          # This is already the default, but for safety we are being explicit about this.
+          persist-credentials: true
       - name: Checkout pull request
         run: gh pr checkout "$PR_NUM"
         env:


### PR DESCRIPTION
Commits pushed by the default token will not cause more workflows to run, so its commits are left in limbo forever.

FORMAT_PR_DEPLOY_KEY is an SSH key I generated. The only copy of its private key is in github actions secrets.