### PR TITLE
text.js -- Add array of regex matches block

### DIFF
--- a/extensions/text.js
+++ b/extensions/text.js
@@ -571,29 +571,6 @@
       }
       return splitCache.arr[item - 1] || "";
     }
-    splitJSON(args, util) {
-      // split but it returns an array
-      const string = Scratch.Cast.toString(args.STRING);
-      const split = Scratch.Cast.toString(args.SPLIT);
-
-      // Cache the last split
-      if (
-        !(
-          splitCache &&
-          splitCache.string === string &&
-          splitCache.split === split
-        )
-      ) {
-        const regex = this._caseInsensitiveRegex(split);
-
-        splitCache = {
-          string,
-          split,
-          arr: string.split(regex),
-        };
-      }
-      return JSON.stringify(splitCache.arr) || "[]";
-    }
 
     count(args, util) {
       // Fill cache


### PR DESCRIPTION
Added modified versions of `split` and `matchRegex` that both return an array instead of a specific item, which can be useful in more complex projects. I also moved `testRegex` so all of the match blocks could be together in the palette.


Pretty quick, so there isn't that much polish. It was mostly an easy copy-and-paste job and things are still left in.