### PR TITLE
cloudlink: make every (non-localhost) server ID behave like 7

### DIFF
--- a/extensions/cloudlink.js
+++ b/extensions/cloudlink.js
@@ -2178,6 +2178,10 @@
         console.warn("[CloudLink] Already connected to a server.");
         return;
       }
+      // This is the only server that's listed and works.
+      if (Scratch.Cast.toNumber(args.ID) >= 1) {
+        args.ID = 7;
+      }
       if (
         !Object.prototype.hasOwnProperty.call(
           clVars.serverList,


### PR DESCRIPTION
this is a bit of a "PR made slightly out of anger".

"use server 7" is almost memetic in the TW server, and some people think CL is broken because people try to connect to e.g server ID 1 and it doesn't work. 7 is the only server left anyways.

(0 still remains as localhost though)