### PR TITLE
ESLint update

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,6 @@ build
 images
 licenses
 website
-eslint.config.js
 *.json
 *.yml
 *.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -192,6 +192,14 @@ module.exports = [
           message: 'Do not call Scratch.translate.setup() yourself. Just use Scratch.translate() and let the build script handle it.'
         },
         {
+          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]',
+          message: 'Extension name should be translated'
+        },
+        {
+          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]',
+          message: 'Block text should be translated'
+        },
+        {
           selector: 'MethodDefinition[key.name=getInfo] Property[key.name=id][value.callee.property.name=translate]',
           message: 'Do not translate extension ID'
         },
@@ -206,6 +214,14 @@ module.exports = [
         {
           selector: 'MemberExpression[object.name=window][property.name=vm]',
           message: 'Use Scratch.vm instead of window.vm'
+        },
+        {
+          selector: 'VariableDeclarator[init.type=MemberExpression][init.object.name=Scratch][init.property.name=translate]',
+          message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
+        },
+        {
+          selector: 'AssignmentExpression[right.type=MemberExpression][right.object.name=Scratch][right.property.name=translate]',
+          message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
         }
       ]
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,31 @@
 const js = require('@eslint/js');
 const globals = require('globals');
+const esquery = require("esquery");
+
+const reportQueryMatches = (context, ast, selector, message) => {
+  const parsedSelector = esquery.parse(selector);
+  const matches = esquery.match(ast, parsedSelector);
+  for (const match of matches) {
+    context.report({
+      node: match,
+      message,
+    });
+  }
+};
+
+/**
+ * Allows creating new rules using same lgoic as ESLint no-restricted-syntax.
+ * @param {Array<{selector: string; message: string;}>} rules
+ */
+const createQueryRule = (rules) => ({
+  create: (context) => ({
+    Program: (node) => {
+      for (const rule of rules) {
+        reportQueryMatches(context, node, rule.selector, rule.message);
+      }
+    }
+  })
+});
 
 module.exports = [
   // Base on eslint recommended
@@ -97,6 +123,148 @@ module.exports = [
         scaffolding: 'readonly'
       }
     },
+    plugins: {
+      extension: {
+        rules: {
+          "no-new-syntax": createQueryRule([
+            {
+              selector: 'AssignmentExpression[operator="??="]',
+              message: 'x ??= y syntax is too new; use x = x ?? y intead'
+            },
+            {
+              selector: 'MemberExpression[object.name=Object][property.name=hasOwn]',
+              message: 'Object.hasOwn(...) is too new; use Object.prototype.hasOwnProperty.call(...) instead'
+            },
+          ]),
+          "no-xmlhttprequest": createQueryRule([
+            {
+              selector: 'NewExpression[callee.name=XMLHttpRequest]',
+              message: 'Use Scratch.fetch() instead of XMLHttpRequest'
+            },
+          ]),
+          "iife": createQueryRule([
+            {
+              selector: 'Program > :not(ExpressionStatement[expression.type=CallExpression][expression.callee.type=/FunctionExpression/])',
+              message: 'All extension code must be within (function (Scratch) { ... })(Scratch);'
+            },
+          ]),
+          "use-scratch-vm": createQueryRule([
+            {
+              selector: 'MemberExpression[object.name=window][property.name=vm]',
+              message: 'Use Scratch.vm instead of window.vm'
+            },
+          ]),
+          "use-scratch-fetch": createQueryRule([
+            {
+              selector: 'CallExpression[callee.name=fetch]',
+              message: 'Use Scratch.fetch() instead of fetch()'
+            },
+            {
+              selector: 'CallExpression[callee.object.name=window][callee.property.name=fetch]',
+              message: 'Use Scratch.fetch() instead of window.fetch()'
+            },
+          ]),
+          "use-scratch-open-window": createQueryRule([
+            {
+              selector: 'CallExpression[callee.name=open]',
+              message: 'Use Scratch.openWindow() instead of open()'
+            },
+            {
+              selector: 'CallExpression[callee.object.name=window][callee.property.name=open]',
+              message: 'Use Scratch.openWindow() instead of window.open()'
+            },
+          ]),
+          "use-scratch-redirect": createQueryRule([
+            {
+              selector: 'AssignmentExpression[left.object.name=location][left.property.name=href]',
+              message: 'Use Scratch.redirect() instead of location.href = ...'
+            },
+            {
+              selector: 'AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]',
+              message: 'Use Scratch.redirect() instead of window.location.href = ...'
+            },
+            {
+              selector: 'AssignmentExpression[left.name=location]',
+              message: 'Use Scratch.redirect() instead of location = ...'
+            },
+            {
+              selector: 'AssignmentExpression[left.object.name=window][left.property.name=location]',
+              message: 'Use Scratch.redirect() instead of window.location = ...'
+            },
+            {
+              selector: 'CallExpression[callee.object.name=location][callee.property.name=assign]',
+              message: 'Use Scratch.redirect() instead of location.assign()'
+            },
+            {
+              selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]',
+              message: 'Use Scratch.redirect() instead of window.location.assign()'
+            },
+            {
+              selector: 'CallExpression[callee.object.name=location][callee.property.name=replace]',
+              message: 'Use Scratch.redirect() instead of location.replace()'
+            },
+            {
+              selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]',
+              message: 'Use Scratch.redirect() instead of window.location.replace()'
+            },
+          ]),
+          "check-can-fetch": createQueryRule([
+            {
+              selector: 'NewExpression[callee.name=WebSocket]',
+              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+            },
+            {
+              selector: 'NewExpression[callee.name=Image]',
+              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+            },
+            {
+              selector: 'NewExpression[callee.name=Audio]',
+              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+            },
+          ]),
+          "no-translate-setup": createQueryRule([
+            {
+              selector: 'CallExpression[callee.object.object.name=Scratch][callee.object.property.name=translate][callee.property.name=setup]',
+              message: 'Do not call Scratch.translate.setup() yourself. Just use Scratch.translate() and let the build script handle it'
+            },
+          ]),
+          "no-translate-alias": createQueryRule([
+            {
+              selector: 'VariableDeclarator[init.type=MemberExpression][init.object.name=Scratch][init.property.name=translate]',
+              message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
+            },
+            {
+              selector: 'AssignmentExpression[right.type=MemberExpression][right.object.name=Scratch][right.property.name=translate]',
+              message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
+            }
+          ]),
+          "should-translate": createQueryRule([
+            {
+              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]',
+              message: 'Extension name should be translated'
+            },
+            {
+              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]',
+              message: 'Block text should be translated'
+            },
+          ]),
+          "should-not-translate": createQueryRule([
+            {
+              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=id][value.callee.property.name=translate]',
+              message: 'Do not translate extension ID'
+            },
+            {
+              selector: 'MethodDefinition[key.name=docsURI] Property[key.name=id][value.callee.property.name=translate]',
+              message: 'Do not translate docsURI'
+            },
+            {
+              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=opcode][value.callee.property.name=translate]',
+              message: 'Do not translate block opcode'
+            },
+          ])
+        }
+      }
+    },
     rules: {
       // Require each extension to use strict mode
       'strict': ['error', 'function'],
@@ -109,121 +277,18 @@ module.exports = [
           message: 'Use Scratch.vm instead of the global vm object. You also can use const vm = Scratch.vm;'
         }
       ],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'AssignmentExpression[operator="??="]',
-          message: 'x ??= y syntax is too new; use x = x ?? y intead'
-        },
-        {
-          selector: 'MemberExpression[object.name=Object][property.name=hasOwn]',
-          message: 'Object.hasOwn(...) is too new; use Object.prototype.hasOwnProperty.call(...) instead'
-        },
-        {
-          selector: 'CallExpression[callee.name=fetch]',
-          message: 'Use Scratch.fetch() instead of fetch()'
-        },
-        {
-          selector: 'CallExpression[callee.object.name=window][callee.property.name=fetch]',
-          message: 'Use Scratch.fetch() instead of window.fetch()'
-        },
-        {
-          selector: 'CallExpression[callee.name=open]',
-          message: 'Use Scratch.openWindow() instead of open()'
-        },
-        {
-          selector: 'CallExpression[callee.object.name=window][callee.property.name=open]',
-          message: 'Use Scratch.openWindow() instead of window.open()'
-        },
-        {
-          selector: 'AssignmentExpression[left.object.name=location][left.property.name=href]',
-          message: 'Use Scratch.redirect() instead of location.href = ...'
-        },
-        {
-          selector: 'AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]',
-          message: 'Use Scratch.redirect() instead of window.location.href = ...'
-        },
-        {
-          selector: 'AssignmentExpression[left.name=location]',
-          message: 'Use Scratch.redirect() instead of location = ...'
-        },
-        {
-          selector: 'AssignmentExpression[left.object.name=window][left.property.name=location]',
-          message: 'Use Scratch.redirect() instead of window.location = ...'
-        },
-        {
-          selector: 'CallExpression[callee.object.name=location][callee.property.name=assign]',
-          message: 'Use Scratch.redirect() instead of location.assign()'
-        },
-        {
-          selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]',
-          message: 'Use Scratch.redirect() instead of window.location.assign()'
-        },
-        {
-          selector: 'CallExpression[callee.object.name=location][callee.property.name=replace]',
-          message: 'Use Scratch.redirect() instead of location.replace()'
-        },
-        {
-          selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]',
-          message: 'Use Scratch.redirect() instead of window.location.replace()'
-        },
-        {
-          selector: 'NewExpression[callee.name=XMLHttpRequest]',
-          message: 'Use Scratch.fetch() instead of XMLHttpRequest'
-        },
-        {
-          selector: 'NewExpression[callee.name=WebSocket]',
-          message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-        },
-        {
-          selector: 'NewExpression[callee.name=Image]',
-          message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-        },
-        {
-          selector: 'NewExpression[callee.name=Audio]',
-          message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
-        },
-        {
-          selector: 'Program > :not(ExpressionStatement[expression.type=CallExpression][expression.callee.type=/FunctionExpression/])',
-          message: 'All extension code must be within (function (Scratch) { ... })(Scratch);'
-        },
-        {
-          selector: 'CallExpression[callee.object.object.name=Scratch][callee.object.property.name=translate][callee.property.name=setup]',
-          message: 'Do not call Scratch.translate.setup() yourself. Just use Scratch.translate() and let the build script handle it.'
-        },
-        {
-          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]',
-          message: 'Extension name should be translated'
-        },
-        {
-          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]',
-          message: 'Block text should be translated'
-        },
-        {
-          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=id][value.callee.property.name=translate]',
-          message: 'Do not translate extension ID'
-        },
-        {
-          selector: 'MethodDefinition[key.name=docsURI] Property[key.name=id][value.callee.property.name=translate]',
-          message: 'Do not translate docsURI'
-        },
-        {
-          selector: 'MethodDefinition[key.name=getInfo] Property[key.name=opcode][value.callee.property.name=translate]',
-          message: 'Do not translate block opcode'
-        },
-        {
-          selector: 'MemberExpression[object.name=window][property.name=vm]',
-          message: 'Use Scratch.vm instead of window.vm'
-        },
-        {
-          selector: 'VariableDeclarator[init.type=MemberExpression][init.object.name=Scratch][init.property.name=translate]',
-          message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
-        },
-        {
-          selector: 'AssignmentExpression[right.type=MemberExpression][right.object.name=Scratch][right.property.name=translate]',
-          message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
-        }
-      ]
+      'extension/no-new-syntax': 'error',
+      'extension/no-xmlhttprequest': 'error',
+      'extension/iife': 'error',
+      'extension/use-scratch-vm': 'error',
+      'extension/use-scratch-fetch': 'error',
+      'extension/use-scratch-open-window': 'error',
+      'extension/use-scratch-redirect': 'error',
+      'extension/check-can-fetch': 'error',
+      'extension/no-translate-setup': 'error',
+      'extension/no-translate-alias': 'error',
+      'extension/should-translate': 'error',
+      'extension/should-not-translate': 'error'
     }
   }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
-const js = require('@eslint/js');
-const globals = require('globals');
+const js = require("@eslint/js");
+const globals = require("globals");
 const esquery = require("esquery");
 
 const reportQueryMatches = (context, ast, selector, message) => {
@@ -23,8 +23,8 @@ const createQueryRule = (rules) => ({
       for (const rule of rules) {
         reportQueryMatches(context, node, rule.selector, rule.message);
       }
-    }
-  })
+    },
+  }),
 });
 
 module.exports = [
@@ -35,93 +35,87 @@ module.exports = [
   {
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: 'commonjs'
+      sourceType: "commonjs",
     },
     rules: {
       // Unused variables commonly indicate logic errors
-      'no-unused-vars': [
-        'error',
+      "no-unused-vars": [
+        "error",
         {
           // Unused arguments are useful, eg. it can be nice for blocks to accept `args` even if they don't use it
-          args: 'none',
+          args: "none",
           // Allow silently eating try { } catch (e) { }
-          caughtErrors: 'none',
+          caughtErrors: "none",
           // Variables starting with _ are intentionally unused
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-        }
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
       ],
       // Allow while (true) { }
-      'no-constant-condition': [
-        'error',
+      "no-constant-condition": [
+        "error",
         {
-          checkLoops: false
-        }
+          checkLoops: false,
+        },
       ],
       // Allow empty catch {} blocks
-      'no-empty': [
-        'error',
+      "no-empty": [
+        "error",
         {
-          allowEmptyCatch: true
-        }
+          allowEmptyCatch: true,
+        },
       ],
       // Returning a value from a constructor() implies a mistake
-      'no-constructor-return': 'error',
+      "no-constructor-return": "error",
       // new Promise(async () => {}) implies a mistake
-      'no-async-promise-executor': 'warn',
+      "no-async-promise-executor": "warn",
       // x === x implies a mistake
-      'no-self-compare': 'error',
+      "no-self-compare": "error",
       // Using ${...} in a non-template-string implies a mistake
-      'no-template-curly-in-string': 'error',
+      "no-template-curly-in-string": "error",
       // Loops that only iterate once imply a mistake
-      'no-unreachable-loop': 'error',
+      "no-unreachable-loop": "error",
       // Detect some untrusted code execution
-      'no-eval': 'error',
-      'no-implied-eval': 'error',
-      'no-new-func': 'error',
-      'no-script-url': 'error',
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-new-func": "error",
+      "no-script-url": "error",
       // Combinations of || and && are unreadable and may not do what you expect
-      'no-mixed-operators': [
-        'error',
+      "no-mixed-operators": [
+        "error",
         {
-          groups: [
-            ['&&', '||']
-          ]
-        }
+          groups: [["&&", "||"]],
+        },
       ],
       // Disallow async functions that don't need to be. This is important as a Promise and non-Promise return value
       // significantly impacts the behavior of projects.
-      'require-await': 'error'
-    }
+      "require-await": "error",
+    },
   },
 
   // For development server
   {
-    files: [
-      'development/**'
-    ],
+    files: ["development/**"],
     languageOptions: {
       globals: {
         ...globals.commonjs,
-        ...globals.node
-      }
-    }
+        ...globals.node,
+      },
+    },
   },
 
   // For extensions
   {
-    files: [
-      'extensions/**'
-    ],
+    files: ["extensions/**"],
     languageOptions: {
       globals: {
         ...globals.browser,
-        Blockly: 'readonly',
-        Scratch: 'readonly',
-        ScratchBlocks: 'readonly',
-        ScratchExtensions: 'readonly',
-        scaffolding: 'readonly'
-      }
+        Blockly: "readonly",
+        Scratch: "readonly",
+        ScratchBlocks: "readonly",
+        ScratchExtensions: "readonly",
+        scaffolding: "readonly",
+      },
     },
     plugins: {
       extension: {
@@ -129,166 +123,199 @@ module.exports = [
           "no-new-syntax": createQueryRule([
             {
               selector: 'AssignmentExpression[operator="??="]',
-              message: 'x ??= y syntax is too new; use x = x ?? y intead'
+              message: "x ??= y syntax is too new; use x = x ?? y intead",
             },
             {
-              selector: 'MemberExpression[object.name=Object][property.name=hasOwn]',
-              message: 'Object.hasOwn(...) is too new; use Object.prototype.hasOwnProperty.call(...) instead'
+              selector:
+                "MemberExpression[object.name=Object][property.name=hasOwn]",
+              message:
+                "Object.hasOwn(...) is too new; use Object.prototype.hasOwnProperty.call(...) instead",
             },
           ]),
           "no-xmlhttprequest": createQueryRule([
             {
-              selector: 'NewExpression[callee.name=XMLHttpRequest]',
-              message: 'Use Scratch.fetch() instead of XMLHttpRequest'
+              selector: "NewExpression[callee.name=XMLHttpRequest]",
+              message: "Use Scratch.fetch() instead of XMLHttpRequest",
             },
           ]),
-          "iife": createQueryRule([
+          iife: createQueryRule([
             {
-              selector: 'Program > :not(ExpressionStatement[expression.type=CallExpression][expression.callee.type=/FunctionExpression/])',
-              message: 'All extension code must be within (function (Scratch) { ... })(Scratch);'
+              selector:
+                "Program > :not(ExpressionStatement[expression.type=CallExpression][expression.callee.type=/FunctionExpression/])",
+              message:
+                "All extension code must be within (function (Scratch) { ... })(Scratch);",
             },
           ]),
           "use-scratch-vm": createQueryRule([
             {
-              selector: 'MemberExpression[object.name=window][property.name=vm]',
-              message: 'Use Scratch.vm instead of window.vm'
+              selector:
+                "MemberExpression[object.name=window][property.name=vm]",
+              message: "Use Scratch.vm instead of window.vm",
             },
           ]),
           "use-scratch-fetch": createQueryRule([
             {
-              selector: 'CallExpression[callee.name=fetch]',
-              message: 'Use Scratch.fetch() instead of fetch()'
+              selector: "CallExpression[callee.name=fetch]",
+              message: "Use Scratch.fetch() instead of fetch()",
             },
             {
-              selector: 'CallExpression[callee.object.name=window][callee.property.name=fetch]',
-              message: 'Use Scratch.fetch() instead of window.fetch()'
+              selector:
+                "CallExpression[callee.object.name=window][callee.property.name=fetch]",
+              message: "Use Scratch.fetch() instead of window.fetch()",
             },
           ]),
           "use-scratch-open-window": createQueryRule([
             {
-              selector: 'CallExpression[callee.name=open]',
-              message: 'Use Scratch.openWindow() instead of open()'
+              selector: "CallExpression[callee.name=open]",
+              message: "Use Scratch.openWindow() instead of open()",
             },
             {
-              selector: 'CallExpression[callee.object.name=window][callee.property.name=open]',
-              message: 'Use Scratch.openWindow() instead of window.open()'
+              selector:
+                "CallExpression[callee.object.name=window][callee.property.name=open]",
+              message: "Use Scratch.openWindow() instead of window.open()",
             },
           ]),
           "use-scratch-redirect": createQueryRule([
             {
-              selector: 'AssignmentExpression[left.object.name=location][left.property.name=href]',
-              message: 'Use Scratch.redirect() instead of location.href = ...'
+              selector:
+                "AssignmentExpression[left.object.name=location][left.property.name=href]",
+              message: "Use Scratch.redirect() instead of location.href = ...",
             },
             {
-              selector: 'AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]',
-              message: 'Use Scratch.redirect() instead of window.location.href = ...'
+              selector:
+                "AssignmentExpression[left.object.object.name=window][left.object.property.name=location][left.property.name=href]",
+              message:
+                "Use Scratch.redirect() instead of window.location.href = ...",
             },
             {
-              selector: 'AssignmentExpression[left.name=location]',
-              message: 'Use Scratch.redirect() instead of location = ...'
+              selector: "AssignmentExpression[left.name=location]",
+              message: "Use Scratch.redirect() instead of location = ...",
             },
             {
-              selector: 'AssignmentExpression[left.object.name=window][left.property.name=location]',
-              message: 'Use Scratch.redirect() instead of window.location = ...'
+              selector:
+                "AssignmentExpression[left.object.name=window][left.property.name=location]",
+              message:
+                "Use Scratch.redirect() instead of window.location = ...",
             },
             {
-              selector: 'CallExpression[callee.object.name=location][callee.property.name=assign]',
-              message: 'Use Scratch.redirect() instead of location.assign()'
+              selector:
+                "CallExpression[callee.object.name=location][callee.property.name=assign]",
+              message: "Use Scratch.redirect() instead of location.assign()",
             },
             {
-              selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]',
-              message: 'Use Scratch.redirect() instead of window.location.assign()'
+              selector:
+                "CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=assign]",
+              message:
+                "Use Scratch.redirect() instead of window.location.assign()",
             },
             {
-              selector: 'CallExpression[callee.object.name=location][callee.property.name=replace]',
-              message: 'Use Scratch.redirect() instead of location.replace()'
+              selector:
+                "CallExpression[callee.object.name=location][callee.property.name=replace]",
+              message: "Use Scratch.redirect() instead of location.replace()",
             },
             {
-              selector: 'CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]',
-              message: 'Use Scratch.redirect() instead of window.location.replace()'
+              selector:
+                "CallExpression[callee.object.object.name=window][callee.object.property.name=location][callee.property.name=replace]",
+              message:
+                "Use Scratch.redirect() instead of window.location.replace()",
             },
           ]),
           "check-can-fetch": createQueryRule([
             {
-              selector: 'NewExpression[callee.name=WebSocket]',
-              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+              selector: "NewExpression[callee.name=WebSocket]",
+              message:
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
             },
             {
-              selector: 'NewExpression[callee.name=Image]',
-              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+              selector: "NewExpression[callee.name=Image]",
+              message:
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
             },
             {
-              selector: 'NewExpression[callee.name=Audio]',
-              message: 'Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax'
+              selector: "NewExpression[callee.name=Audio]",
+              message:
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
             },
           ]),
           "no-translate-setup": createQueryRule([
             {
-              selector: 'CallExpression[callee.object.object.name=Scratch][callee.object.property.name=translate][callee.property.name=setup]',
-              message: 'Do not call Scratch.translate.setup() yourself. Just use Scratch.translate() and let the build script handle it'
+              selector:
+                "CallExpression[callee.object.object.name=Scratch][callee.object.property.name=translate][callee.property.name=setup]",
+              message:
+                "Do not call Scratch.translate.setup() yourself. Just use Scratch.translate() and let the build script handle it",
             },
           ]),
           "no-translate-alias": createQueryRule([
             {
-              selector: 'VariableDeclarator[init.type=MemberExpression][init.object.name=Scratch][init.property.name=translate]',
-              message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
+              selector:
+                "VariableDeclarator[init.type=MemberExpression][init.object.name=Scratch][init.property.name=translate]",
+              message:
+                "Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings",
             },
             {
-              selector: 'AssignmentExpression[right.type=MemberExpression][right.object.name=Scratch][right.property.name=translate]',
-              message: 'Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings'
-            }
+              selector:
+                "AssignmentExpression[right.type=MemberExpression][right.object.name=Scratch][right.property.name=translate]",
+              message:
+                "Do not store Scratch.translate in a variable as the build script will not be able to statically analyze the strings",
+            },
           ]),
           "should-translate": createQueryRule([
             {
-              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]',
-              message: 'Extension name should be translated'
+              selector:
+                "MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]",
+              message: "Extension name should be translated",
             },
             {
-              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]',
-              message: 'Block text should be translated'
+              selector:
+                "MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]",
+              message: "Block text should be translated",
             },
           ]),
           "should-not-translate": createQueryRule([
             {
-              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=id][value.callee.property.name=translate]',
-              message: 'Do not translate extension ID'
+              selector:
+                "MethodDefinition[key.name=getInfo] Property[key.name=id][value.callee.property.name=translate]",
+              message: "Do not translate extension ID",
             },
             {
-              selector: 'MethodDefinition[key.name=docsURI] Property[key.name=id][value.callee.property.name=translate]',
-              message: 'Do not translate docsURI'
+              selector:
+                "MethodDefinition[key.name=docsURI] Property[key.name=id][value.callee.property.name=translate]",
+              message: "Do not translate docsURI",
             },
             {
-              selector: 'MethodDefinition[key.name=getInfo] Property[key.name=opcode][value.callee.property.name=translate]',
-              message: 'Do not translate block opcode'
+              selector:
+                "MethodDefinition[key.name=getInfo] Property[key.name=opcode][value.callee.property.name=translate]",
+              message: "Do not translate block opcode",
             },
-          ])
-        }
-      }
+          ]),
+        },
+      },
     },
     rules: {
       // Require each extension to use strict mode
-      'strict': ['error', 'function'],
+      strict: ["error", "function"],
       // Disallow APIs that are replaced by Scratch.* APIs
       // This is not comprehensive, but it should be enough to prevent the most common ways for these to be written.
-      'no-restricted-globals': [
-        'error',
+      "no-restricted-globals": [
+        "error",
         {
-          name: 'vm',
-          message: 'Use Scratch.vm instead of the global vm object. You also can use const vm = Scratch.vm;'
-        }
+          name: "vm",
+          message:
+            "Use Scratch.vm instead of the global vm object. You also can use const vm = Scratch.vm;",
+        },
       ],
-      'extension/no-new-syntax': 'error',
-      'extension/no-xmlhttprequest': 'error',
-      'extension/iife': 'error',
-      'extension/use-scratch-vm': 'error',
-      'extension/use-scratch-fetch': 'error',
-      'extension/use-scratch-open-window': 'error',
-      'extension/use-scratch-redirect': 'error',
-      'extension/check-can-fetch': 'error',
-      'extension/no-translate-setup': 'error',
-      'extension/no-translate-alias': 'error',
-      'extension/should-translate': 'error',
-      'extension/should-not-translate': 'error'
-    }
-  }
+      "extension/no-new-syntax": "error",
+      "extension/no-xmlhttprequest": "error",
+      "extension/iife": "error",
+      "extension/use-scratch-vm": "error",
+      "extension/use-scratch-fetch": "error",
+      "extension/use-scratch-open-window": "error",
+      "extension/use-scratch-redirect": "error",
+      "extension/check-can-fetch": "error",
+      "extension/no-translate-setup": "error",
+      "extension/no-translate-alias": "error",
+      "extension/should-translate": "error",
+      "extension/should-not-translate": "error",
+    },
+  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ const reportQueryMatches = (context, ast, selector, message) => {
 };
 
 /**
- * Allows creating new rules using same lgoic as ESLint no-restricted-syntax.
+ * Allows creating custom rules that work similar to ESLint's no-restricted-syntax.
  * @param {Array<{selector: string; message: string;}>} rules
  */
 const createQueryRule = (rules) => ({
@@ -224,17 +224,17 @@ module.exports = [
             {
               selector: "NewExpression[callee.name=WebSocket]",
               message:
-                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line extension/check-can-fetch",
             },
             {
               selector: "NewExpression[callee.name=Image]",
               message:
-                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line extension/check-can-fetch",
             },
             {
               selector: "NewExpression[callee.name=Audio]",
               message:
-                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line no-restricted-syntax",
+                "Ensure that `await Scratch.canFetch(url)` is checked first, then add // eslint-disable-next-line extension/check-can-fetch",
             },
           ]),
           "no-translate-setup": createQueryRule([

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -263,12 +263,12 @@ module.exports = [
             {
               selector:
                 "MethodDefinition[key.name=getInfo] Property[key.name=name][value.type=Literal]",
-              message: "Extension name should be translated",
+              message: "Extension name should usually be translated",
             },
             {
               selector:
                 "MethodDefinition[key.name=getInfo] Property[key.name=blocks] Property[key.name=text][value.type=Literal]",
-              message: "Block text should be translated",
+              message: "Block text should usually be translated",
             },
           ]),
           "should-not-translate": createQueryRule([

--- a/extensions/0832/rxFS.js
+++ b/extensions/0832/rxFS.js
@@ -23,6 +23,7 @@
     getInfo() {
       return {
         id: "0832rxfs",
+        // eslint-disable-next-line extension/should-translate
         name: "rxFS",
         color1: "#2bdab7",
         blocks: [

--- a/extensions/0832/rxFS2.js
+++ b/extensions/0832/rxFS2.js
@@ -29,6 +29,7 @@
     getInfo() {
       return {
         id: "0832rxfs2",
+        // eslint-disable-next-line extension/should-translate
         name: "rxFS",
         color1: "#192d50",
         color2: "#192d50",

--- a/extensions/CST1229/images.js
+++ b/extensions/CST1229/images.js
@@ -234,7 +234,7 @@
           case "image/jpeg":
             {
               if (!(await Scratch.canFetch(IMAGEURL))) return;
-              // eslint-disable-next-line no-restricted-syntax
+              // eslint-disable-next-line extension/check-can-fetch
               const image = new Image();
               image.crossOrigin = "anonymous";
               image.src = IMAGEURL;

--- a/extensions/CST1229/zip.js
+++ b/extensions/CST1229/zip.js
@@ -264,7 +264,9 @@
           {
             opcode: "copyFileToArchive",
             blockType: Scratch.BlockType.COMMAND,
-            text: Scratch.translate("copy [FROM] in [FROMARCHIVE] to [TO] in [TOARCHIVE]"),
+            text: Scratch.translate(
+              "copy [FROM] in [FROMARCHIVE] to [TO] in [TOARCHIVE]"
+            ),
             arguments: {
               FROM: {
                 type: Scratch.ArgumentType.STRING,

--- a/extensions/CST1229/zip.js
+++ b/extensions/CST1229/zip.js
@@ -227,7 +227,7 @@
           {
             opcode: "renameFile",
             blockType: Scratch.BlockType.COMMAND,
-            text: "rename [FROM] to [TO]",
+            text: Scratch.translate("rename [FROM] to [TO]"),
             arguments: {
               FROM: {
                 type: Scratch.ArgumentType.STRING,
@@ -244,7 +244,7 @@
           {
             opcode: "copyFile",
             blockType: Scratch.BlockType.COMMAND,
-            text: "copy [FROM] to [TO]",
+            text: Scratch.translate("copy [FROM] to [TO]"),
             arguments: {
               FROM: {
                 type: Scratch.ArgumentType.STRING,
@@ -264,7 +264,7 @@
           {
             opcode: "copyFileToArchive",
             blockType: Scratch.BlockType.COMMAND,
-            text: "copy [FROM] in [FROMARCHIVE] to [TO] in [TOARCHIVE]",
+            text: Scratch.translate("copy [FROM] in [FROMARCHIVE] to [TO] in [TOARCHIVE]"),
             arguments: {
               FROM: {
                 type: Scratch.ArgumentType.STRING,

--- a/extensions/CubesterYT/TurboHook.js
+++ b/extensions/CubesterYT/TurboHook.js
@@ -46,6 +46,7 @@
           {
             opcode: "params",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[MENU] [DATA]",
             arguments: {
               MENU: {
@@ -60,6 +61,7 @@
           {
             opcode: "connector",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[STRING1] , [STRING2]",
           },
         ],

--- a/extensions/Lily/Cast.js
+++ b/extensions/Lily/Cast.js
@@ -13,7 +13,7 @@
     getInfo() {
       return {
         id: "lmsCast",
-        name: "Cast",
+        name: Scratch.translate("Cast"),
         blocks: [
           {
             opcode: "toType",

--- a/extensions/Lily/CommentBlocks.js
+++ b/extensions/Lily/CommentBlocks.js
@@ -20,6 +20,7 @@
         color2: "#c6be79",
         color3: "#a8a167",
         blocks: [
+          /* eslint-disable extension/should-translate */
           {
             opcode: "commentHat",
             blockType: Scratch.BlockType.HAT,
@@ -84,6 +85,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
         ],
       };
     }

--- a/extensions/Lily/McUtils.js
+++ b/extensions/Lily/McUtils.js
@@ -16,6 +16,7 @@
     getInfo() {
       return {
         id: "lmsmcutils",
+        // eslint-disable-next-line extension/should-translate
         name: "McUtils",
         color1: "#ec2020",
         color3: "#ffe427",
@@ -86,6 +87,7 @@
           {
             opcode: "grimaceBlock",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "🎂",
             extensions: ["colours_looks"],
             hideFromPalette: new Date().getMonth() !== 5,

--- a/extensions/Lily/Skins.js
+++ b/extensions/Lily/Skins.js
@@ -437,7 +437,7 @@
         contentType === "image/jpeg" ||
         contentType === "image/bmp"
       ) {
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line extension/check-can-fetch
         const output = new Image();
         output.src = URL;
         output.crossOrigin = "anonymous";

--- a/extensions/Lily/lmsutils.js
+++ b/extensions/Lily/lmsutils.js
@@ -72,6 +72,7 @@
           {
             opcode: "trueFalseBoolean",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[TRUEFALSE]",
             arguments: {
               TRUEFALSE: {
@@ -338,6 +339,7 @@
           {
             opcode: "stringReporter",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[STRING]",
             disableMonitor: true,
             hideFromPalette: hideLegacyBlocks,
@@ -409,6 +411,7 @@
           {
             opcode: "equalsExactly",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[ONE] === [TWO]",
             arguments: {
               ONE: {
@@ -424,6 +427,7 @@
           {
             opcode: "notEqualTo",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[INPUTA] ≠ [INPUTB]",
             arguments: {
               INPUTA: {
@@ -439,6 +443,7 @@
           {
             opcode: "moreThanEqual",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[INPUTA] ≥ [INPUTB]",
             arguments: {
               INPUTA: {
@@ -454,6 +459,7 @@
           {
             opcode: "lessThanEqual",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[INPUTA] ≤ [INPUTB]",
             arguments: {
               INPUTA: {
@@ -524,6 +530,7 @@
           {
             opcode: "negativeReporter",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "- [INPUT]",
             disableMonitor: true,
             arguments: {
@@ -536,6 +543,7 @@
           {
             opcode: "exponentBlock",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[INPUTA] ^ [INPUTB]",
             disableMonitor: true,
             arguments: {
@@ -552,6 +560,7 @@
           {
             opcode: "rootBlock",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[INPUTA] √ [INPUTB]",
             arguments: {
               INPUTA: {
@@ -883,6 +892,7 @@
 
           "---",
 
+          /* eslint-disable extension/should-translate */
           {
             opcode: "commentHat",
             blockType: Scratch.BlockType.HAT,
@@ -939,6 +949,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
 
           "---",
 

--- a/extensions/Medericoder/textcase.js
+++ b/extensions/Medericoder/textcase.js
@@ -244,6 +244,7 @@
           {
             opcode: "strictlyequal",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[TEXT1] ≡ [TEXT2]",
             arguments: {
               TEXT1: {
@@ -259,6 +260,7 @@
           {
             opcode: "quasiequal",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[TEXT1] ≈ [TEXT2]",
             arguments: {
               TEXT1: {

--- a/extensions/NOname-awa/cn-number.js
+++ b/extensions/NOname-awa/cn-number.js
@@ -16,7 +16,7 @@
             opcode: "CN_number",
             blockType: Scratch.BlockType.REPORTER,
             disableMonitor: true,
-            text: "convert [a] to chinese number using [u] numerals",
+            text: Scratch.translate("convert [a] to chinese number using [u] numerals"),
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,

--- a/extensions/NOname-awa/cn-number.js
+++ b/extensions/NOname-awa/cn-number.js
@@ -16,7 +16,9 @@
             opcode: "CN_number",
             blockType: Scratch.BlockType.REPORTER,
             disableMonitor: true,
-            text: Scratch.translate("convert [a] to chinese number using [u] numerals"),
+            text: Scratch.translate(
+              "convert [a] to chinese number using [u] numerals"
+            ),
             arguments: {
               a: {
                 type: Scratch.ArgumentType.NUMBER,

--- a/extensions/NOname-awa/graphics2d.js
+++ b/extensions/NOname-awa/graphics2d.js
@@ -97,6 +97,7 @@
           {
             opcode: "vertical",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[a] ⊥ [b]",
             arguments: {
               a: {

--- a/extensions/NOname-awa/math-and-string.js
+++ b/extensions/NOname-awa/math-and-string.js
@@ -9,6 +9,7 @@
         id: "nonameawamathandstring",
         name: Scratch.translate("Math And String"),
         blocks: [
+          /* eslint-disable extension/should-translate */
           {
             opcode: "exponent",
             blockType: Scratch.BlockType.REPORTER,
@@ -50,6 +51,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
           "---",
           {
             opcode: "astrict",
@@ -90,6 +92,7 @@
             },
           },
           "---",
+          /* eslint-disable extension/should-translate */
           {
             opcode: "boolean",
             blockType: Scratch.BlockType.BOOLEAN,
@@ -332,6 +335,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
           {
             opcode: "trim",
             blockType: Scratch.BlockType.REPORTER,
@@ -339,7 +343,7 @@
             arguments: {
               text: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: Scratch.translate("   Text   "),
+                defaultValue: `   ${Scratch.translate("Text")}   `,
               },
             },
           },
@@ -733,6 +737,7 @@
             text: Scratch.translate("false"),
             disableMonitor: true,
           },
+          /* eslint-disable extension/should-translate */
           {
             opcode: "new_line",
             disableMonitor: true,
@@ -763,6 +768,7 @@
             blockType: Scratch.BlockType.REPORTER,
             text: "∞",
           },
+          /* eslint-enable extension/should-translate */
         ],
         menus: {
           rd: {

--- a/extensions/NOname-awa/more-comparisons.js
+++ b/extensions/NOname-awa/more-comparisons.js
@@ -31,6 +31,7 @@
             arguments: {},
             disableMonitor: true,
           },
+          /* eslint-disable extension/should-translate */
           {
             opcode: "boolean",
             blockType: Scratch.BlockType.BOOLEAN,
@@ -432,6 +433,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
         ],
       };
     }

--- a/extensions/NOname-awa/regular-expression.js
+++ b/extensions/NOname-awa/regular-expression.js
@@ -110,6 +110,7 @@
           {
             opcode: "constant",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "[constant]",
             arguments: {
               constant: {
@@ -122,16 +123,19 @@
           {
             opcode: "text",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "a",
           },
           {
             opcode: "pattern",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "b",
           },
           {
             opcode: "attach",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "c",
           },
         ],

--- a/extensions/Skyhigh173/bigint.js
+++ b/extensions/Skyhigh173/bigint.js
@@ -57,6 +57,7 @@
         name: Scratch.translate("BigInt"),
         color1: "#59C093",
         blocks: [
+          /* eslint-disable extension/should-translate */
           {
             opcode: "from",
             blockType: Scratch.BlockType.REPORTER,
@@ -371,6 +372,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
         ],
         menus: {
           op: {

--- a/extensions/Skyhigh173/json.js
+++ b/extensions/Skyhigh173/json.js
@@ -24,6 +24,7 @@
     getInfo() {
       return {
         id: "skyhigh173JSON",
+        // eslint-disable-next-line extension/should-translate
         name: "JSON",
         color1: "#3271D0",
         blocks: [

--- a/extensions/TheShovel/CanvasEffects.js
+++ b/extensions/TheShovel/CanvasEffects.js
@@ -155,7 +155,7 @@
           {
             opcode: "cleareffects",
             blockType: Scratch.BlockType.COMMAND,
-            text: "clear canvas effects",
+            text: Scratch.translate("clear canvas effects"),
           },
           "---",
           {

--- a/extensions/TheShovel/ShovelUtils.js
+++ b/extensions/TheShovel/ShovelUtils.js
@@ -30,7 +30,7 @@
     getInfo() {
       return {
         id: "ShovelUtils",
-        name: "ShovelUtils",
+        name: Scratch.translate("ShovelUtils"),
         color1: "#f54242",
         color2: "#f54242",
         color3: "#f54242",

--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1485,7 +1485,7 @@ void main() {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line extension/check-can-fetch
     const image = new Image();
     image.src =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpUUqDnYQcchQneyiIo61FYpQIdQKrTqYvPQPmjQkKS6OgmvBwZ/FqoOLs64OroIg+APi7OCk6CIl3pcUWsT44PI+znvncN99gNCqMc3qSwCabpvZdFLMF1bF0CsEhAGqmMwsY16SMvBdX/cI8P0uzrP87/25BtWixYCASJxghmkTbxDPbtoG533iKKvIKvE58aRJDRI/cl3x+I1z2WWBZ0bNXDZFHCUWyz2s9DCrmBrxDHFM1XTKF/Ieq5y3OGu1Buv0yV8YKeory1ynGkMai1iCBBEKGqiiBhtx2nVSLGTpPOnjH3X9ErkUclXByLGAOjTIrh/8D37P1ipNT3lJkSTQ/+I4H+NAaBdoNx3n+9hx2idA8Bm40rv+eguY+yS92dViR8DQNnBx3dWUPeByBxh5MmRTdqUglVAqAe9n9E0FYPgWGFjz5tY5x+kDkKNZZW6Ag0NgokzZ6z7vDvfO7d87nfn9ACRZcoedT/mXAAAAGFBMVEVtbW11dXVtbf+EhIT/bW2goKBt/21t//8Qh6V7AAAACXBIWXMAABhMAAAYdAGfqEAgAAAAB3RJTUUH6AIIAA4YBFj9GAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAABjSURBVAjXPctBDkAwFIThqdey91ygnIAoa9EzcIBGLyDS69MW/26+ZIAvZYwhZkbpNy/saKGOyUjmFeQ2J5Z+SUJNFi+TfK+/uKJCtENbhT2gYO7UNT+ie03nfoLqV4os4X/dFf0TKILDS0AAAAAASUVORK5CYII=";
@@ -1843,7 +1843,7 @@ void main() {
       def: function () {
         // Exempted from Scratch.openWindow as initiated by user gesture.
         // docsURI won't ask for permission so it doesn't make sense for this to either.
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line extension/use-scratch-open-window
         window.open("https://xeltalliv.github.io/simple3d-extension/");
       },
     },
@@ -1859,7 +1859,7 @@ void main() {
         );
         // Exempted from Scratch.openWindow as it is in response to a user gesture and it does not
         // bring in third-party websites at all.
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line extension/use-scratch-open-window
         window.open(url.href);
       },
     },
@@ -3421,7 +3421,7 @@ void main() {
                 resolve(null);
                 return;
               }
-              // eslint-disable-next-line no-restricted-syntax
+              // eslint-disable-next-line extension/check-can-fetch
               const img = new Image();
               if (
                 new URL(TEXURL, window.location.href).origin !==
@@ -3468,7 +3468,7 @@ void main() {
           const costumeIndex = target.getCostumeIndexByName(NAME);
           if (costumeIndex == -1) return;
           const costume = target.sprite.costumes[costumeIndex];
-          // eslint-disable-next-line no-restricted-syntax
+          // eslint-disable-next-line extension/check-can-fetch
           const img = new Image();
           img.src = costume.asset.encodeDataURI();
           img.onload = function () {

--- a/extensions/XeroName/Deltatime.js
+++ b/extensions/XeroName/Deltatime.js
@@ -46,11 +46,13 @@
           {
             opcode: "dt",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "ΔT",
           },
           {
             opcode: "fps",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "fps",
           },
         ],

--- a/extensions/bitwise.js
+++ b/extensions/bitwise.js
@@ -80,6 +80,7 @@
             },
           },
           "---",
+          /* eslint-disable extension/should-translate */
           {
             opcode: "bitwiseRightShift",
             blockType: Scratch.BlockType.REPORTER,
@@ -155,6 +156,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
           "---",
           {
             opcode: "bitwiseAnd",

--- a/extensions/clouddata-ping.js
+++ b/extensions/clouddata-ping.js
@@ -34,7 +34,7 @@
     let ws;
     try {
       // Permission is checked earlier.
-      // eslint-disable-next-line no-restricted-syntax
+      // eslint-disable-next-line extension/check-can-fetch
       ws = new WebSocket(uri);
     } catch (e) {
       return {

--- a/extensions/docs-examples/unsandboxed/block-utility-examples.js
+++ b/extensions/docs-examples/unsandboxed/block-utility-examples.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/broadcast-1.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-1.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class Broadcast1 {

--- a/extensions/docs-examples/unsandboxed/broadcast-2.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-2.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class Broadcast2 {

--- a/extensions/docs-examples/unsandboxed/broadcast-3.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-3.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class Broadcast3 {

--- a/extensions/docs-examples/unsandboxed/broadcast-4.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-4.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class Broadcast4 {

--- a/extensions/docs-examples/unsandboxed/broadcast-5.js
+++ b/extensions/docs-examples/unsandboxed/broadcast-5.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class Broadcast5 {

--- a/extensions/docs-examples/unsandboxed/every-second.js
+++ b/extensions/docs-examples/unsandboxed/every-second.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
   class EverySecond {
@@ -18,7 +20,6 @@
   }
   // highlight-start
   setInterval(() => {
-    // eslint-disable-next-line no-unused-vars
     const startedThreads = Scratch.vm.runtime.startHats('everysecondexample_everySecond');
   }, 1000);
   // highlight-end

--- a/extensions/docs-examples/unsandboxed/hello-world-unsandboxed.js
+++ b/extensions/docs-examples/unsandboxed/hello-world-unsandboxed.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/turbo-mode.js
+++ b/extensions/docs-examples/unsandboxed/turbo-mode.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/when-key-pressed-restart.js
+++ b/extensions/docs-examples/unsandboxed/when-key-pressed-restart.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/when-key-pressed-stage.js
+++ b/extensions/docs-examples/unsandboxed/when-key-pressed-stage.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/when-key-pressed.js
+++ b/extensions/docs-examples/unsandboxed/when-key-pressed.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/when-space-key-pressed.js
+++ b/extensions/docs-examples/unsandboxed/when-space-key-pressed.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/docs-examples/unsandboxed/when.js
+++ b/extensions/docs-examples/unsandboxed/when.js
@@ -1,3 +1,5 @@
+/* eslint-disable -- passing the linting step requires content not covered when this is introduced */
+
 (function(Scratch) {
   'use strict';
 

--- a/extensions/fetch.js
+++ b/extensions/fetch.js
@@ -15,6 +15,7 @@
           {
             opcode: "get",
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate
             text: "GET [URL]",
             arguments: {
               URL: {

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -1394,6 +1394,7 @@
     getInfo() {
       return {
         id: "GameJoltAPI",
+        // eslint-disable-next-line extension/should-translate
         name: "Game Jolt API",
         color1: "#2F7F6F",
         color2: "#2A2731",
@@ -1577,6 +1578,7 @@
             opcode: "friendsFetch",
             blockIconURI: icons.user,
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate -- deprecated
             text: "fetched user's friend ID at index[index] (Deprecated)",
             arguments: {
               index: {
@@ -1642,6 +1644,7 @@
             opcode: "trophyFetch",
             blockIconURI: icons.trophy,
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate -- deprecated
             text: "fetched trophy [trophyDataType] at [indexOrID][value] (Deprecated)",
             arguments: {
               trophyDataType: {
@@ -2066,6 +2069,7 @@
             opcode: "dataStoreGetKey",
             blockIconURI: icons.store,
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate -- deprecated
             text: "fetched [globalOrPerUser] keys with pattern [pattern] at index [index] (Deprecated)",
             arguments: {
               globalOrPerUser: {
@@ -2142,6 +2146,7 @@
             opcode: "timeFetch",
             blockIconURI: icons.time,
             blockType: Scratch.BlockType.REPORTER,
+            // eslint-disable-next-line extension/should-translate -- deprecated
             text: "server's current [timeType] (Deprecated)",
             arguments: {
               timeType: {

--- a/extensions/gamejolt.js
+++ b/extensions/gamejolt.js
@@ -875,7 +875,7 @@
         }
 
         // canFetch() checked above
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line extension/no-xmlhttprequest
         var pRequest = new XMLHttpRequest();
 
         // bind callback function

--- a/extensions/godslayerakp/http.js
+++ b/extensions/godslayerakp/http.js
@@ -239,6 +239,7 @@
     getInfo() {
       return {
         id: extensionId,
+        // eslint-disable-next-line extension/should-translate
         name: "HTTP",
         color1: "#307eff",
         color2: "#2c5eb0",

--- a/extensions/godslayerakp/ws.js
+++ b/extensions/godslayerakp/ws.js
@@ -293,7 +293,7 @@
               }
 
               // canFetch() checked above
-              // eslint-disable-next-line no-restricted-syntax
+              // eslint-disable-next-line extension/check-can-fetch
               const websocket = new WebSocket(url);
               instance.websocket = websocket;
 

--- a/extensions/godslayerakp/ws.js
+++ b/extensions/godslayerakp/ws.js
@@ -103,6 +103,7 @@
     getInfo() {
       return {
         id: "gsaWebsocket",
+        // eslint-disable-next-line extension/should-translate
         name: "WebSocket",
         docsURI: "https://extensions.turbowarp.org/godslayerakp/ws",
         color1: "#307eff",

--- a/extensions/itchio.js
+++ b/extensions/itchio.js
@@ -71,6 +71,7 @@
     getInfo() {
       return {
         id: "itch",
+        // eslint-disable-next-line extension/should-translate
         name: "itch.io",
         menuIconURI: icon,
         blockIconURI: icon,

--- a/extensions/lab/text.js
+++ b/extensions/lab/text.js
@@ -836,7 +836,7 @@
           {
             opcode: "setOutlineWidth",
             blockType: Scratch.BlockType.COMMAND,
-            text: "set outline width to [WIDTH]",
+            text: Scratch.translate("set outline width to [WIDTH]"),
             hideFromPalette: compatibilityMode,
             arguments: {
               WIDTH: {
@@ -849,7 +849,7 @@
           {
             opcode: "setOutlineColor",
             blockType: Scratch.BlockType.COMMAND,
-            text: "set outline color to [COLOR]",
+            text: Scratch.translate("set outline color to [COLOR]"),
             hideFromPalette: compatibilityMode,
             arguments: {
               COLOR: {
@@ -1021,7 +1021,7 @@
           {
             opcode: "setShakeIntensity",
             blockType: Scratch.BlockType.COMMAND,
-            text: "set shake intensity to [NUM]%",
+            text: Scratch.translate("set shake intensity to [NUM]%"),
             hideFromPalette: compatibilityMode,
             arguments: {
               NUM: {

--- a/extensions/mbw/xml.js
+++ b/extensions/mbw/xml.js
@@ -51,6 +51,7 @@
     getInfo() {
       return {
         id: "mbwxml",
+        // eslint-disable-next-line extension/should-translate
         name: "XML",
         color1: "#6c2b5f",
         blocks: [

--- a/extensions/obviousAlexC/newgroundsIO.js
+++ b/extensions/obviousAlexC/newgroundsIO.js
@@ -9129,6 +9129,7 @@
     getInfo() {
       return {
         id: "NGIO",
+        // eslint-disable-next-line extension/should-translate
         name: "Newgrounds",
 
         color1: "#EB7522",

--- a/extensions/obviousAlexC/penPlus.js
+++ b/extensions/obviousAlexC/penPlus.js
@@ -887,7 +887,7 @@
               return;
             }
             // Permission is checked earlier.
-            // eslint-disable-next-line no-restricted-syntax
+            // eslint-disable-next-line extension/check-can-fetch
             const image = new Image();
             image.onload = function () {
               gl.bindTexture(gl.TEXTURE_2D, texture);

--- a/extensions/penplus.js
+++ b/extensions/penplus.js
@@ -2423,7 +2423,7 @@ Other various small fixes
     getInfo() {
       return {
         id: "betterpen",
-        name: "Pen+ V5",
+        name: Scratch.translate("Pen+ V5"),
         color1: "#0e9a6b",
         color2: "#0b7f58",
         color3: "#096647",

--- a/extensions/penplus.js
+++ b/extensions/penplus.js
@@ -1779,7 +1779,7 @@ Other various small fixes
         return;
       }
       // Permission is checked earlier.
-      // eslint-disable-next-line no-restricted-syntax
+      // eslint-disable-next-line extension/check-can-fetch
       const image = new Image();
       image.onload = function () {
         textureInfo.width = image.width;

--- a/extensions/rixxyx.js
+++ b/extensions/rixxyx.js
@@ -28,11 +28,13 @@
         color1: "#773c00",
         color2: "#5f3000",
         id: "RixxyX",
+        // eslint-disable-next-line extension/should-translate
         name: "RixxyX",
         blocks: [
           {
             opcode: "notEquals",
             blockType: Scratch.BlockType.BOOLEAN,
+            // eslint-disable-next-line extension/should-translate
             text: "[TEXT_1] != [TEXT_2]",
             arguments: {
               TEXT_1: {
@@ -308,7 +310,7 @@
           {
             opcode: "jsonParse",
             blockType: Scratch.BlockType.REPORTER,
-            text: "JSON.parse([TEXT])",
+            text: Scratch.translate("parse JSON [TEXT]"),
             arguments: {
               TEXT: {
                 type: Scratch.ArgumentType.STRING,
@@ -319,7 +321,8 @@
           {
             opcode: "returnENum",
             blockType: Scratch.BlockType.REPORTER,
-            text: "e", // e
+            // eslint-disable-next-line extension/should-translate
+            text: "e",
             arguments: {},
           },
           {

--- a/extensions/sound.js
+++ b/extensions/sound.js
@@ -16,7 +16,7 @@
   const fetchAsArrayBufferWithTimeout = (url) =>
     new Promise((resolve, reject) => {
       // Permission is checked in playSound()
-      // eslint-disable-next-line no-restricted-syntax
+      // eslint-disable-next-line extension/no-xmlhttprequest
       const xhr = new XMLHttpRequest();
       let timeout = setTimeout(() => {
         xhr.abort();
@@ -121,7 +121,7 @@
       // For these sounds, fall back to a primitive <audio>-based solution that will work for all
       // sounds, even those without CORS.
       // Permission is checked in playSound()
-      // eslint-disable-next-line no-restricted-syntax
+      // eslint-disable-next-line extension/check-can-fetch
       const mediaElement = new Audio(url);
 
       // Make a minimal effort to simulate Scratch's sound effects.

--- a/extensions/steamworks.js
+++ b/extensions/steamworks.js
@@ -15,6 +15,7 @@
     getInfo() {
       return {
         id: "steamworks",
+        // eslint-disable-next-line extension/should-translate
         name: "Steamworks",
         color1: "#136C9F",
         color2: "#105e8c",

--- a/extensions/true-fantom/couplers.js
+++ b/extensions/true-fantom/couplers.js
@@ -23,6 +23,7 @@
         menuIconURI: icon,
 
         blocks: [
+          /* eslint-disable extension/should-translate */
           {
             opcode: "value1_or_value2_block",
             blockType: Scratch.BlockType.REPORTER,
@@ -75,6 +76,7 @@
               },
             },
           },
+          /* eslint-enable extension/should-translate */
           {
             opcode: "true_block",
             blockType: Scratch.BlockType.BOOLEAN,

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -109,6 +109,7 @@
         menuIconURI: icon,
 
         blocks: [
+          /* eslint-disable extension/should-translate */
           {
             opcode: "exponent_block",
             blockType: Scratch.BlockType.REPORTER,
@@ -364,6 +365,7 @@
             },
             extensions: ["colours_operators"],
           },
+          /* eslint-enable extension/should-translate */
           "---",
           {
             opcode: "exactly_cont_block",
@@ -496,6 +498,7 @@
             extensions: ["colours_operators"],
           },
           "---",
+          /* eslint-disable extension/should-translate */
           {
             opcode: "pi_block",
             blockType: Scratch.BlockType.REPORTER,
@@ -514,6 +517,7 @@
             text: "∞",
             extensions: ["colours_operators"],
           },
+          /* eslint-enable extension/should-translate */
           "---",
           {
             opcode: "is_safe_number_block",

--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -73,6 +73,7 @@
 
             blockType: Scratch.BlockType.BOOLEAN,
 
+            // eslint-disable-next-line extension/should-translate
             text: "[A] <= [B]",
             arguments: {
               A: {
@@ -89,6 +90,7 @@
 
             blockType: Scratch.BlockType.BOOLEAN,
 
+            // eslint-disable-next-line extension/should-translate
             text: "[A] >= [B]",
             arguments: {
               A: {
@@ -123,6 +125,7 @@
 
             blockType: Scratch.BlockType.REPORTER,
 
+            // eslint-disable-next-line extension/should-translate
             text: "[A] ^ [B]",
             arguments: {
               A: {
@@ -247,7 +250,7 @@
           {
             opcode: "newline",
             blockType: Scratch.BlockType.REPORTER,
-            text: "newline character",
+            text: Scratch.translate("newline character"),
             disableMonitor: true,
             arguments: {},
           },
@@ -256,6 +259,7 @@
 
             blockType: Scratch.BlockType.BOOLEAN,
 
+            // eslint-disable-next-line extension/should-translate
             text: "[STRING]",
             arguments: {
               STRING: {


### PR DESCRIPTION
- Emit error when doing things like `const translate = Scratch.translate;` because the build script won't realize you are translating strings.
- Emit error when extension name is not translated and fix a couple instances of this
- Emit error when block text is not translated and fix a couple instances of this
- Refactor ESLint rules to be many separate rules instead of no-restricted-syntax being very big
- Include eslint.config.js in prettier
