### PR TITLE
Require Scratch.Cast in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,6 +164,16 @@ module.exports = [
               message: "Use Scratch.fetch() instead of window.fetch()",
             },
           ]),
+          "use-scratch-cast": createQueryRule([
+            {
+              selector: "MemberExpression[object.name=Cast]",
+              message: "Use Scratch.Cast instead of Cast",
+            },
+            {
+              selector: "MemberExpression[object.name=window][property.name=Cast]",
+              message: "Use Scratch.Cast instead of window.Cast",
+            },
+          ]),
           "use-scratch-open-window": createQueryRule([
             {
               selector: "CallExpression[callee.name=open]",
@@ -309,6 +319,7 @@ module.exports = [
       "extension/iife": "error",
       "extension/use-scratch-vm": "error",
       "extension/use-scratch-fetch": "error",
+      "extension/use-scratch-cast": "error",
       "extension/use-scratch-open-window": "error",
       "extension/use-scratch-redirect": "error",
       "extension/check-can-fetch": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -170,7 +170,8 @@ module.exports = [
               message: "Use Scratch.Cast instead of Cast",
             },
             {
-              selector: "MemberExpression[object.name=window][property.name=Cast]",
+              selector:
+                "MemberExpression[object.name=window][property.name=Cast]",
               message: "Use Scratch.Cast instead of window.Cast",
             },
           ]),


### PR DESCRIPTION
This is the first time I've done something like this, and I was just following the patterns already in the file and in #1855, so I hope I did this right.

I don't think this will get merged, I probably did something dumb somewhere and I haven't tested this...

Anyway, I added a rule to eslint.config.js to return an ESLint error if using `Cast` instead of `Scratch.Cast` for all future extensions. Don't know if it will work.