### PR TITLE
Create iframeplus.js

### DIFF
--- a/extensions/kilgorezer/iframeplus.js
+++ b/extensions/kilgorezer/iframeplus.js
@@ -1,0 +1,6 @@
+// This is a loader that automatically loads the extension from GitHub.
+(async function(Scratch) {
+  'use strict';
+  var code = await (await Scratch.fetch('https://raw.githubusercontent.com/kilgorezer/turbowarpIframeplus/main/iframeplus.js')).text();
+  code.constructor.constructor(code)();
+})(Scratch)


### PR DESCRIPTION
iframe+ is an extension that adds to the iframe extension
wiki: https://github.com/kilgorezer/turbowarpIframeplus/wiki