### PR TITLE
text: fix a weird string choice

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -408,7 +408,8 @@
             blockType: Scratch.BlockType.BOOLEAN,
             text: Scratch.translate({
               default: "[STRING] [POSITION] with [SUBSTRING]?",
-              description: "[POSITION] is a dropdown with 'starts' and 'ends'. The block then takes the form '[STRING] starts with [SUBSTRING]?' or '[STRING] ends with [SUBSTRING]?'"
+              description:
+                "[POSITION] is a dropdown with 'starts' and 'ends'. The block then takes the form '[STRING] starts with [SUBSTRING]?' or '[STRING] ends with [SUBSTRING]?'",
             }),
             arguments: {
               STRING: {


### PR DESCRIPTION
Trying to be funny and put the `s` outside of the dropdown is very confusing to users and especially the people who have to try translating that into other languages