### PR TITLE
Use a service account PAT for format workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # Credentials needed for pushing changes at the end.
-          # This is already the default, but for safety we are being explicit about this.
+          # This is already the default, but it's good to be explicit about this.
           persist-credentials: true
           # Commits made by workflow_dispatch trigger will trigger new workflows to run,
           # so don't need to use SSH deploy key.
@@ -101,7 +101,7 @@ jobs:
           # @DangoCat account.
           token: "${{ secrets.FORMAT_PR_GH_TOKEN }}"
           # Credentials needed for pushing changes at the end.
-          # This is already the default, but for safety we are being explicit about this.
+          # This is already the default, but it's good to be explicit about this.
           persist-credentials: true
       - name: Checkout pull request
         run: gh pr checkout "$PR_NUM"

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
+          # Commits made by workflow_dispatch trigger can trigger new workflows to run,
+          # so just use the default workflow token.
           # Credentials needed for pushing changes at the end.
           # This is already the default, but it's good to be explicit about this.
           persist-credentials: true
-          # Commits made by workflow_dispatch trigger will trigger new workflows to run,
-          # so don't need to use SSH deploy key.
       - name: Install Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -92,11 +92,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: TurboWarp/extensions
-          # Commits made using the default token in an issue_comment trigger won't cause more
-          # workflows to run, so any commits it pushes will be stuck in limbo forever waiting
-          # for workflows to run that will never run. To workaround this, we use an SSH key
-          # instead. It's a GitHub deploy key so it's scoped only to this repository.
-          ssh-key: "${{ secrets.FORMAT_PR_DEPLOY_KEY }}"
+          # Can't use the default workflow token because commits made by it won't cause more
+          # workflows to un, so any commits it pushes get stuck in limbo waiting for workflows
+          # to run that will never run.
+          # Can't use a deploy key because it won't be able to access the fork that the pull
+          # request is coming from.
+          # Thus we use a manually created fine-grained personal access token under the
+          # @DangoCat account.
+          token: "${{ secrets.FORMAT_PR_GH_TOKEN }}"
           # Credentials needed for pushing changes at the end.
           # This is already the default, but for safety we are being explicit about this.
           persist-credentials: true


### PR DESCRIPTION
Deploy key's write access is limited to TurboWarp/extensions, can't touch forks. Instead it now uses a PAT which I've tested to have the necessary permissions

Comment explains why the default workflow token isn't sufficient.