### PR TITLE
Update Text extension for casting compliance under new guidelines

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -510,10 +510,10 @@
     }
 
     letters_of(args, util) {
-      args.STRING = Scratch.Cast.toString(args.STRING);
-      args.LETTER1 = Number(args.LETTER1) || 0;
-      args.LETTER2 = Number(args.LETTER2) || 0;
-      return args.STRING.substring(args.LETTER1 - 1, args.LETTER2);
+      const string = Scratch.Cast.toString(args.STRING);
+      const letter1 = Scratch.Cast.toNumber(args.LETTER1);
+      const letter2 = Scratch.Cast.toNumber(args.LETTER2);
+      return string.substring(letter1 - 1, letter2);
     }
 
     _caseInsensitiveRegex(str) {
@@ -521,27 +521,26 @@
     }
 
     split(args, util) {
-      args.STRING = Scratch.Cast.toString(args.STRING ?? "");
-      args.SPLIT = Scratch.Cast.toString(args.SPLIT ?? "");
-      args.ITEM = Number(args.ITEM) || 0;
+      const string = Scratch.Cast.toString(args.STRING);
+      const split = Scratch.Cast.toString(args.SPLIT);
+      const item = Scratch.Cast.toNumber(args.ITEM);
 
       // Cache the last split
       if (
         !(
           splitCache &&
-          splitCache.string === args.STRING &&
-          splitCache.split === args.SPLIT
+          splitCache.string === string &&
+          splitCache.split === split
         )
       ) {
-        const regex = this._caseInsensitiveRegex(args.SPLIT);
+        const regex = this._caseInsensitiveRegex(split);
 
         splitCache = {
-          string: args.STRING,
-          split: args.SPLIT,
-          arr: args.STRING.split(regex),
+          string, split,
+          arr: string.split(regex),
         };
       }
-      return splitCache.arr[args.ITEM - 1] || "";
+      return splitCache.arr[item - 1] || "";
     }
 
     count(args, util) {
@@ -558,48 +557,45 @@
     }
 
     replace(args, util) {
-      args.STRING = Scratch.Cast.toString(args.STRING);
-      args.SUBSTRING = Scratch.Cast.toString(args.SUBSTRING);
+      const string = Scratch.Cast.toString(args.STRING);
+      const substring = Scratch.Cast.toString(args.SUBSTRING);
+      const replace = Scratch.Cast.toString(args.REPLACE);
 
-      args.REPLACE = Scratch.Cast.toString(args.REPLACE);
+      const regex = this._caseInsensitiveRegex(substring);
 
-      const regex = this._caseInsensitiveRegex(args.SUBSTRING);
-
-      return args.STRING.replace(regex, args.REPLACE);
+      return string.replace(regex, replace);
     }
 
     indexof(args, util) {
       // .toLowerCase() for case insensitivity
-      args.STRING = Scratch.Cast.toString(args.STRING ?? "").toLowerCase();
-      args.SUBSTRING = Scratch.Cast.toString(
-        args.SUBSTRING ?? ""
-      ).toLowerCase();
+      const string = Scratch.Cast.toString(args.STRING).toLowerCase();
+      const substring = Scratch.Cast.toString(args.SUBSTRING).toLowerCase();
 
       // Since both arguments are casted to strings beforehand,
       // we don't have to worry about type differences
       // like in the item number of in list block
-      const found = args.STRING.indexOf(args.SUBSTRING);
+      const found = string.indexOf(substring);
 
       // indexOf returns -1 when no matches are found, we can just +1
       return found + 1;
     }
 
     repeat(args, util) {
-      args.STRING = Scratch.Cast.toString(args.STRING);
-      args.REPEAT = Number(args.REPEAT) || 0;
-      return args.STRING.repeat(args.REPEAT);
+      const string = Scratch.Cast.toString(args.STRING);
+      const repeat = Scratch.Cast.toNumber(args.REPEAT);
+      return string.repeat(repeat);
     }
 
     replaceRegex(args, util) {
       try {
-        args.STRING = Scratch.Cast.toString(args.STRING);
-        args.REPLACE = Scratch.Cast.toString(args.REPLACE);
-        args.REGEX = Scratch.Cast.toString(args.REGEX);
-        args.FLAGS = Scratch.Cast.toString(args.FLAGS);
+        const string = Scratch.Cast.toString(args.STRING);
+        const replacer = Scratch.Cast.toString(args.REPLACE);
+        const regex = Scratch.Cast.toString(args.REGEX);
+        const flags = Scratch.Cast.toString(args.FLAGS);
 
-        return args.STRING.replace(
-          new RegExp(args.REGEX, args.FLAGS),
-          args.REPLACE
+        return string.replace(
+          new RegExp(regex, flags),
+          replacer
         );
       } catch (e) {
         console.error(e);
@@ -609,33 +605,33 @@
 
     matchRegex(args, util) {
       try {
-        args.STRING = Scratch.Cast.toString(args.STRING ?? "");
-        args.REGEX = Scratch.Cast.toString(args.REGEX ?? "");
-        args.FLAGS = Scratch.Cast.toString(args.FLAGS ?? "");
-        args.ITEM = Number(args.ITEM) || 0;
+        const string = Scratch.Cast.toString(args.STRING);
+        const uncleanRegex = Scratch.Cast.toString(args.REGEX);
+        const flags = Scratch.Cast.toString(args.FLAGS);
+        const item = Scratch.Cast.toNumber(args.ITEM);
 
         // Cache the last matched string
         if (
           !(
             matchCache &&
-            matchCache.string === args.STRING &&
-            matchCache.regex === args.REGEX &&
-            matchCache.flags === args.FLAGS
+            matchCache.string === string &&
+            matchCache.regex === uncleanRegex &&
+            matchCache.flags === flags
           )
         ) {
-          const newFlags = args.FLAGS.includes("g")
-            ? args.FLAGS
-            : args.FLAGS + "g";
-          const regex = new RegExp(args.REGEX, newFlags);
+          const newFlags = flags.includes("g")
+            ? flags
+            : flags + "g";
+          const regex = new RegExp(uncleanRegex, newFlags);
 
           matchCache = {
-            string: args.STRING,
-            regex: args.REGEX,
-            flags: args.FLAGS,
-            arr: args.STRING.match(regex) || [],
+            string,
+            regex: uncleanRegex,
+            flags,
+            arr: string.match(regex) || [],
           };
         }
-        return matchCache.arr[args.ITEM - 1] || "";
+        return matchCache.arr[item - 1] || "";
       } catch (e) {
         console.error(e);
         return "";
@@ -652,11 +648,11 @@
 
     testRegex(args, util) {
       try {
-        args.STRING = Scratch.Cast.toString(args.STRING);
-        args.REGEX = Scratch.Cast.toString(args.REGEX);
-        args.FLAGS = Scratch.Cast.toString(args.FLAGS);
+        const string = Scratch.Cast.toString(args.STRING);
+        const regex = Scratch.Cast.toString(args.REGEX);
+        const flags = Scratch.Cast.toString(args.FLAGS);
 
-        return new RegExp(args.REGEX, args.FLAGS).test(args.STRING);
+        return new RegExp(regex, flags).test(string);
       } catch (e) {
         console.error(e);
         return false;

--- a/extensions/text.js
+++ b/extensions/text.js
@@ -501,7 +501,7 @@
     }
 
     unicodeof(args, util) {
-      const chars = Array.from(args.STRING.toString());
+      const chars = Array.from(Scratch.Cast.toString(args.STRING));
       return chars.map((char) => char.charCodeAt(0)).join(" ");
     }
 
@@ -510,7 +510,7 @@
     }
 
     letters_of(args, util) {
-      args.STRING = args.STRING.toString();
+      args.STRING = Scratch.Cast.toString(args.STRING);
       args.LETTER1 = Number(args.LETTER1) || 0;
       args.LETTER2 = Number(args.LETTER2) || 0;
       return args.STRING.substring(args.LETTER1 - 1, args.LETTER2);
@@ -521,8 +521,8 @@
     }
 
     split(args, util) {
-      args.STRING = (args.STRING ?? "").toString();
-      args.SPLIT = (args.SPLIT ?? "").toString();
+      args.STRING = Scratch.Cast.toString((args.STRING ?? ""));
+      args.SPLIT = Scratch.Cast.toString((args.SPLIT ?? ""));
       args.ITEM = Number(args.ITEM) || 0;
 
       // Cache the last split
@@ -558,10 +558,10 @@
     }
 
     replace(args, util) {
-      args.STRING = args.STRING.toString();
-      args.SUBSTRING = args.SUBSTRING.toString();
+      args.STRING = Scratch.Cast.toString(args.STRING);
+      args.SUBSTRING = Scratch.Cast.toString(args.SUBSTRING);
 
-      args.REPLACE = args.REPLACE.toString();
+      args.REPLACE = Scratch.Cast.toString(args.REPLACE);
 
       const regex = this._caseInsensitiveRegex(args.SUBSTRING);
 
@@ -570,8 +570,8 @@
 
     indexof(args, util) {
       // .toLowerCase() for case insensitivity
-      args.STRING = (args.STRING ?? "").toString().toLowerCase();
-      args.SUBSTRING = (args.SUBSTRING ?? "").toString().toLowerCase();
+      args.STRING = Scratch.Cast.toString((args.STRING ?? "")).toLowerCase();
+      args.SUBSTRING = Scratch.Cast.toString((args.SUBSTRING ?? "")).toLowerCase();
 
       // Since both arguments are casted to strings beforehand,
       // we don't have to worry about type differences
@@ -583,17 +583,17 @@
     }
 
     repeat(args, util) {
-      args.STRING = args.STRING.toString();
+      args.STRING = Scratch.Cast.toString(args.STRING);
       args.REPEAT = Number(args.REPEAT) || 0;
       return args.STRING.repeat(args.REPEAT);
     }
 
     replaceRegex(args, util) {
       try {
-        args.STRING = args.STRING.toString();
-        args.REPLACE = args.REPLACE.toString();
-        args.REGEX = args.REGEX.toString();
-        args.FLAGS = args.FLAGS.toString();
+        args.STRING = Scratch.Cast.toString(args.STRING);
+        args.REPLACE = Scratch.Cast.toString(args.REPLACE);
+        args.REGEX = Scratch.Cast.toString(args.REGEX);
+        args.FLAGS = Scratch.Cast.toString(args.FLAGS);
 
         return args.STRING.replace(
           new RegExp(args.REGEX, args.FLAGS),
@@ -607,9 +607,9 @@
 
     matchRegex(args, util) {
       try {
-        args.STRING = (args.STRING ?? "").toString();
-        args.REGEX = (args.REGEX ?? "").toString();
-        args.FLAGS = (args.FLAGS ?? "").toString();
+        args.STRING = Scratch.Cast.toString((args.STRING ?? ""));
+        args.REGEX = Scratch.Cast.toString((args.REGEX ?? ""));
+        args.FLAGS = Scratch.Cast.toString((args.FLAGS ?? ""));
         args.ITEM = Number(args.ITEM) || 0;
 
         // Cache the last matched string
@@ -650,9 +650,9 @@
 
     testRegex(args, util) {
       try {
-        args.STRING = args.STRING.toString();
-        args.REGEX = args.REGEX.toString();
-        args.FLAGS = args.FLAGS.toString();
+        args.STRING = Scratch.Cast.toString(args.STRING);
+        args.REGEX = Scratch.Cast.toString(args.REGEX);
+        args.FLAGS = Scratch.Cast.toString(args.FLAGS);
 
         return new RegExp(args.REGEX, args.FLAGS).test(args.STRING);
       } catch (e) {
@@ -662,8 +662,8 @@
     }
 
     isCase(args, util) {
-      const string = args.STRING.toString();
-      const textCase = args.TEXTCASE.toString();
+      const string = Scratch.Cast.toString(args.STRING);
+      const textCase = Scratch.Cast.toString(args.TEXTCASE);
       switch (textCase) {
         case CaseParam.LOWERCASE:
           return string.toLowerCase() === string;
@@ -698,8 +698,8 @@
     }
 
     toCase(args, util) {
-      const string = args.STRING.toString();
-      const textCase = args.TEXTCASE.toString();
+      const string = Scratch.Cast.toString(args.STRING);
+      const textCase = Scratch.Cast.toString(args.TEXTCASE);
       let workingText = "";
       let sentenceCapitalFlag = false;
       switch (textCase) {
@@ -762,26 +762,26 @@
             } else {
               workingText += string[i].toLowerCase();
             }
-          }
+          }v
           return workingText.replace(/\s/g, "");
         default:
           return string;
       }
     }
     posWith(args) {
-      const STRING = args.STRING.toString();
-      const SUBSTRING = args.SUBSTRING.toString();
-      if (args.POSITION.toString() === "starts") {
+      const STRING = Scratch.Cast.toString(args.STRING);
+      const SUBSTRING = Scratch.Cast.toString(args.SUBSTRING);
+      if (Scratch.Cast.toString(args.POSITION) === "starts") {
         return STRING.startsWith(SUBSTRING);
       }
       return STRING.endsWith(SUBSTRING);
     }
     reverse(args) {
-      return Array.from(args.STRING.toString()).reverse().join("");
+      return Array.from(Scratch.Cast.toString(args.STRING)).reverse().join("");
     }
     trim(args) {
-      const STRING = args.STRING.toString();
-      switch (args.METHOD.toString()) {
+      const STRING = Scratch.Cast.toString(args.STRING);
+      switch (Scratch.Cast.toString(args.METHOD)) {
         case "start":
           return STRING.trimStart();
         case "end":

--- a/extensions/text.js
+++ b/extensions/text.js
@@ -536,7 +536,8 @@
         const regex = this._caseInsensitiveRegex(split);
 
         splitCache = {
-          string, split,
+          string,
+          split,
           arr: string.split(regex),
         };
       }
@@ -593,10 +594,7 @@
         const regex = Scratch.Cast.toString(args.REGEX);
         const flags = Scratch.Cast.toString(args.FLAGS);
 
-        return string.replace(
-          new RegExp(regex, flags),
-          replacer
-        );
+        return string.replace(new RegExp(regex, flags), replacer);
       } catch (e) {
         console.error(e);
         return "";
@@ -619,9 +617,7 @@
             matchCache.flags === flags
           )
         ) {
-          const newFlags = flags.includes("g")
-            ? flags
-            : flags + "g";
+          const newFlags = flags.includes("g") ? flags : flags + "g";
           const regex = new RegExp(uncleanRegex, newFlags);
 
           matchCache = {

--- a/extensions/text.js
+++ b/extensions/text.js
@@ -521,8 +521,8 @@
     }
 
     split(args, util) {
-      args.STRING = Scratch.Cast.toString((args.STRING ?? ""));
-      args.SPLIT = Scratch.Cast.toString((args.SPLIT ?? ""));
+      args.STRING = Scratch.Cast.toString(args.STRING ?? "");
+      args.SPLIT = Scratch.Cast.toString(args.SPLIT ?? "");
       args.ITEM = Number(args.ITEM) || 0;
 
       // Cache the last split
@@ -570,8 +570,10 @@
 
     indexof(args, util) {
       // .toLowerCase() for case insensitivity
-      args.STRING = Scratch.Cast.toString((args.STRING ?? "")).toLowerCase();
-      args.SUBSTRING = Scratch.Cast.toString((args.SUBSTRING ?? "")).toLowerCase();
+      args.STRING = Scratch.Cast.toString(args.STRING ?? "").toLowerCase();
+      args.SUBSTRING = Scratch.Cast.toString(
+        args.SUBSTRING ?? ""
+      ).toLowerCase();
 
       // Since both arguments are casted to strings beforehand,
       // we don't have to worry about type differences
@@ -607,9 +609,9 @@
 
     matchRegex(args, util) {
       try {
-        args.STRING = Scratch.Cast.toString((args.STRING ?? ""));
-        args.REGEX = Scratch.Cast.toString((args.REGEX ?? ""));
-        args.FLAGS = Scratch.Cast.toString((args.FLAGS ?? ""));
+        args.STRING = Scratch.Cast.toString(args.STRING ?? "");
+        args.REGEX = Scratch.Cast.toString(args.REGEX ?? "");
+        args.FLAGS = Scratch.Cast.toString(args.FLAGS ?? "");
         args.ITEM = Number(args.ITEM) || 0;
 
         // Cache the last matched string

--- a/extensions/text.js
+++ b/extensions/text.js
@@ -762,7 +762,7 @@
             } else {
               workingText += string[i].toLowerCase();
             }
-          }v
+          }
           return workingText.replace(/\s/g, "");
         default:
           return string;


### PR DESCRIPTION
I fixed the Text extension to use the Scratch.Cast.* API, as specified in #1810.
This is similar to part of the pull request #1990, where the same idea was proposed.

I may have made some mistakes during my review of precedent regarding this matter, so please alert me if I got something incorrect.