### PR TITLE
SharkPool/Camera V2 -- Fix hidden sprites not receiving camera updates

### DIFF
--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -4,7 +4,7 @@
 // By: SharkPool
 // License: MIT
 
-// Version V.1.0.09
+// Version V.1.0.1
 
 (function (Scratch) {
   "use strict";
@@ -272,6 +272,23 @@
       this._skinScaleDirty = true;
       this.setTransformDirty();
     }
+  };
+
+  const ogUpdateVisible = render.exports.Drawable.prototype.updateVisible;
+  render.exports.Drawable.prototype.updateVisible = function (isVisible) {
+    if (!this[cameraSymbol]) setupState(this);
+    if (isVisible && this._visible !== isVisible) {
+      // save some renderer calls, packing this all into one
+      // while running only when isVisible is true combines this
+      // into a single renderer call
+      this[cameraSymbol].needsRefresh = true;
+      this.updateProperties({
+        position: this._position,
+        direction: this._direction,
+        scale: this.scale,
+      });
+    }
+    ogUpdateVisible.call(this, isVisible);
   };
 
   // Clones should inherit the parents camera


### PR DESCRIPTION
This also fixes https://github.com/TurboWarp/extensions/issues/2370

Its basically the same code as before the revert, except I added the important line that makes it *not* refresh the camera if the visibility change is the same value is before...

this was tested under the same conditions and project @DogeisCut provided