### PR TITLE
DogeisCut/FormatNumbers: don't trim off zeros when decimals = 0

### DIFF
--- a/extensions/DogeisCut/FormatNumbers.js
+++ b/extensions/DogeisCut/FormatNumbers.js
@@ -29,6 +29,11 @@
       this.decimalPlaces = 2;
     }
 
+    toFixedTrimmed(number, decimalPlaces) {
+      const formatted = number.toFixed(decimalPlaces);
+      return decimalPlaces > 0 ? formatted.replace(/\.?0+$/, "") : formatted;
+    }
+
     convertToADStandard(number, decimalPlaces = 2) {
       if (typeof number !== "number" || isNaN(number)) {
         return "Invalid Input";
@@ -86,7 +91,7 @@
       }
 
       if (Math.abs(number) < 1000) {
-        return number.toFixed(decimalPlaces).replace(/\.?0+$/, "");
+        return this.toFixedTrimmed(number, decimalPlaces);
       }
 
       const tier = Math.max(0, Math.floor(Math.log10(Math.abs(number)) / 3));
@@ -94,7 +99,8 @@
       if (tier <= 11) {
         const scaledNumber = number / Math.pow(10, tier * 3);
         return (
-          scaledNumber.toFixed(decimalPlaces).replace(/\.?0+$/, "") + kMBd[tier]
+          this.toFixedTrimmed(scaledNumber, decimalPlaces) +
+          kMBd[tier]
         );
       }
 
@@ -136,7 +142,7 @@
       const scaledNumber =
         number / Math.pow(10, Math.floor(Math.log10(Math.abs(number)) / 3) * 3);
       return (
-        scaledNumber.toFixed(decimalPlaces).replace(/\.?0+$/, "") +
+        this.toFixedTrimmed(scaledNumber, decimalPlaces) +
         " " +
         illionString
       );

--- a/extensions/DogeisCut/FormatNumbers.js
+++ b/extensions/DogeisCut/FormatNumbers.js
@@ -98,10 +98,7 @@
 
       if (tier <= 11) {
         const scaledNumber = number / Math.pow(10, tier * 3);
-        return (
-          this.toFixedTrimmed(scaledNumber, decimalPlaces) +
-          kMBd[tier]
-        );
+        return this.toFixedTrimmed(scaledNumber, decimalPlaces) + kMBd[tier];
       }
 
       const illionNumber = Math.floor(Math.log10(Math.abs(number)) / 3) - 1;
@@ -142,9 +139,7 @@
       const scaledNumber =
         number / Math.pow(10, Math.floor(Math.log10(Math.abs(number)) / 3) * 3);
       return (
-        this.toFixedTrimmed(scaledNumber, decimalPlaces) +
-        " " +
-        illionString
+        this.toFixedTrimmed(scaledNumber, decimalPlaces) + " " + illionString
       );
     }
 


### PR DESCRIPTION
I suspect we can get rid of this whole .replace(...) string operation stuff with just numbers but decided to keep it safe for now

This was investigated with some help from Claude. Given just the prompt "investigate issue 2436" it was able to identify the problem and propose a fix (not a great one, but still it would've worked)

Closes #2436