### PR TITLE
pointerlock: use stage height instead of width for mouse Y position

### DIFF
--- a/extensions/pointerlock.js
+++ b/extensions/pointerlock.js
@@ -30,7 +30,7 @@
     mouse._clientX = x;
     mouse._scratchX = mouse.runtime.stageWidth * (x / width - 0.5);
     mouse._clientY = y;
-    mouse._scratchY = mouse.runtime.stageWidth * (y / height - 0.5);
+    mouse._scratchY = mouse.runtime.stageHeight * (y / height - 0.5);
     if (typeof isDown === "boolean") {
       const data = {
         button: e.button,


### PR DESCRIPTION
This bug caused the mouse Y to scale improperly based on the stage width, causing decimals to appear sometimes.  This is especially noticeable with thin X stage sizes (which decrease Y sensitivity due to the bug) and thick ones (which increase Y sensitivity).