### PR TITLE
local-storage: generate random namspace, persist namespace, and optimize

### DIFF
--- a/extensions/local-storage.js
+++ b/extensions/local-storage.js
@@ -13,12 +13,84 @@
   const getNamespace = () =>
     Scratch.vm.runtime.extensionStorage["localstorage"]?.namespace;
 
+  /**
+   * @param {string} newNamespace
+   */
   const setNamespace = (newNamespace) => {
     Scratch.vm.runtime.extensionStorage["localstorage"] = {
       namespace: newNamespace,
     };
     Scratch.vm.extensionManager.refreshBlocks("localstorage");
+    readFromStorage();
   };
+
+  const STORAGE_PREFIX = "extensions.turbowarp.org/local-storage:";
+  const getStorageKey = () => `${STORAGE_PREFIX}${getNamespace()}`;
+
+  /**
+   * Cached in memory for performance.
+   * @type {Record<string, string|number|boolean>}
+   */
+  let namespaceValues = Object.create(null);
+
+  const readFromStorage = () => {
+    namespaceValues = Object.create(null);
+
+    try {
+      // localStorage could throw if unsupported
+      const data = localStorage.getItem(getStorageKey());
+      if (data) {
+        // JSON.parse could throw if data is invalid
+        const parsed = JSON.parse(data);
+        if (parsed && parsed.data) {
+          // Remove invalid values from the JSON
+          for (const [key, value] of Object.entries(parsed.data)) {
+            if (
+              typeof value === "string" ||
+              typeof value === "number" ||
+              typeof value === "boolean"
+            ) {
+              namespaceValues[key] = value;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error reading from local storage", error);
+    }
+  };
+
+  const saveToLocalStorage = () => {
+    try {
+      if (Object.keys(namespaceValues).length > 0) {
+        localStorage.setItem(
+          getStorageKey(),
+          JSON.stringify({
+            // If we find that turbowarp.org is commonly running out of shared space in local storage,
+            // having a timestamp here makes it at least theoretically possible to delete storage based
+            // on last used time.
+            time: Math.round(Date.now() / 1000),
+            data: namespaceValues,
+          })
+        );
+      } else {
+        localStorage.removeItem(getStorageKey());
+      }
+    } catch (error) {
+      console.error("Error saving to local storage", error);
+    }
+  };
+
+  window.addEventListener("storage", (event) => {
+    if (
+      getNamespace() &&
+      event.key === getStorageKey() &&
+      event.storageArea === localStorage
+    ) {
+      readFromStorage();
+      Scratch.vm.runtime.startHats("localstorage_whenChanged");
+    }
+  });
 
   const generateRandomNamespace = () => {
     // doesn't need to be cryptographically secure and doesn't need to have excessive length
@@ -60,65 +132,6 @@
     }
     return valid;
   };
-
-  const STORAGE_PREFIX = "extensions.turbowarp.org/local-storage:";
-  const getStorageKey = () => `${STORAGE_PREFIX}${getNamespace()}`;
-
-  const readFromStorage = () => {
-    try {
-      // localStorage could throw if unsupported
-      const data = localStorage.getItem(getStorageKey());
-      if (data) {
-        // JSON.parse could throw if data is invalid
-        const parsed = JSON.parse(data);
-        if (parsed && parsed.data) {
-          // Remove invalid values from the JSON
-          const processed = {};
-          for (const [key, value] of Object.entries(parsed.data)) {
-            if (
-              typeof value === "number" ||
-              typeof value === "string" ||
-              typeof value === "boolean"
-            ) {
-              processed[key] = value;
-            }
-          }
-          return processed;
-        }
-      }
-    } catch (error) {
-      console.error("error reading from local storage", error);
-    }
-    return {};
-  };
-
-  const saveToLocalStorage = (data) => {
-    try {
-      if (Object.keys(data).length > 0) {
-        localStorage.setItem(
-          getStorageKey(),
-          JSON.stringify({
-            time: Math.round(Date.now() / 1000),
-            data,
-          })
-        );
-      } else {
-        localStorage.removeItem(getStorageKey());
-      }
-    } catch (error) {
-      console.error("error saving to locacl storage", error);
-    }
-  };
-
-  window.addEventListener("storage", (event) => {
-    if (
-      getNamespace() &&
-      event.key === getStorageKey() &&
-      event.storageArea === localStorage
-    ) {
-      Scratch.vm.runtime.startHats("localstorage_whenChanged");
-    }
-  });
 
   class LocalStorage {
     getInfo() {
@@ -196,7 +209,8 @@
             arguments: {
               ID: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: getNamespace() || Scratch.translate("project title"),
+                defaultValue:
+                  getNamespace() || Scratch.translate("project title"),
               },
             },
           },
@@ -212,37 +226,35 @@
       if (!validNamespace()) {
         return "";
       }
-      const storage = readFromStorage();
       KEY = Scratch.Cast.toString(KEY);
-      if (!Object.prototype.hasOwnProperty.call(storage, KEY)) {
+      if (!Object.prototype.hasOwnProperty.call(namespaceValues, KEY)) {
         return "";
       }
-      return storage[KEY];
+      return namespaceValues[KEY];
     }
 
     set({ KEY, VALUE }) {
       if (!validNamespace()) {
         return "";
       }
-      const storage = readFromStorage();
-      storage[Scratch.Cast.toString(KEY)] = VALUE;
-      saveToLocalStorage(storage);
+      namespaceValues[Scratch.Cast.toString(KEY)] = VALUE;
+      saveToLocalStorage();
     }
 
     remove({ KEY }) {
       if (!validNamespace()) {
         return "";
       }
-      const storage = readFromStorage();
-      delete storage[Scratch.Cast.toString(KEY)];
-      saveToLocalStorage(storage);
+      delete namespaceValues[Scratch.Cast.toString(KEY)];
+      saveToLocalStorage();
     }
 
     removeAll() {
       if (!validNamespace()) {
         return "";
       }
-      saveToLocalStorage({});
+      namespaceValues = Object.create(null);
+      saveToLocalStorage();
     }
   }
 


### PR DESCRIPTION
- whatever namespace is last set gets saved in project.json and loaded again later, so using "set namespace id to ..." no longer necessary for 99% of projects
- random namespace is generated when extension is loaded and there isn't a saved namespace
- reading variables is now faster since it doesn't actually go to storage every time
- rename blocks for clarity

missing: update docs