### PR TITLE
More legible text on colored buttons

### DIFF
--- a/development/homepage-template.ejs
+++ b/development/homepage-template.ejs
@@ -158,14 +158,15 @@
         backdrop-filter: blur(0.6px);
       }
       .extension-buttons > * {
-        padding: 0.5rem;
         background-color: #4c97ff;
+        padding: 0.5rem;
         border-radius: 0.5rem;
         border: none;
         font: inherit;
         cursor: pointer;
         color: white;
         text-decoration: none;
+        text-shadow: 0 0 4px #0003;
         pointer-events: auto;
         transition: filter 0.15s;
         filter: drop-shadow(0px 1px 3px #00000075);
@@ -185,11 +186,11 @@
         color: white;
       }
       .extension-buttons .docs {
-        background-color: #FFAB19;
+        background-color: #f69925;
         color: white;
       }
       .extension-buttons .sample {
-        background-color: #40BF4A;
+        background-color: #3ebb48;
         color: white;
       }
       .extension-buttons :disabled {


### PR DESCRIPTION
This just changes the colors of a few buttons and adds a faint shadow to the text on those buttons to make it easier to read the text.

Before/after:
![Before vs after extension buttons](https://github.com/user-attachments/assets/c2b0f7e2-e18b-43c9-9856-3d132e5241a1)
