### PR TITLE
Update autolabeler workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -32,20 +32,20 @@ jobs:
 
           if [[ "$BASE_REF" == "master" ]]; then
             # Download just the diff so it is harder to accidentally run any code from the pull request.
-            gh pr diff "$PR_NUMBER" > pr.diff
+            gh pr diff --repo TurboWarp/desktop "$PR_NUMBER" > pr.diff
 
             # Note that pcregrep exits with success on any match, failure on no match
             if pcregrep -M "^--- /dev/null\n\+\+\+ b/extensions/" pr.diff; then
               # Example:
               # --- /dev/null
               # +++ b/extensions/DangoCat/extension.js
-              gh pr edit "$PR_NUMBER" --add-label "$LABEL_NEW_EXTENSION"
+              gh pr edit --repo TurboWarp/desktop "$PR_NUMBER" --add-label "$LABEL_NEW_EXTENSION"
               got_any_specific_label=true
             elif pcregrep "^\+\+\+ b/extensions/" pr.diff; then
               # Example:
               # --- a/extensions/DangoCat/extension.js
               # +++ b/extensions/DangoCat/extension.js
-              gh pr edit "$PR_NUMBER" --add-label "$LABEL_CHANGE_EXTENSION"
+              gh pr edit --repo TurboWarp/desktop "$PR_NUMBER" --add-label "$LABEL_CHANGE_EXTENSION"
               got_any_specific_label=true
             fi
           else
@@ -54,7 +54,7 @@ jobs:
 
           # Any PR that didn't get a specific label will go into other, for a human to look at.
           if [[ "$got_any_specific_label" == "false" ]]; then
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL_OTHER"
+            gh pr edit --repo TurboWarp/desktop "$PR_NUMBER" --add-label "$LABEL_OTHER"
           fi
         env:
           PR_NUMBER: "${{ github.event.number }}"


### PR DESCRIPTION
Since it doesn't actually clone the repository, have to explicitly tell `gh` what repository we're talking about