### PR TITLE
Xeltalliv/simple3D: mark drawable as non-interactive

### DIFF
--- a/extensions/Xeltalliv/simple3D.js
+++ b/extensions/Xeltalliv/simple3D.js
@@ -1136,6 +1136,13 @@
     const drawable = renderer._allDrawables[drawableId];
     renderer.updateDrawableSkinId(drawableId, skinId);
 
+    // Prevent pick() from trying to read all the pixels from the 3D skin as this drawable does not
+    // correspond to a target, so it can't be dragged or anything like that. Fixes pick() doing an
+    // unnecessary GPU -> CPU transfer (very slow) for a collision test whose result doesn't matter.
+    if (renderer.markDrawableAsNoninteractive) {
+      renderer.markDrawableAsNoninteractive(drawableId);
+    }
+
     // Detect resizing
     drawable.setHighQuality = function (...args) {
       Object.getPrototypeOf(this).setHighQuality(...args);


### PR DESCRIPTION
Fixes performance issue in https://github.com/TurboWarp/scratch-gui/issues/1026

Relies on https://github.com/TurboWarp/scratch-render/commit/1ffefcf2cdff2fcbe0bc7f0f000521ae2843f3a8
