### PR TITLE
SharkPool/Camera-V2 -- Refactor visibility patch

### DIFF
--- a/extensions/SharkPool/Camera.js
+++ b/extensions/SharkPool/Camera.js
@@ -4,7 +4,7 @@
 // By: SharkPool
 // License: MIT
 
-// Version V.1.0.1
+// Version V.1.0.11
 
 (function (Scratch) {
   "use strict";
@@ -278,14 +278,17 @@
   render.exports.Drawable.prototype.updateVisible = function (isVisible) {
     if (!this[cameraSymbol]) setupState(this);
     if (isVisible && this._visible !== isVisible) {
+      const camSystem = this[cameraSymbol];
+      const safeOgSZ = camSystem.ogSZ !== 0 ? camSystem.ogSZ : 1e-10;
+      const updatedScale = [this.scale[0] / safeOgSZ, this.scale[1] / safeOgSZ];
+
       // save some renderer calls, packing this all into one
       // while running only when isVisible is true combines this
       // into a single renderer call
-      this[cameraSymbol].needsRefresh = true;
       this.updateProperties({
-        position: this._position,
-        direction: this._direction,
-        scale: this.scale,
+        position: translatePosition(this._position, true, camSystem),
+        direction: this._direction + camSystem.ogDir,
+        scale: updatedScale,
       });
     }
     ogUpdateVisible.call(this, isVisible);


### PR DESCRIPTION
Fixes a niche issue brought up in discord. Essentially, my code *does* fix sprites not receiving *camera* updates while hidden, but it seemed to not receive *sprite* updates (so normal motion blocks).

Anyways the fix was just refactoring the code, nothing too special, but it does fix the issue.