### PR TITLE
Lily/Video: Update volume functions to interact with the project volume

### DIFF
--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -151,13 +151,18 @@
       // Updated code to apply the project's volume to that of the video.
       // This allows the volume to interact with Scratch Addons and Sound Expanded.
       runtime.on("AFTER_EXECUTE", () => {
+        this.updateAudio();
+      });
+
+      this.updateAudio = function () {
         for (const skin of renderer._allSkins) {
           if (skin instanceof VideoSkin) {
             let projectVolume = runtime.audioEngine.inputNode.gain.value;
             skin.videoElement.volume = skin.videoVolume * projectVolume;
+            console.log(skin.videoElement.volume);
           }
         }
-      });
+      }
 
       runtime.on("RUNTIME_PAUSED", () => {
         for (const skin of renderer._allSkins) {
@@ -696,6 +701,7 @@
 
       const value = Cast.toNumber(args.VALUE);
       videoSkin.videoVolume = Math.min(1, Math.max(0, value / 100));
+      this.updateAudio();
     }
 
     setPlaybackRate(args) {

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -42,6 +42,8 @@
       /** @type {string} */
       this.videoSrc = videoSrc;
 
+      this.videoVolume = 1;
+
       this.videoError = false;
 
       this.readyPromise = new Promise((resolve) => {
@@ -142,6 +144,17 @@
         for (const skin of renderer._allSkins) {
           if (skin instanceof VideoSkin && !skin.videoElement.paused) {
             skin.markVideoDirty();
+          }
+        }
+      });
+
+      // Updated code to apply the project's volume to that of the video.
+      // This allows the volume to interact with Scratch Addons and Sound Expanded.
+      runtime.on("AFTER_EXECUTE", () => {
+        for (const skin of renderer._allSkins) {
+          if (skin instanceof VideoSkin) {
+            let projectVolume = runtime.audioEngine.inputNode.gain.value;
+            skin.videoElement.volume = skin.videoVolume * projectVolume;
           }
         }
       });
@@ -598,7 +611,7 @@
         case "duration":
           return videoSkin.videoElement.duration;
         case "volume":
-          return videoSkin.videoElement.volume * 100;
+          return videoSkin.videoVolume * 100;
         case "width":
           return videoSkin.size[0];
         case "height":
@@ -682,7 +695,7 @@
       if (!videoSkin) return;
 
       const value = Cast.toNumber(args.VALUE);
-      videoSkin.videoElement.volume = Math.min(1, Math.max(0, value / 100));
+      videoSkin.videoVolume = Math.min(1, Math.max(0, value / 100));
     }
 
     setPlaybackRate(args) {

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -180,7 +180,7 @@
           skin.videoElement.volume = skin.videoVolume * projectVolume;
         }
       }
-    };
+    }
 
     getInfo() {
       return {

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -148,20 +148,9 @@
         }
       });
 
-      // Updated code to apply the project's volume to that of the video.
-      // This allows the volume to interact with Scratch Addons and Sound Expanded.
       runtime.on("AFTER_EXECUTE", () => {
         this.updateAudio();
       });
-
-      this.updateAudio = function () {
-        for (const skin of renderer._allSkins) {
-          if (skin instanceof VideoSkin) {
-            let projectVolume = runtime.audioEngine.inputNode.gain.value;
-            skin.videoElement.volume = skin.videoVolume * projectVolume;
-          }
-        }
-      };
 
       runtime.on("RUNTIME_PAUSED", () => {
         for (const skin of renderer._allSkins) {
@@ -172,6 +161,8 @@
         }
       });
 
+      // Updated code to apply the project's volume to that of the video.
+      // This allows the volume to interact with Scratch Addons and Sound Expanded.
       runtime.on("RUNTIME_UNPAUSED", () => {
         for (const skin of renderer._allSkins) {
           if (skin instanceof VideoSkin) {
@@ -181,6 +172,15 @@
         }
       });
     }
+
+    updateAudio() {
+      for (const skin of renderer._allSkins) {
+        if (skin instanceof VideoSkin) {
+          let projectVolume = runtime.audioEngine.inputNode.gain.value;
+          skin.videoElement.volume = skin.videoVolume * projectVolume;
+        }
+      }
+    };
 
     getInfo() {
       return {

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -159,7 +159,6 @@
           if (skin instanceof VideoSkin) {
             let projectVolume = runtime.audioEngine.inputNode.gain.value;
             skin.videoElement.volume = skin.videoVolume * projectVolume;
-            console.log(skin.videoElement.volume);
           }
         }
       };

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -162,7 +162,7 @@
             console.log(skin.videoElement.volume);
           }
         }
-      }
+      };
 
       runtime.on("RUNTIME_PAUSED", () => {
         for (const skin of renderer._allSkins) {

--- a/extensions/Lily/Video.js
+++ b/extensions/Lily/Video.js
@@ -33,7 +33,7 @@
 
   // Updated code to apply the project's volume to that of the video.
   // This allows the volume to interact with Scratch Addons and Sound Expanded.
-  const updateAudio = function() {
+  const updateAudio = function () {
     for (const skin of renderer._allSkins) {
       if (skin instanceof VideoSkin) {
         let projectVolume = runtime.audioEngine.inputNode.gain.value;


### PR DESCRIPTION
Resolves https://github.com/TurboWarp/extensions/issues/2033

Let the video's volume be affected by the project's volume (which can be manipulated through Scratch Addons and Sound Expanded).

The "volume of video" reporter has been updated to only return the video's personal volume, and does not take into account the project's volume.


https://github.com/user-attachments/assets/31dc0dca-23c2-488e-8ca0-a4725315e845
