### PR TITLE
Lily/Cast: Just return typeof. Lily/tempvars2: Add final missed credit.

### DIFF
--- a/extensions/Lily/Cast.js
+++ b/extensions/Lily/Cast.js
@@ -86,17 +86,7 @@
     }
 
     typeOf(args) {
-      const input = args.INPUT;
-      switch (typeof input) {
-        case "number":
-          return "number";
-        case "string":
-          return "string";
-        case "boolean":
-          return "boolean";
-        default:
-          return "";
-      }
+      return (typeof args.INPUT);
     }
   }
 

--- a/extensions/Lily/Cast.js
+++ b/extensions/Lily/Cast.js
@@ -86,7 +86,7 @@
     }
 
     typeOf(args) {
-      return (typeof args.INPUT);
+      return typeof args.INPUT;
     }
   }
 

--- a/extensions/Lily/TempVariables2.js
+++ b/extensions/Lily/TempVariables2.js
@@ -2,6 +2,7 @@
 // ID: lmsTempVars2
 // Description: Create disposable runtime or thread variables.
 // By: LilyMakesThings <https://scratch.mit.edu/users/LilyMakesThings/>
+// By: Mio <https://scratch.mit.edu/users/0znzw/>
 // License: MIT AND LGPL-3.0
 
 (function (Scratch) {


### PR DESCRIPTION
These are more of fixes