### PR TITLE
Lily/Assets: Add credit and new blocks

### DIFF
--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -1,6 +1,8 @@
 // Name: Asset Manager
 // ID: lmsAssets
 // Description: Add, remove, and get data from various types of assets.
+// By: LilyMakesThings <https://scratch.mit.edu/users/LilyMakesThings/>
+// By: Mio <https://scratch.mit.edu/users/0znzw/>
 // License: MIT AND LGPL-3.0
 
 // TheShovel is so epic and cool and awesome
@@ -174,9 +176,23 @@
             text: Scratch.translate("all sounds"),
           },
           {
+            // Legacy block
+            hideFromPalette: true,
             opcode: "getSpriteName",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("sprite name"),
+          },
+          {
+            disableMonitor: true,
+            opcode: "getSpriteValue",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("get sprite [EXPORT]"),
+            arguments: {
+              EXPORT: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "sprite",
+              },
+            },
           },
           "---",
           {
@@ -277,9 +293,23 @@
             },
           },
           {
+            // Legacy block
+            hideFromPalette: true,
             opcode: "getProjectJSON",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("project JSON"),
+          },
+          {
+            disableMonitor: true,
+            opcode: "getProjectValue",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("get project as [EXPORT]"),
+            arguments: {
+              EXPORT: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "project",
+              },
+            },
           },
           "---",
           {
@@ -327,6 +357,32 @@
               {
                 text: Scratch.translate("asset ID"),
                 value: "asset ID",
+              },
+            ],
+          },
+          project: {
+            acceptReporters: false,
+            items: [
+              {
+                text: Scratch.translate("JSON"),
+                value: "JSON",
+              },
+              {
+                text: Scratch.translate("dataURI"),
+                value: "dataURI",
+              },
+            ],
+          },
+          sprite: {
+            acceptReporters: false,
+            items: [
+              {
+                text: Scratch.translate("name"),
+                value: "name",
+              },
+              {
+                text: Scratch.translate("as dataURI"),
+                value: "dataURI",
               },
             ],
           },
@@ -525,6 +581,29 @@
       return util.target.sprite.name ?? "";
     }
 
+    getSpriteValue(args, util) {
+      const option = Cast.toString(args.EXPORT);
+      if (option === "name") {
+        return util.target.sprite.name ?? "";
+      } else if (option === "dataURI") {
+        try {
+          return new Promise((resolve) => {
+            Scratch.vm.exportSprite(util.target.id).then((blob) => {
+              const fr = new FileReader();
+              fr.onload = () => resolve(fr.result);
+              fr.onabort = () => {
+                throw new Error("Read aborted");
+              };
+              fr.readAsDataURL(blob);
+            });
+          });
+        } catch(e) {
+          console.error("Failed to export the sprite", e);
+          return "";
+        }
+      }
+    }
+
     reorderCostume(args, util) {
       const target = util.target;
       const index1 = Cast.toNumber(args.INDEX1) - 1;
@@ -632,6 +711,29 @@
 
     getProjectJSON() {
       return Scratch.vm.toJSON();
+    }
+
+    getProjectValue(args) {
+      const option = Cast.toString(args.EXPORT);
+      if (option === "JSON") {
+        return Scratch.vm.toJSON();
+      } else if (option === "dataURI") {
+        try {
+          return new Promise((resolve) => {
+            vm.saveProjectSb3().then((blob) => {
+              const fr = new FileReader();
+              fr.onload = () => resolve(fr.result);
+              fr.onabort = () => {
+                throw new Error("Read aborted");
+              };
+              fr.readAsDataURL(blob);
+            });
+          });
+        } catch(e) {
+          console.error("Failed to export the project", e);
+          return "";
+        }
+      }
     }
 
     async loadExtension(args) {

--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -303,7 +303,7 @@
             disableMonitor: true,
             opcode: "getProjectValue",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("project as [EXPORT]"),
+            text: Scratch.translate("project [EXPORT]"),
             arguments: {
               EXPORT: {
                 type: Scratch.ArgumentType.STRING,

--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -186,7 +186,7 @@
             disableMonitor: true,
             opcode: "getSpriteValue",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("get sprite [EXPORT]"),
+            text: Scratch.translate("sprite [EXPORT]"),
             arguments: {
               EXPORT: {
                 type: Scratch.ArgumentType.STRING,
@@ -303,7 +303,7 @@
             disableMonitor: true,
             opcode: "getProjectValue",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("get project as [EXPORT]"),
+            text: Scratch.translate("project as [EXPORT]"),
             arguments: {
               EXPORT: {
                 type: Scratch.ArgumentType.STRING,
@@ -381,7 +381,7 @@
                 value: "name",
               },
               {
-                text: Scratch.translate("as dataURI"),
+                text: Scratch.translate("dataURI"),
                 value: "dataURI",
               },
             ],

--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -597,7 +597,7 @@
               fr.readAsDataURL(blob);
             });
           });
-        } catch(e) {
+        } catch (e) {
           console.error("Failed to export the sprite", e);
           return "";
         }
@@ -729,7 +729,7 @@
               fr.readAsDataURL(blob);
             });
           });
-        } catch(e) {
+        } catch (e) {
           console.error("Failed to export the project", e);
           return "";
         }

--- a/extensions/Lily/Assets.js
+++ b/extensions/Lily/Assets.js
@@ -26,6 +26,10 @@
 
   class Assets {
     getInfo() {
+      const dataURIOption = Scratch.translate({
+        default: "dataURI",
+        description: "Menu option called dataURI",
+      });
       return {
         id: "lmsAssets",
         color1: "#5779ca",
@@ -343,7 +347,7 @@
                 value: "index",
               },
               {
-                text: Scratch.translate("dataURI"),
+                text: dataURIOption,
                 value: "dataURI",
               },
               {
@@ -368,7 +372,7 @@
                 value: "JSON",
               },
               {
-                text: Scratch.translate("dataURI"),
+                text: dataURIOption,
                 value: "dataURI",
               },
             ],
@@ -381,7 +385,7 @@
                 value: "name",
               },
               {
-                text: Scratch.translate("dataURI"),
+                text: dataURIOption,
                 value: "dataURI",
               },
             ],


### PR DESCRIPTION
This PR credits @LilyMakesThings  as well as adds 2 new blocks.

![image](https://github.com/user-attachments/assets/915fcf0f-b168-4fca-9f69-57e767775aa6)
*wording changed to sprite [name,dataURI v]*
![image](https://github.com/user-attachments/assets/de031101-eca8-4628-abd0-18898949782c)
*wording changed to project [JSON,dataURI v]*
With these following blocks being merged into the menus
![image](https://github.com/user-attachments/assets/1de11036-bc52-4225-b6ce-a5a4dcfaaf7e)
