### PR TITLE
Documentation enhancement: support markdown alerts

### DIFF
--- a/development/docs-template.ejs
+++ b/development/docs-template.ejs
@@ -141,6 +141,64 @@
         margin: 1rem 0;
         font-size: small;
       }
+
+      .alert {
+        padding-left: 15px;
+      }
+      .alert.alert-note {
+        border-left: .25em solid #1f6feb;
+      }
+      .alert.alert-tip {
+        border-left: .25em solid #238636;
+      }
+      .alert.alert-important {
+        border-left: .25em solid #8957e5;
+      }
+      .alert.alert-warning {
+        border-left: .25em solid #9e6a03;
+      }
+      .alert.alert-caution {
+        border-left: .25em solid #da3633;
+      }
+      div.alert.alert-note > p:first-child {
+        padding-top: 10px;
+        color: #4493f8;
+        font-weight: 500;
+        font-size: 14px;
+        display: flex;
+      }
+      div.alert.alert-tip > p:first-child {
+        padding-top: 10px;
+        color: #3fb950;
+        font-weight: 500;
+        font-size: 14px;
+        display: flex;
+      }
+      div.alert.alert-important > p:first-child {
+        padding-top: 10px;
+        color: #ab7df8;
+        font-weight: 500;
+        font-size: 14px;
+        display: flex;
+      }
+      div.alert.alert-warning > p:first-child {
+        padding-top: 10px;
+        color: #d29922;
+        font-weight: 500;
+        font-size: 14px;
+        display: flex;
+      }
+      div.alert.alert-caution > p:first-child {
+        padding-top: 10px;
+        color: #f85149;
+        font-weight: 500;
+        font-size: 14px;
+        display: flex;
+      }
+
+      div.alert svg {
+        margin-right: 8px;
+      }
     </style>
   </head>
   <body>

--- a/development/render-docs.js
+++ b/development/render-docs.js
@@ -25,6 +25,71 @@ md.renderer.rules.fence = function (tokens, idx, options, env, self) {
   )}">${md.utils.escapeHtml(token.content)}</pre>`;
 };
 
+md.block.ruler.before("blockquote", "custom_blockquote", function (state, startLine, endLine, silent) {
+  const marker = state.src.slice(state.bMarks[startLine], state.eMarks[startLine]);
+
+  const match = /^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)]\s*(.*)/.exec(marker);
+  if (match) {
+    const type = match[1].toLowerCase();
+    let content = match[2].trim();
+  
+    let icon;
+    switch (type) {
+      case "note":
+        icon = `<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true" fill="#4493f8"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>`;
+        break;
+      case "tip":
+        icon = `<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true" fill="#3fb950"><path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"></path></svg>`;
+        break;
+      case "important":
+        icon = `<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true" fill="#ab7df8"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>`;
+        break;
+      case "warning":
+        icon = `<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true" fill="#d29922"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>`;
+        break;
+      case "caution":
+        icon = `<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true" fill="#f85149"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>`;
+        break;
+    }
+
+    content = `<p>${icon + type.charAt(0).toUpperCase() + type.slice(1)}</p><p>${content}`;
+
+    let nextLine = startLine + 1;
+
+    while (nextLine < endLine) {
+      const nextMarker = state.src.slice(state.bMarks[nextLine], state.eMarks[nextLine]);
+
+      if (/^\s*>/.test(nextMarker)) {
+        const lineContent = nextMarker.replace(/^\s*>?\s*/, "").trim();
+        
+        if (lineContent === "") {
+          content += `<br>`;
+        } else {
+          content += `${lineContent}<br>`;
+        }
+
+        nextLine++;
+      } else {
+        break;
+      }
+    }
+
+    content += `</p>`;
+
+    if (silent) {
+      return true;
+    }
+
+    const token = state.push("html_block", "", 0);
+    token.content = `<div class="alert alert-${type}">${content}</div>`;
+
+    state.line = nextLine;
+    return true;
+  }
+
+  return false;
+});
+
 /**
  * @param {string} markdownSource Markdown code
  * @param {string} slug Path slug like 'TestMuffin/fetch'


### PR DESCRIPTION
This is a simple pull request that adds support for alerts in extension documentation markdown files: 

> [!NOTE]
> Useful information that users should know, even when skimming content.

> [!TIP]
> Helpful advice for doing things better or more easily.

> [!IMPORTANT]
> Key information users need to know to achieve their goal.

> [!WARNING]
> Urgent info that needs immediate user attention to avoid problems.

> [!CAUTION]
> Advises about risks or negative outcomes of certain actions.

Some of the CSS is messy and the rule was poorly designed and I kind of rushed this