### PR TITLE
Only update first party dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    ignore:
-      # Prettier updates that result in style changes result in cascading format validation
-      # errors until all pull requests get rebased. It's not worth the effort to follow
-      # every update. We'll do this manually when there's some change we want.
-      - dependency-name: prettier
+      interval: "daily"
+    assignees:
+      - "GarboMuffin"
+    allow:
+      # Only try to automatically bump first-party dependencies.
+      - dependency-name: "@turbowarp/*"


### PR DESCRIPTION
npm gets compromised every other day. We don't really benefit from updating to every little version of ESLint (etc.) but the risks are distinctly non-zero.
