### PR TITLE
Xeltalliv/clippingblending: Fix canvas alpha compatibility and other changes

### DIFF
--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -383,6 +383,7 @@
               },
             },
             filter: [Scratch.TargetType.SPRITE],
+            hideFromPalette: true,
             extensions: ["colours_looks"],
           },
           {

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -309,6 +309,13 @@
         menuIconURI: icon,
         blocks: [
           {
+            blockType: Scratch.BlockType.LABEL,
+            text: Scratch.translate(
+              "Stage selected: no blocks"
+            ),
+            filter: [Scratch.TargetType.STAGE],
+          },
+          {
             opcode: "setClipbox",
             blockType: Scratch.BlockType.COMMAND,
             text: Scratch.translate(

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -32,8 +32,9 @@
   const runtime = vm.runtime;
   const renderer = vm.renderer;
   const _drawThese = renderer._drawThese;
-  const gl = renderer._gl;
+  const gl = renderer.gl;
   const canvas = renderer.canvas;
+  let Drawable = renderer?.exports?.Drawable || getDrawable();
   let width = 0;
   let height = 0;
   let scratchUnitWidth = 480;
@@ -109,10 +110,12 @@
     bfb.call(this, target, framebuffer);
   };
 
-  // Getting Drawable
-  const dr = renderer.createDrawable("background");
-  const DrawableProto = renderer._allDrawables[dr].__proto__;
-  renderer.destroyDrawable(dr, "background");
+  function getDrawable() {
+    const dr = renderer.createDrawable("background");
+    const Drawable = renderer._allDrawables[dr].constructor;
+    renderer.destroyDrawable(dr, "background");
+    return Drawable;
+  }
 
   function setupModes(clipbox, blendMode, flipY) {
     if (clipbox) {
@@ -136,17 +139,17 @@
   }
 
   // Modifying and expanding Drawable
-  const gu = DrawableProto.getUniforms;
-  DrawableProto.getUniforms = function () {
+  const gu = Drawable.prototype.getUniforms;
+  Drawable.prototype.getUniforms = function () {
     if (active && toCorrectThing) {
       setupModes(this.clipbox, this.blendMode, flipY);
     }
     return gu.call(this);
   };
-  DrawableProto.updateClipBox = function (clipbox) {
+  Drawable.prototype.updateClipBox = function (clipbox) {
     this.clipbox = clipbox;
   };
-  DrawableProto.updateBlendMode = function (blendMode) {
+  Drawable.prototype.updateBlendMode = function (blendMode) {
     this.blendMode = blendMode;
   };
 

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -310,9 +310,7 @@
         blocks: [
           {
             blockType: Scratch.BlockType.LABEL,
-            text: Scratch.translate(
-              "Stage selected: no blocks"
-            ),
+            text: Scratch.translate("Stage selected: no blocks"),
             filter: [Scratch.TargetType.STAGE],
           },
           {

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -96,13 +96,17 @@
       gl.disable(gl.SCISSOR_TEST);
     }
     switch (blendMode) {
+      case "default behind":
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE_MINUS_DST_ALPHA, gl.ONE);
+        break;
       case "additive":
         gl.blendEquation(gl.FUNC_ADD);
-        gl.blendFunc(gl.ONE, gl.ONE);
+        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ZERO, gl.ONE);
         break;
       case "subtract":
         gl.blendEquation(gl.FUNC_REVERSE_SUBTRACT);
-        gl.blendFunc(gl.ONE, gl.ONE);
+        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ZERO, gl.ONE);
         break;
       case "multiply":
         gl.blendEquation(gl.FUNC_ADD);
@@ -110,7 +114,15 @@
         break;
       case "invert":
         gl.blendEquation(gl.FUNC_ADD);
-        gl.blendFunc(gl.ONE_MINUS_DST_COLOR, gl.ONE_MINUS_SRC_COLOR);
+        gl.blendFuncSeparate(gl.ONE_MINUS_DST_COLOR, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE);
+        break;
+      case "mask":
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ZERO, gl.SRC_ALPHA);
+        break;
+      case "erase":
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ZERO, gl.ONE_MINUS_SRC_ALPHA);
         break;
       default:
         gl.blendEquation(gl.FUNC_ADD);
@@ -400,10 +412,13 @@
             acceptReporters: true,
             items: [
               { text: Scratch.translate("default"), value: "default" },
+              { text: Scratch.translate("default behind"), value: "default behind" },
               { text: Scratch.translate("additive"), value: "additive" },
               { text: Scratch.translate("subtract"), value: "subtract" },
               { text: Scratch.translate("multiply"), value: "multiply" },
               { text: Scratch.translate("invert"), value: "invert" },
+              { text: Scratch.translate("mask"), value: "mask" },
+              { text: Scratch.translate("erase"), value: "erase" },
             ],
           },
           props: {
@@ -482,10 +497,13 @@
       let newValue = null;
       switch (BLENDMODE) {
         case "default":
+        case "default behind":
         case "additive":
         case "subtract":
         case "multiply":
         case "invert":
+        case "mask":
+        case "erase":
           newValue = BLENDMODE;
           break;
         default:

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -34,7 +34,7 @@
   const _drawThese = renderer._drawThese;
   const gl = renderer.gl;
   const canvas = renderer.canvas;
-  let Drawable = renderer?.exports?.Drawable || getDrawable();
+  let Drawable = renderer.exports.Drawable;
   let width = 0;
   let height = 0;
   let scratchUnitWidth = 480;
@@ -109,13 +109,6 @@
     }
     bfb.call(this, target, framebuffer);
   };
-
-  function getDrawable() {
-    const dr = renderer.createDrawable("background");
-    const Drawable = renderer._allDrawables[dr].constructor;
-    renderer.destroyDrawable(dr, "background");
-    return Drawable;
-  }
 
   function setupModes(clipbox, blendMode, flipY) {
     if (clipbox) {

--- a/extensions/Xeltalliv/clippingblending.js
+++ b/extensions/Xeltalliv/clippingblending.js
@@ -39,6 +39,13 @@
   let scratchUnitWidth = 480;
   let scratchUnitHeight = 360;
   let penDirty = false;
+  const publicApi =
+    runtime.ext_clippingblendingapi ?? (runtime.ext_clippingblendingapi = {});
+  if (!publicApi.mainFramebuffer) publicApi.mainFramebuffer = null;
+  if (!publicApi.setActive)
+    publicApi.setActive = (value) => {
+      active = value;
+    };
 
   // prettier-ignore
   const Blendings = Object.assign(Object.create(null), {
@@ -70,7 +77,7 @@
   gl.bindFramebuffer = function (target, framebuffer) {
     let toCanvas = false;
     if (target == gl.FRAMEBUFFER) {
-      if (framebuffer == null) {
+      if (framebuffer == publicApi.mainFramebuffer) {
         toCanvas = true;
         toCorrectThing = true;
         flipY = false;


### PR DESCRIPTION
This:
* Fixes compatibility with canvas having alpha, without changing behavior of  _any_ old projects compared to how they used to work (at least in theory).
* Sorts out long standing issue of some blending modes working incorrectly, by deprecating old block and making a new one, where everything is done in a corrected and clean way.
* Adds new blending modes, to provide proper solutions to what was done through bugs.
* Adds API, so that [Shaded](https://pen-group.github.io/extensions/) extension can be compatible with this extension, without the need for maintaining a custom fork of it.
* Adds a label explaining why there is sometimes no blocks in the palette.
![image](https://github.com/user-attachments/assets/774ba0c9-7373-4ad6-89ba-2afbde218f78)

