### PR TITLE
true-fantom/network: hide connected_to_internet_block

### DIFF
--- a/extensions/true-fantom/network.js
+++ b/extensions/true-fantom/network.js
@@ -102,8 +102,8 @@
             opcode: "connected_to_internet_block",
             blockType: Scratch.BlockType.BOOLEAN,
             text: Scratch.translate("connected to internet?"),
+            hideFromPalette: true,
           },
-          "---",
           {
             opcode: "browser_block",
             blockType: Scratch.BlockType.REPORTER,


### PR DESCRIPTION
There is now an "online?" block in upstream so a separate block is unnecessary