### PR TITLE
text: change my credit from original to normal

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -1,7 +1,7 @@
 // Name: Text
 // ID: strings
 // Description: Manipulate characters and text.
-// Original: CST1229 <https://scratch.mit.edu/users/CST1229/>
+// By: CST1229 <https://scratch.mit.edu/users/CST1229/>
 // By: BludIsAnLemon <https://scratch.mit.edu/users/BludIsAnLemon/>
 // License: MIT AND MPL-2.0
 


### PR DESCRIPTION
Mostly so I show up first in the credits list, but also, I was the one who submitted it to the extensions gallery (unlike, say, window controls with bluedome77 or physics with griffpatch) so it could make more sense for this to be a normal credit.