### PR TITLE
veggiecan/mobilekeyboard: a couple changes

### DIFF
--- a/extensions/veggiecan/mobilekeyboard.js
+++ b/extensions/veggiecan/mobilekeyboard.js
@@ -36,6 +36,10 @@
         name: Scratch.translate("Mobile Keyboard"),
         blocks: [
           {
+            blockType: Scratch.BlockType.LABEL,
+            text: Scratch.translate("Currently only works on Android"),
+          },
+          {
             opcode: "showKeyboardBlock",
             blockType: Scratch.BlockType.COMMAND,
             text: Scratch.translate("show [TYPE] keyboard"),

--- a/extensions/veggiecan/mobilekeyboard.js
+++ b/extensions/veggiecan/mobilekeyboard.js
@@ -19,7 +19,8 @@
   class MobileKeyboard {
     constructor() {
       this.keyboardOpen = false;
-      this.waitCallback = null;
+      /** @type {Array<() => void>} */
+      this.waitCallbacks = [];
       this.defaultValue = "";
       this.inputElement = null;
     }
@@ -207,10 +208,10 @@
           input.parentNode.removeChild(input);
         }
 
-        if (this.waitCallback) {
-          this.waitCallback();
-          this.waitCallback = null;
+        for (const callback of this.waitCallbacks) {
+          callback();
         }
+        this.waitCallbacks.length = 0;
       };
 
       input.addEventListener("input", () => {
@@ -236,7 +237,7 @@
 
     showKeyboardAndWaitBlock(args) {
       return new Promise((resolve) => {
-        this.waitCallback = resolve;
+        this.waitCallbacks.push(() => resolve());
         this.showKeyboard(args.TYPE);
       });
     }


### PR DESCRIPTION
 - Fix "show keyboard and wait"  getting stuck forever if run more than once concurrently (may have other problems still)
 - Add note that it only works on Android
