### PR TITLE
true-fantom/math: Add true sin/cos/tan block.

### DIFF
--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -699,8 +699,9 @@
           return Math.acos(n);
         case "atan":
           return Math.atan(n);
+        default:
+          return 0;
       }
-      return 0;
     }
     pi_block() {
       return Math.PI;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -497,6 +497,21 @@
             },
             extensions: ["colours_operators"],
           },
+          {
+            opcode: "true_math_op",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("true [OPERATOR] [NUM]"),
+            arguments: {
+              OPERATOR: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "OPERATOR",
+              },
+              NUM: {
+                type: Scratch.ArgumentType.NUMBER
+              },
+            },
+            extensions: ["colours_operators"],
+          },
           "---",
           /* eslint-disable extension/should-translate */
           {
@@ -569,6 +584,12 @@
             extensions: ["colours_operators"],
           },
         ],
+        menus: {
+            OPERATOR: {
+              acceptReporters: true,
+              items: ["sin", "cos", "tan", "asin", "acos", "atan"],
+            },
+          },
       };
     }
 
@@ -661,6 +682,19 @@
     }
     log_with_base_block({ A, B }) {
       return Math.log(cast.toNumber(A)) / Math.log(cast.toNumber(B));
+    }
+    true_math_op(args) {
+        const operator = cast.toString(args.OPERATOR).toLowerCase();
+        const n = cast.toNumber(args.NUM);
+        switch (operator) {
+        case 'sin': return Math.sin(n);
+        case 'cos': return Math.cos(n);
+        case 'tan': return Math.tan(n);
+        case 'asin': return Math.asin(n);
+        case 'acos': return Math.acos(n);
+        case 'atan': return Math.atan(n);
+        }
+        return 0;
     }
     pi_block() {
       return Math.PI;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -507,7 +507,7 @@
                 menu: "OPERATOR",
               },
               NUM: {
-                type: Scratch.ArgumentType.NUMBER
+                type: Scratch.ArgumentType.NUMBER,
               },
             },
             extensions: ["colours_operators"],
@@ -585,11 +585,11 @@
           },
         ],
         menus: {
-            OPERATOR: {
-              acceptReporters: true,
-              items: ["sin", "cos", "tan", "asin", "acos", "atan"],
-            },
+          OPERATOR: {
+            acceptReporters: true,
+            items: ["sin", "cos", "tan", "asin", "acos", "atan"],
           },
+        },
       };
     }
 
@@ -684,17 +684,23 @@
       return Math.log(cast.toNumber(A)) / Math.log(cast.toNumber(B));
     }
     true_math_op(args) {
-        const operator = cast.toString(args.OPERATOR).toLowerCase();
-        const n = cast.toNumber(args.NUM);
-        switch (operator) {
-        case 'sin': return Math.sin(n);
-        case 'cos': return Math.cos(n);
-        case 'tan': return Math.tan(n);
-        case 'asin': return Math.asin(n);
-        case 'acos': return Math.acos(n);
-        case 'atan': return Math.atan(n);
-        }
-        return 0;
+      const operator = cast.toString(args.OPERATOR).toLowerCase();
+      const n = cast.toNumber(args.NUM);
+      switch (operator) {
+        case "sin":
+          return Math.sin(n);
+        case "cos":
+          return Math.cos(n);
+        case "tan":
+          return Math.tan(n);
+        case "asin":
+          return Math.asin(n);
+        case "acos":
+          return Math.acos(n);
+        case "atan":
+          return Math.atan(n);
+      }
+      return 0;
     }
     pi_block() {
       return Math.PI;


### PR DESCRIPTION
sorry mio

In Scratch/Turbowarp, the sin/cos/tan/asin/acos/atan blocks don't return as expected-- they're run through several other equations to deal with rounding, and to make the blocks compatible with degrees. 

![chrome_eTFJtRFaWZ](https://github.com/user-attachments/assets/b474b477-7ce1-479e-9af0-3bfe223f9ba3)

While this makes the blocks more user-friendly, it can be annoying for people who want the original functions to have to essentially undo the extra calculations. This PR adds a new block to the Math extension which introduces a new block, featuring all the same trig functions, but returning exactly what their Javascript Math counterpart does.

![chrome_zkk2vNonX3](https://github.com/user-attachments/assets/9506267f-0f02-4e5e-a239-cf1c6c7ecc3c)
