### PR TITLE
box2d: Correct mixup of the x and y coordinates

### DIFF
--- a/extensions/box2d.js
+++ b/extensions/box2d.js
@@ -13720,7 +13720,7 @@
           }
           break;
         case SPACE_TYPE_OPTIONS.RELATIVE: {
-          _setXY(util.target, util.target.x + x, util.target.x + y);
+          _setXY(util.target, util.target.x + x, util.target.y + y);
           if (body) {
             const pos = body.GetPosition();
             const pos2 = new b2Vec2(pos.x + x / zoom, pos.y + y / zoom);


### PR DESCRIPTION
The relative space type of the set position block in Box2D was set incorrectly such that it set the y position relative to the current x position rather than the y position.

This means that setting inputs of -2, 20 would result in the sprite going negative in both directions, with the y coordinate always being +20 > the x coordinate. (see below video)

------------------------------------------------------------------------------------------------------

The following video shows the incorrect behavior (current) and the corrected behavior (this patch) using the same script:

<img width="349" height="347" alt="Screenshot 2026-01-19 191552" src="https://github.com/user-attachments/assets/f83b7674-7d5c-485f-96e1-9bd1bd244d5f" />

https://github.com/user-attachments/assets/fe0ba0cd-c4cf-4379-8e03-de75ef6a31f1

------------------------------------------------------------------------------------------------------

Didn't look before making this change but I'm pretty sure this patch resolves this issue:

Fixes #935

Also, I think this bug is almost 7 years old, since I found the original patch in Griffpatch's VM fork, and it's from February 2019.