### PR TITLE
Add `client-metadata.json`, `bskycallback.html` for Bluesky's OAuth System

### DIFF
--- a/website/bskycallback.html
+++ b/website/bskycallback.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>TurboWarp OAuth Callback for BlueSky</title>
+    <link rel="stylesheet" href="https://raw.githubusercontent.com/hammouda101010/turbowarp-bsky-api/refs/heads/main/src/styles/auth.css">
+    <link rel="icon" sizes="180x180" href="website/favicon.ico">
+    <script type="module" src="https://raw.githubusercontent.com/hammouda101010/turbowarp-bsky-api/refs/heads/main/dist/callback.js"></script>
+</head>
+<body>
+  <p id="auth_result">Processing OAuth Response...</p>
+</body>
+</html>

--- a/website/client-metadata.json
+++ b/website/client-metadata.json
@@ -1,0 +1,15 @@
+{
+    "client_id": "https://extensions.turbowarp.org/website/client-metadata.json",
+    "client_name": "TurboWarp",
+    "client_uri": "https://turbowarp.org",
+    "logo_uri": "https://turbowarp.org/favicon.ico",
+    "tos_uri": "https://scratch.mit.edu/terms_of_use",
+    "policy_uri": "https://turbowarp.org/privacy.html",
+    "redirect_uris": ["https://extensions.turbowarp.org/website/bskycallback.html"],
+    "scope": "atproto transition:generic",
+    "grant_types": ["authorization_code", "refresh_token"],
+    "response_types": ["code"],
+    "token_endpoint_auth_method": "none",
+    "application_type": "web",
+    "dpop_bound_access_tokens": true
+}


### PR DESCRIPTION
### Changes Made:
- Added `client-metadata.json` inside the `website` folder
- Added `bskycallback.html` inside the `website` folder

### Notes:
This doesn't add an new extension, but it has to be done for support for BlueSky's OAuth system (because it uses `IndexedDB`, which is not shared by origin), so that [TurboButterfly's new OAuth rework](https://github.com/hammouda101010/turbowarp-bsky-api) can work properly.

I will create a pull request of the extension when it will be done.
This won't conflict with any extension anyways.