### PR TITLE
Lily/ClonesPlus: revert breaking change

### DIFF
--- a/extensions/Lily/ClonesPlus.js
+++ b/extensions/Lily/ClonesPlus.js
@@ -442,7 +442,7 @@
     createCloneWithVar(args, util) {
       // @ts-expect-error - not typed yet
       Scratch.vm.runtime.ext_scratch3_control._createClone(
-        "_myself_",
+        util.target.sprite.name,
         util.target
       );
       const clones = util.target.sprite.clones;


### PR DESCRIPTION
https://github.com/TurboWarp/extensions/commit/5825ea724fe303963adb8aa4af75ce75094bd38f
This change breaks projects made with previous versions of the extension. This is was a change in functionality!

One of my projects is affected by this change, because it is built with clones starting with empty local variables in mind. This should be handled differently. I dont know how this was approved. You cant change stuff like this after such a long time of them working this way, without making sure that old projects are unaffected