### PR TITLE
TheShovel/CustomStyles: fix list scrolling getter

### DIFF
--- a/extensions/TheShovel/CustomStyles.js
+++ b/extensions/TheShovel/CustomStyles.js
@@ -729,7 +729,7 @@
               },
               {
                 text: Scratch.translate("list scrolling"),
-                value: "list scrolling"
+                value: "list scrolling",
               },
             ],
           },
@@ -915,7 +915,10 @@
         return askInputRoundness;
       } else if (args.ITEM === "ask prompt button image") {
         return askButtonImage;
-      } else if (args.ITEM === "list scrolling" || args.ITEM === "list scroll rule") {
+      } else if (
+        args.ITEM === "list scrolling" ||
+        args.ITEM === "list scroll rule"
+      ) {
         if (allowScrolling === "hidden") {
           return "disabled";
         } else {

--- a/extensions/TheShovel/CustomStyles.js
+++ b/extensions/TheShovel/CustomStyles.js
@@ -917,6 +917,9 @@
         return askButtonImage;
       } else if (
         args.ITEM === "list scrolling" ||
+        // Old version of this extension had "list scroll rule" in the menu so
+        // we'll support either.
+        // https://github.com/TurboWarp/extensions/pull/2262
         args.ITEM === "list scroll rule"
       ) {
         if (allowScrolling === "hidden") {

--- a/extensions/TheShovel/CustomStyles.js
+++ b/extensions/TheShovel/CustomStyles.js
@@ -728,8 +728,8 @@
                 value: "ask prompt button image",
               },
               {
-                text: Scratch.translate("list scroll rule"),
-                value: "list scroll rule",
+                text: Scratch.translate("list scrolling"),
+                value: "list scrolling"
               },
             ],
           },
@@ -915,11 +915,11 @@
         return askInputRoundness;
       } else if (args.ITEM === "ask prompt button image") {
         return askButtonImage;
-      } else if (args.ITEM === "list scrolling") {
-        if (allowScrolling === "auto") {
-          return "enabled";
-        } else {
+      } else if (args.ITEM === "list scrolling" || args.ITEM === "list scroll rule") {
+        if (allowScrolling === "hidden") {
           return "disabled";
+        } else {
+          return "enabled";
         }
       }
       return "";


### PR DESCRIPTION
- The menu value didn't match what the block wanted so it always reported empty string
- The name was confusing
- Even if you manually put the right text in, it would report the wrong thing if you didn't run the set list scrolling block before running the getter