### PR TITLE
Update Time extension to use Scratch.Cast.* APIs

### DIFF
--- a/extensions/-SIPC-/time.js
+++ b/extensions/-SIPC-/time.js
@@ -387,15 +387,12 @@
       const totalSeconds = Scratch.Cast.toNumber(args.VALUE);
       const seconds =
         args.ROUND === "rounded"
-          ? Math.round(totalSeconds % 60)
-              .toString()
+          ? Scratch.Cast.toString(Math.round(totalSeconds % 60))
               .padStart(2, "0")
           : (totalSeconds % 60).toFixed(3).padStart(6, "0");
-      const minutes = Math.floor((totalSeconds / 60) % 60)
-        .toString()
+      const minutes = Scratch.Cast.toString(Math.floor((totalSeconds / 60) % 60))
         .padStart(2, "0");
-      const hours = Math.floor(totalSeconds / 3600)
-        .toString()
+      const hours = Scratch.Cast.toString(Math.floor(totalSeconds / 3600))
         .padStart(2, "0");
       return `${hours}:${minutes}:${seconds}`;
     }


### PR DESCRIPTION
In the `formatTime()` function linked to the `format [VALUE] seconds as [ROUND] time` block, I rewrote parts of the code to use the Scratch.Cast.* API.

I believe that this update should make the Time extension compliant with the standards set out by #1810.

This was tested in the stable release of the TurboWarp website with sandboxing and seemingly functioned as before.