### PR TITLE
utilities: Port "normalize" block from Lily's Toolbox

### DIFF
--- a/extensions/utilities.js
+++ b/extensions/utilities.js
@@ -208,6 +208,17 @@
             },
           },
           {
+            opcode: "normalize",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("normalize [INPUT]"),
+            arguments: {
+              INPUT: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0.1,
+              },
+            },
+          },
+          {
             opcode: "currentMillisecond",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("current millisecond"),
@@ -342,6 +353,12 @@
       } else {
         return Math.min(Math.max(INPUT, MIN), MAX);
       }
+    }
+
+    normalize ({ INPUT }) {
+      let input = Scratch.Cast.toNumber(INPUT);
+      let normal = input / Math.abs(input);
+      return isNaN(normal) ? 0 : normal;
     }
 
     currentMillisecond() {


### PR DESCRIPTION
Technically isn't a 1:1 port (I cleaned up the code a little and added an extra Scratch.Cast call just to be safe), however it functions practically identically.

![chrome_spL57aYLcY](https://github.com/user-attachments/assets/202bc27f-b0fa-4086-845b-c53f963ebd66)
