### PR TITLE
Add min and max block to true-fantom/math.js

### DIFF
--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -639,7 +639,11 @@
       return 0 - cast.toNumber(A);
     }
     min_or_max_block(args) {
-      if (args.MIN_OR_MAX === "min") { return Math.min(args.A, args.B); } else { return Math.max(args.A, args.B); }
+      if (args.MIN_OR_MAX === "min") {
+        return Math.min(args.A, args.B);
+      } else {
+        return Math.max(args.A, args.B);
+      }
     }
     more_or_equal_block({ A, B }) {
       return cast.compare(A, B) >= 0;

--- a/extensions/true-fantom/math.js
+++ b/extensions/true-fantom/math.js
@@ -154,6 +154,26 @@
             },
             extensions: ["colours_operators"],
           },
+          {
+            opcode: "min_or_max_block",
+            blockType: Scratch.BlockType.REPORTER,
+            text: "get [A] [MIN_OR_MAX] [B]",
+            arguments: {
+              A: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "",
+              },
+              B: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: "",
+              },
+              MIN_OR_MAX: {
+                type: Scratch.ArgumentType.NUMBER,
+                menu: "MIN_OR_MAX",
+              },
+            },
+            extensions: ["colours_operators"],
+          },
           "---",
           {
             opcode: "more_or_equal_block",
@@ -601,6 +621,10 @@
             acceptReporters: true,
             items: ["sin", "cos", "tan", "asin", "acos", "atan"],
           },
+          MIN_OR_MAX: {
+            acceptReporters: true,
+            items: ["min", "max"],
+          },
         },
       };
     }
@@ -613,6 +637,9 @@
     }
     negative_block({ A }) {
       return 0 - cast.toNumber(A);
+    }
+    min_or_max_block(args) {
+      if (args.MIN_OR_MAX === "min") { return Math.min(args.A, args.B); } else { return Math.max(args.A, args.B); }
     }
     more_or_equal_block({ A, B }) {
       return cast.compare(A, B) >= 0;


### PR DESCRIPTION
Not only do we need this, but I literally don't know an official extension in the gallery that has this block.

<img width="424" height="80" alt="block_8_4_2025-2_30_53 PM" src="https://github.com/user-attachments/assets/b17e8099-ed32-483b-8ae9-56fa5e3f830d" />
