### PR TITLE
cloudlink: fix weird string

### DIFF
--- a/extensions/cloudlink.js
+++ b/extensions/cloudlink.js
@@ -1347,7 +1347,7 @@
             arguments: {
               ROOMS: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: Scratch.translate('["test"]'),
+                defaultValue: JSON.stringify(["test"]),
               },
             },
           },
@@ -1359,7 +1359,7 @@
             arguments: {
               ROOMS: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: Scratch.translate('["test"]'),
+                defaultValue: JSON.stringify(["test"]),
               },
             },
           },


### PR DESCRIPTION
transifex interprets `["test"]` as a variable so then the translators can't even change what it says

but even if they could change what it says: we can't expect translators to implicitly understand that this is JSON 

but even if we could assume that: it's not clear how a translator should go about translating this

so let's just hardcode English there, as is already done for some other places in the extension where there is a free-form input for some sort of identifier