### PR TITLE
obviousAlexC/newgroundsIO: use minified JS instead

### DIFF
--- a/extension-dependencies.json
+++ b/extension-dependencies.json
@@ -36,8 +36,8 @@
       "sha256": "95f4d1cbf099f57161b664bc048426ec3df92637801a4c79116e83315aa787e7",
       "contentType": "application/javascript; charset=utf-8"
     },
-    "https://raw.githubusercontent.com/PsychoGoldfishNG/NewgroundsIO-JS/b0383337ef72d42dac12b7a4d7a24dfbc4105eb3/dist/NewgroundsIO.js": {
-      "sha256": "b6f68cf85f59b17d6489d1dde4b499827b0cc29f58472832643abaa8b9352ae8",
+    "https://raw.githubusercontent.com/PsychoGoldfishNG/NewgroundsIO-JS/b0383337ef72d42dac12b7a4d7a24dfbc4105eb3/dist/NewgroundsIO.min.js": {
+      "sha256": "cc18cf00a76e0bc8a2117b9ac4c7c123131a7377e186576182d2a1552510a86a",
       "contentType": "text/plain; charset=utf-8"
     }
   }

--- a/extensions/obviousAlexC/newgroundsIO.js
+++ b/extensions/obviousAlexC/newgroundsIO.js
@@ -33,7 +33,7 @@
     SOFTWARE.
   */
   const NGIO = await Scratch.external.evalAndReturn(
-    "https://raw.githubusercontent.com/PsychoGoldfishNG/NewgroundsIO-JS/b0383337ef72d42dac12b7a4d7a24dfbc4105eb3/dist/NewgroundsIO.js",
+    "https://raw.githubusercontent.com/PsychoGoldfishNG/NewgroundsIO-JS/b0383337ef72d42dac12b7a4d7a24dfbc4105eb3/dist/NewgroundsIO.min.js",
     "NGIO"
   );
 


### PR DESCRIPTION
Saves some space. It should be easy to verify that the JS file was generated at the same commit as the unminified JS so you don't need to do crazy testing.