### PR TITLE
true-fantom/math: Add "sign" block

### DIFF
--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -660,7 +660,7 @@
     }
     sign_of({ A }) {
       let sign = Math.sign(cast.toNumber(A));
-      return isNaN(A) ? 0 : sign;
+      return isNaN(sign) ? 0 : sign;
     }
     clamp_block({ A, B, C }) {
       if (cast.compare(A, B) < 0) {

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -385,6 +385,18 @@
           },
           "---",
           {
+            opcode: "sign_of",
+            blockType: Scratch.BlockType.REPORTER,
+            text: Scratch.translate("sign of [A]"),
+            arguments: {
+              A: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 0.1,
+              },
+            },
+            extensions: ["colours_operators"],
+          },
+          {
             opcode: "clamp_block",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("clamp [A] between [B] and [C]"),
@@ -507,7 +519,7 @@
                 menu: "OPERATOR",
               },
               NUM: {
-                type: Scratch.ArgumentType.NUMBER,
+                type: Scratch.ArgumentType.NUMBER
               },
             },
             extensions: ["colours_operators"],
@@ -585,11 +597,11 @@
           },
         ],
         menus: {
-          OPERATOR: {
-            acceptReporters: true,
-            items: ["sin", "cos", "tan", "asin", "acos", "atan"],
+            OPERATOR: {
+              acceptReporters: true,
+              items: ["sin", "cos", "tan", "asin", "acos", "atan"],
+            },
           },
-        },
       };
     }
 
@@ -646,6 +658,10 @@
     exactly_cont_block({ A, B }) {
       return cast.toString(A).includes(cast.toString(B));
     }
+    sign_of({ A }) {
+      let sign = Math.sign(cast.toNumber(A));
+      return isNaN(A) ? 0 : sign;
+    }
     clamp_block({ A, B, C }) {
       if (cast.compare(A, B) < 0) {
         return B;
@@ -684,24 +700,17 @@
       return Math.log(cast.toNumber(A)) / Math.log(cast.toNumber(B));
     }
     true_math_op(args) {
-      const operator = cast.toString(args.OPERATOR).toLowerCase();
-      const n = cast.toNumber(args.NUM);
-      switch (operator) {
-        case "sin":
-          return Math.sin(n);
-        case "cos":
-          return Math.cos(n);
-        case "tan":
-          return Math.tan(n);
-        case "asin":
-          return Math.asin(n);
-        case "acos":
-          return Math.acos(n);
-        case "atan":
-          return Math.atan(n);
-        default:
-          return 0;
-      }
+        const operator = cast.toString(args.OPERATOR).toLowerCase();
+        const n = cast.toNumber(args.NUM);
+        switch (operator) {
+        case 'sin': return Math.sin(n);
+        case 'cos': return Math.cos(n);
+        case 'tan': return Math.tan(n);
+        case 'asin': return Math.asin(n);
+        case 'acos': return Math.acos(n);
+        case 'atan': return Math.atan(n);
+        }
+        return 0;
     }
     pi_block() {
       return Math.PI;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -714,8 +714,9 @@
           return Math.acos(n);
         case "atan":
           return Math.atan(n);
+        default:
+          return 0;
       }
-      return 0;
     }
     pi_block() {
       return Math.PI;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -519,7 +519,7 @@
                 menu: "OPERATOR",
               },
               NUM: {
-                type: Scratch.ArgumentType.NUMBER
+                type: Scratch.ArgumentType.NUMBER,
               },
             },
             extensions: ["colours_operators"],
@@ -597,11 +597,11 @@
           },
         ],
         menus: {
-            OPERATOR: {
-              acceptReporters: true,
-              items: ["sin", "cos", "tan", "asin", "acos", "atan"],
-            },
+          OPERATOR: {
+            acceptReporters: true,
+            items: ["sin", "cos", "tan", "asin", "acos", "atan"],
           },
+        },
       };
     }
 
@@ -700,17 +700,23 @@
       return Math.log(cast.toNumber(A)) / Math.log(cast.toNumber(B));
     }
     true_math_op(args) {
-        const operator = cast.toString(args.OPERATOR).toLowerCase();
-        const n = cast.toNumber(args.NUM);
-        switch (operator) {
-        case 'sin': return Math.sin(n);
-        case 'cos': return Math.cos(n);
-        case 'tan': return Math.tan(n);
-        case 'asin': return Math.asin(n);
-        case 'acos': return Math.acos(n);
-        case 'atan': return Math.atan(n);
-        }
-        return 0;
+      const operator = cast.toString(args.OPERATOR).toLowerCase();
+      const n = cast.toNumber(args.NUM);
+      switch (operator) {
+        case "sin":
+          return Math.sin(n);
+        case "cos":
+          return Math.cos(n);
+        case "tan":
+          return Math.tan(n);
+        case "asin":
+          return Math.asin(n);
+        case "acos":
+          return Math.acos(n);
+        case "atan":
+          return Math.atan(n);
+      }
+      return 0;
     }
     pi_block() {
       return Math.PI;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -659,8 +659,7 @@
       return cast.toString(A).includes(cast.toString(B));
     }
     sign_of({ A }) {
-      let sign = Math.sign(cast.toNumber(A));
-      return isNaN(sign) ? 0 : sign;
+      return Math.sign(cast.toNumber(A));
     }
     clamp_block({ A, B, C }) {
       if (cast.compare(A, B) < 0) {


### PR DESCRIPTION
continuation of https://github.com/TurboWarp/extensions/pull/1980, everything from there applies except:

- ctrl + f replace every time I said "normalize" with "sign of"
- block code was changed a bit because apparently there's a math function to get sign (how am i just now learning of this)

![chrome_uiOoLW48ex](https://github.com/user-attachments/assets/b880379d-8a5d-4848-b84f-69948ee2500a)

