### PR TITLE
Change attribution from ClaytonTDM to clay.rip

### DIFF
--- a/extensions/Clay/htmlEncode.js
+++ b/extensions/Clay/htmlEncode.js
@@ -1,7 +1,7 @@
 // Name: HTML Encode
 // ID: clayhtmlencode
 // Description: Escape untrusted text to safely include in HTML.
-// By: ClaytonTDM
+// By: clay.rip
 // License: MIT
 
 (function (Scratch) {

--- a/images/README.md
+++ b/images/README.md
@@ -311,7 +311,7 @@ All images in this folder are licensed under the [GNU General Public License ver
  - Font is Deja Vu Sans.
 
 ## Clay/htmlEncode.svg
- - Created by [@ClaytonTDM](https://github.com/ClaytonTDM) in https://github.com/TurboWarp/extensions/issues/90#issuecomment-1849825710
+ - Created by [@clay-rip](https://github.com/clay-rip) in https://github.com/TurboWarp/extensions/issues/90#issuecomment-1849825710
 
 ## CST1229/images.svg
  - Created by [@wiktorlaskowski](https://github.com/wiktorlaskowski) in https://github.com/TurboWarp/extensions/pull/2144


### PR DESCRIPTION
I've updated my online username in most places to "Clay" or "clay.rip" — this PR updates it in the TurboWarp extension gallery.