### PR TITLE
Update CONTRIBUTING.md to provide better guidelines about translation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,13 @@ Most extensions shouldn't need external documentation -- it should be obvious wh
 
 Static resources such as example resources used by extensions go in the `website` folder.
 
+## Making sure that your extension can be easily translated
+### In block text
+Make sure to use `Scratch.translate()` on any user-facing text in your extension, unless there is a good reason not to.
+
+### In your extension's image
+You should avoid putting any important text in your extension's image, because TurboWarp does not know how to translate it. As a rule of thumb, try replacing all of your image's text with gibberish and see if the intended meaning comes across either way; if it doesn't, it shouldn't be added to Turbowarp.
+
 ## Banned APIs
 
 Don't use these:


### PR DESCRIPTION
I've noticed that a lot of developers writing new extensions for TurboWarp are not paying much attention to the translatability of their work, and I don't blame them. Nowhere in the documentation or contribution guidelines do we mention things like `Scratch.translate()`, and so many extensions take much longer to refine before they get accepted.

I have written a rough draft for improved guidelines that will hopefully make this situation much more manageable. A lot of help is needed; feel free to improve it!