### PR TITLE
0832/rxFS: fix delete block, hide search block

### DIFF
--- a/extensions/0832/rxFS.js
+++ b/extensions/0832/rxFS.js
@@ -149,6 +149,7 @@
           {
             blockIconURI: file,
             opcode: "search",
+            hideFromPalette: true,
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("search [STR]"),
             arguments: {

--- a/extensions/0832/rxFS.js
+++ b/extensions/0832/rxFS.js
@@ -200,8 +200,11 @@
 
     del({ STR }) {
       str = btoa(unescape(encodeURIComponent(STR)));
-      rxFSfi[rxFSsy.indexOf(str) + 1 - 1] = undefined;
-      rxFSsy[rxFSsy.indexOf(str) + 1 - 1] = undefined;
+      const index = rxFSsy.indexOf(str);
+      if (index !== -1) {
+        rxFSfi.splice(index, 1);
+        rxFSsy.splice(index, 1);
+      }
     }
 
     file({ STR, STR2 }) {

--- a/extensions/0832/rxFS2.js
+++ b/extensions/0832/rxFS2.js
@@ -225,8 +225,11 @@
 
     del({ STR }) {
       str = encodeURIComponent(STR);
-      rxFSfi[rxFSsy.indexOf(str) + 1 - 1] = undefined;
-      rxFSsy[rxFSsy.indexOf(str) + 1 - 1] = undefined;
+      const index = rxFSsy.indexOf(str);
+      if (index !== -1) {
+        rxFSfi.splice(index, 1);
+        rxFSsy.splice(index, 1);
+      }
     }
 
     folder({ STR, STR2 }) {

--- a/extensions/0832/rxFS2.js
+++ b/extensions/0832/rxFS2.js
@@ -180,6 +180,7 @@
           {
             blockIconURI: folder,
             opcode: "search",
+            hideFromPalette: true,
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate({ id: "search", default: "search [STR]" }),
             arguments: {

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -76,7 +76,6 @@
   "CST1229/zip",
   "CST1229/images",
   "TheShovel/LZ-String",
-  "0832/rxFS2",
   "NexusKitten/sgrab",
   "NOname-awa/graphics2d",
   "NOname-awa/more-comparisons",

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -76,6 +76,7 @@
   "CST1229/zip",
   "CST1229/images",
   "TheShovel/LZ-String",
+  "0832/rxFS2",
   "NexusKitten/sgrab",
   "NOname-awa/graphics2d",
   "NOname-awa/more-comparisons",


### PR DESCRIPTION
 - Delete blocks leave holes in the arrays, breaking other blocks
 - The search block has been broken this entire time (`.indexOf(...) == undefined` is always false). It's not clear what it's even supposed to do, so just hide it.
