### PR TITLE
DogeisCut/FormatNumbers: Resolve AD notation inconsistencies

### DIFF
--- a/extensions/DogeisCut/FormatNumbers.js
+++ b/extensions/DogeisCut/FormatNumbers.js
@@ -56,13 +56,13 @@
         "No",
         "Dc",
       ];
-      const unitPrefixes = ["U", "D", "T", "Qa", "Qt", "Sx", "Sp", "O", "N"];
+      const unitPrefixes = ["U", "D", "T", "Qa", "Qn", "Sx", "Sp", "O", "N"];
       const tensPrefixes = [
         "Dc",
         "Vg",
         "Tg",
         "Qd",
-        "Qi",
+        "Qn",
         "Se",
         "St",
         "Og",
@@ -98,7 +98,7 @@
         );
       }
 
-      const illionNumber = Math.floor(Math.log10(Math.abs(number)) / 3);
+      const illionNumber = Math.floor(Math.log10(Math.abs(number)) / 3) - 1;
       let illionString = "";
 
       if (illionNumber <= 999) {
@@ -108,8 +108,8 @@
 
         illionString =
           (hundreds > 0 ? hundredsPrefixes[hundreds - 1] : "") +
-          (tens > 0 ? tensPrefixes[tens - 1] : "") +
-          (units > 0 ? unitPrefixes[units - 1] : "");
+          (units > 0 ? unitPrefixes[units - 1] : "") +
+          (tens > 0 ? tensPrefixes[tens - 1] : "");
       } else {
         const tier2Index = Math.floor(illionNumber / 1000);
         const tier2Remainder = illionNumber % 1000;


### PR DESCRIPTION
Resolves: https://github.com/TurboWarp/extensions/issues/2328

Results:
10^33: 1Dc
10^36: 1 UDc
10^45: 1 QaDc
10^48: 1 QnDc

See https://pastebin.com/JpUFnLtp for full results, please let me know if you see anything wrong as I can not locate the resource I was previously using to verify this.