### PR TITLE
SharkPool/Camera: bug fixes

### DIFF
--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -674,9 +674,9 @@
       const videoLayer = runtime.ioDevices.video._drawable;
 
       if (name === "_pen_")
-        return penLayer ? { drawableID: penLayer } : undefined;
+        return penLayer > -1 ? { drawableID: penLayer } : undefined;
       else if (name === "_video_")
-        return videoLayer !== -1 ? { drawableID: videoLayer } : undefined;
+        return videoLayer > -1 ? { drawableID: videoLayer } : undefined;
       else if (name.includes("=SP-custLayer")) {
         const drawableID = parseInt(name);
         if (render._allDrawables[drawableID]?.customDrawableName !== undefined)

--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -811,7 +811,7 @@
 
     setDirectionNew(args) {
       if (!allCameras[args.CAMERA]) return;
-      allCameras[args.CAMERA].dir = 180 - Cast.toNumber(args.NUM) - 90;
+      allCameras[args.CAMERA].dir = 90 - Cast.toNumber(args.NUM);
       updateCamera(args.CAMERA);
     }
     setDirection(args) {
@@ -843,7 +843,7 @@
 
     getDirectionNew(args) {
       if (!allCameras[args.CAMERA]) return 0;
-      return 180 - allCameras[args.CAMERA].dir - 90;
+      return 90 - allCameras[args.CAMERA].dir;
     }
     getDirection(args) {
       if (!allCameras[args.CAMERA]) return 0;

--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -600,7 +600,11 @@
     }
 
     getCameras() {
-      return Object.keys(allCameras);
+      const cameraNames = Object.keys(allCameras);
+      return cameraNames.map((i) => {
+        if (i === "default") return { text: Scratch.translate("default"), value: "default" };
+        else return { text: i, value: i };
+      });
     }
 
     refreshBlocks() {

--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -151,7 +151,10 @@
     const camSystem = allCameras[drawable[cameraSymbol].name];
 
     const ogNativeSize = render._nativeSize;
-    if (Math.abs(camSystem.xy[0]) > runtime.stageWidth || Math.abs(camSystem.xy[1]) > runtime.stageHeight) {
+    if (
+      Math.abs(camSystem.xy[0]) > runtime.stageWidth ||
+      Math.abs(camSystem.xy[1]) > runtime.stageHeight
+    ) {
       render._nativeSize = [Infinity, Infinity];
     }
     ogPositionBubble.call(this, target);
@@ -528,7 +531,10 @@
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("rendered x position of [TARGET]"),
             arguments: {
-              TARGET: { type: Scratch.ArgumentType.STRING, menu: "EXACT_OBJECTS" },
+              TARGET: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "EXACT_OBJECTS",
+              },
             },
           },
           {
@@ -536,7 +542,10 @@
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("rendered y position of [TARGET]"),
             arguments: {
-              TARGET: { type: Scratch.ArgumentType.STRING, menu: "EXACT_OBJECTS" },
+              TARGET: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "EXACT_OBJECTS",
+              },
             },
           },
         ],
@@ -619,7 +628,8 @@
     getCameras() {
       const cameraNames = Object.keys(allCameras);
       return cameraNames.map((i) => {
-        if (i === "default") return { text: Scratch.translate("default"), value: "default" };
+        if (i === "default")
+          return { text: Scratch.translate("default"), value: "default" };
         else return { text: i, value: i };
       });
     }
@@ -801,7 +811,7 @@
 
     setDirectionNew(args) {
       if (!allCameras[args.CAMERA]) return;
-      allCameras[args.CAMERA].dir = (180 - Cast.toNumber(args.NUM)) - 90;
+      allCameras[args.CAMERA].dir = 180 - Cast.toNumber(args.NUM) - 90;
       updateCamera(args.CAMERA);
     }
     setDirection(args) {
@@ -833,7 +843,7 @@
 
     getDirectionNew(args) {
       if (!allCameras[args.CAMERA]) return 0;
-      return (180 - allCameras[args.CAMERA].dir) - 90;
+      return 180 - allCameras[args.CAMERA].dir - 90;
     }
     getDirection(args) {
       if (!allCameras[args.CAMERA]) return 0;

--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -522,6 +522,23 @@
               CAMERA: { type: Scratch.ArgumentType.STRING, menu: "CAMERAS" },
             },
           },
+          "---",
+          {
+            opcode: "renderedX",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("rendered x position of [TARGET]"),
+            arguments: {
+              TARGET: { type: Scratch.ArgumentType.STRING, menu: "EXACT_OBJECTS" },
+            },
+          },
+          {
+            opcode: "renderedY",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("rendered y position of [TARGET]"),
+            arguments: {
+              TARGET: { type: Scratch.ArgumentType.STRING, menu: "EXACT_OBJECTS" },
+            },
+          },
         ],
         menus: {
           CAMERAS: { acceptReporters: false, items: "getCameras" },
@@ -864,6 +881,20 @@
         false,
         camData
       )[1];
+    }
+
+    renderedX(args, util) {
+      const target = this.getTarget(args.TARGET, util);
+      if (!target) return "";
+      const drawable = render._allDrawables[target.drawableID];
+      return drawable._position[0];
+    }
+
+    renderedY(args, util) {
+      const target = this.getTarget(args.TARGET, util);
+      if (!target) return "";
+      const drawable = render._allDrawables[target.drawableID];
+      return drawable._position[1];
     }
   }
 

--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -154,7 +154,7 @@
     if (Math.abs(camSystem.xy[0]) > runtime.stageWidth || Math.abs(camSystem.xy[1]) > runtime.stageHeight) {
       render._nativeSize = [Infinity, Infinity];
     }
-    const bounds = ogPositionBubble.call(this, target);
+    ogPositionBubble.call(this, target);
     render._nativeSize = ogNativeSize;
   };
 


### PR DESCRIPTION
Various fixes and improvements Garbomuffin and others requested:
- added "rendered position" blocks

<img width="400" alt="Screenshot 2025-02-20 at 11 06 22 AM" src="https://github.com/user-attachments/assets/e04cbf94-ac41-489e-9034-4463787586de" />

- "default" camera text should be translated ✅ 
- Loading Extension Storage had a invalid variable ✅
- Camera Rotation Blocks should act the same as Camera V1 ✅ 
- Speech Bubbles offscreen will have their position offset ✅ 

<img width="400" alt="Screenshot 2025-02-20 at 11 06 22 AM" src="https://github.com/user-attachments/assets/0a11f44c-c396-460a-aa25-f1bcfec6ccf0" />

- Point-to Blocks are broken when Camera Position Offsets ✅ 
> I should point out this doesnt technically fix the issue. But its a solid workaround. The issue lies with the actual block functions of the "point to" blocks.

<img width="400" alt="Screenshot 2025-02-20 at 11 06 22 AM" src="https://github.com/user-attachments/assets/4d1361a7-cdcc-4cdd-8096-f70de9195ca7" />

