### PR TITLE
Add cameratools extension to TurboWarp Extensions list

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -76,6 +76,7 @@
   "Longboost/color_channels",
   "CST1229/zip",
   "CST1229/images",
+  "libmaster169/cameratools",
   "TheShovel/LZ-String",
   "0832/rxFS2",
   "NexusKitten/sgrab",


### PR DESCRIPTION
# 📷 CameraTools Extension

The **CameraTools** extension provides blocks for accessing the user's webcam and analyzing live video frames. It enables Scratch projects to interact with the real world through camera input, making it ideal for creative coding, interactive installations, and basic computer vision experiments.

## 🧩 Features

- Capture live video frames from the user's webcam
- Read pixel color and brightness at specific coordinates
- Detect motion or changes in the image
- Apply simple filters or effects to the video stream

## 🎮 Example Use Cases

- Motion-controlled games
- Color-based object tracking
- Interactive art reacting to movement
- Educational demos on image processing