### PR TITLE
Add Pixelbridge extension

### DIFF
--- a/extensions/pixelbridge.js
+++ b/extensions/pixelbridge.js
@@ -1,0 +1,204 @@
+// Name: PixelBridge
+// ID: pixelbridge
+// Description: Convert PNG Data URLs to pixel arrays and back. Enables pixel-level image manipulation inside Scratch projects.
+// By: Claude AI
+// License: MIT
+
+(function (Scratch) {
+  'use strict';
+
+  // ── Utilities ─────────────────────────────────────────────────────────────────
+
+  /** Creates an off-screen canvas of the given size. */
+  function createCanvas(w, h) {
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    return canvas;
+  }
+
+  /**
+   * Loads a Data URL into an HTMLImageElement.
+   * Resolves with the element, rejects if the source is invalid.
+   */
+  function loadImage(src) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('Invalid or corrupt image source.'));
+      img.src = src;
+    });
+  }
+
+  /**
+   * Converts a raw RGBA Uint8ClampedArray into an array of 24-bit integers
+   * (0xRRGGBB). The alpha channel is discarded.
+   */
+  function rgbaToInt24Array(data) {
+    const pixels = new Array(data.length / 4);
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+      pixels[p] = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+    }
+    return pixels;
+  }
+
+  /**
+   * Writes a 24-bit integer array into an ImageData buffer (alpha set to 255).
+   * Returns false if the array is shorter than pixelCount.
+   */
+  function int24ArrayToImageData(arr, imgData, pixelCount) {
+    if (arr.length < pixelCount) return false;
+    for (let i = 0; i < pixelCount; i++) {
+      const c = (Number(arr[i]) >>> 0) & 0xffffff;
+      imgData.data[i * 4]     = (c >> 16) & 0xff; // R
+      imgData.data[i * 4 + 1] = (c >>  8) & 0xff; // G
+      imgData.data[i * 4 + 2] =  c        & 0xff; // B
+      imgData.data[i * 4 + 3] = 255;               // A (fully opaque)
+    }
+    return true;
+  }
+
+  // ── Extension class ───────────────────────────────────────────────────────────
+
+  class PixelBridge {
+    getInfo() {
+      return {
+        id: 'pixelbridge',
+        name: 'PixelBridge',
+        color1: '#5C4FCE',
+        color2: '#3D3491',
+        color3: '#2B2468',
+
+        blocks: [
+          // Block 1 — PNG Data URL → pixel array
+          {
+            opcode: 'pngToArray',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'PNG [URL] to pixel array',
+            arguments: {
+              URL: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'data:image/png;base64,...'
+              }
+            }
+          },
+
+          // Block 2 — pixel array → PNG Data URL
+          {
+            opcode: 'arrayToPng',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'array [ARRAY] width [W] height [H] to PNG',
+            arguments: {
+              ARRAY: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: '[16711680,65280,255]'
+              },
+              W: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 3
+              },
+              H: {
+                type: Scratch.ArgumentType.NUMBER,
+                defaultValue: 1
+              }
+            }
+          },
+
+          // Block 3 — read image dimensions
+          {
+            opcode: 'pngDimensions',
+            blockType: Scratch.BlockType.REPORTER,
+            text: 'dimensions of PNG [URL]',
+            arguments: {
+              URL: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: 'data:image/png;base64,...'
+              }
+            }
+          }
+        ]
+      };
+    }
+
+    // ── Block implementations ──────────────────────────────────────────────────
+
+    /**
+     * Decodes a PNG Data URL and returns a JSON array of 24-bit pixel integers.
+     *
+     * Output format: ["WxH", pixel0, pixel1, ...]
+     * The first element encodes the image dimensions so the array can be fed
+     * back into [arrayToPng] without specifying width/height manually.
+     */
+    async pngToArray({ URL }) {
+      let img;
+      try {
+        img = await loadImage(URL);
+      } catch {
+        return '[]';
+      }
+
+      const { width: w, height: h } = img;
+      const canvas = createCanvas(w, h);
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+
+      const { data } = ctx.getImageData(0, 0, w, h);
+      const pixels = rgbaToInt24Array(data);
+
+      return JSON.stringify([`${w}x${h}`, ...pixels]);
+    }
+
+    /**
+     * Encodes a JSON array of 24-bit integers into a PNG Data URL.
+     *
+     * Accepts arrays with or without the "WxH" header produced by [pngToArray].
+     * When W and H are both 0, dimensions are read from the header automatically.
+     */
+    arrayToPng(args) {
+      let arr;
+      try {
+        arr = JSON.parse(args.ARRAY);
+      } catch {
+        return '';
+      }
+      if (!Array.isArray(arr) || arr.length === 0) return '';
+
+      let w = Math.floor(Number(args.W));
+      let h = Math.floor(Number(args.H));
+
+      // Auto-detect the optional "WxH" header
+      if (typeof arr[0] === 'string' && /^\d+x\d+$/.test(arr[0])) {
+        const [dw, dh] = arr[0].split('x').map(Number);
+        if (w <= 0) w = dw;
+        if (h <= 0) h = dh;
+        arr = arr.slice(1);
+      }
+
+      if (w <= 0 || h <= 0) return '';
+
+      const canvas = createCanvas(w, h);
+      const ctx = canvas.getContext('2d');
+      const imgData = ctx.createImageData(w, h);
+
+      if (!int24ArrayToImageData(arr, imgData, w * h)) return '';
+
+      ctx.putImageData(imgData, 0, 0);
+      return canvas.toDataURL('image/png');
+    }
+
+    /**
+     * Returns the width and height of a PNG Data URL as "width height"
+     * (space-separated). Returns "0 0" on error.
+     */
+    async pngDimensions({ URL }) {
+      try {
+        const img = await loadImage(URL);
+        return `${img.width} ${img.height}`;
+      } catch {
+        return '0 0';
+      }
+    }
+  }
+
+  Scratch.extensions.register(new PixelBridge());
+})(Scratch);

--- a/extensions/pixelbridge.js
+++ b/extensions/pixelbridge.js
@@ -5,13 +5,13 @@
 // License: MIT
 
 (function (Scratch) {
-  'use strict';
+  "use strict";
 
   // ── Utilities ─────────────────────────────────────────────────────────────────
 
   /** Creates an off-screen canvas of the given size. */
   function createCanvas(w, h) {
-    const canvas = document.createElement('canvas');
+    const canvas = document.createElement("canvas");
     canvas.width = w;
     canvas.height = h;
     return canvas;
@@ -25,7 +25,7 @@
     return new Promise((resolve, reject) => {
       const img = new Image();
       img.onload = () => resolve(img);
-      img.onerror = () => reject(new Error('Invalid or corrupt image source.'));
+      img.onerror = () => reject(new Error("Invalid or corrupt image source."));
       img.src = src;
     });
   }
@@ -50,10 +50,10 @@
     if (arr.length < pixelCount) return false;
     for (let i = 0; i < pixelCount; i++) {
       const c = (Number(arr[i]) >>> 0) & 0xffffff;
-      imgData.data[i * 4]     = (c >> 16) & 0xff; // R
-      imgData.data[i * 4 + 1] = (c >>  8) & 0xff; // G
-      imgData.data[i * 4 + 2] =  c        & 0xff; // B
-      imgData.data[i * 4 + 3] = 255;               // A (fully opaque)
+      imgData.data[i * 4] = (c >> 16) & 0xff; // R
+      imgData.data[i * 4 + 1] = (c >> 8) & 0xff; // G
+      imgData.data[i * 4 + 2] = c & 0xff; // B
+      imgData.data[i * 4 + 3] = 255; // A (fully opaque)
     }
     return true;
   }
@@ -63,83 +63,81 @@
   class PixelBridge {
     getInfo() {
       return {
-        id: 'pixelbridge',
-        name: 'PixelBridge',
-        color1: '#5C4FCE',
-        color2: '#3D3491',
-        color3: '#2B2468',
+        id: "pixelbridge",
+        name: Scratch.translate("PixelBridge"),
+        color1: "#5C4FCE",
+        color2: "#3D3491",
+        color3: "#2B2468",
 
         blocks: [
           // Block 1 — PNG Data URL → pixel array
           {
-            opcode: 'pngToArray',
+            opcode: "pngToArray",
             blockType: Scratch.BlockType.REPORTER,
-            text: 'PNG [URL] to pixel array',
+            text: Scratch.translate("PNG [URL] to pixel array"),
             arguments: {
               URL: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: 'data:image/png;base64,...'
-              }
-            }
+                defaultValue: "data:image/png;base64,...",
+              },
+            },
           },
 
           // Block 2 — pixel array → PNG Data URL
           {
-            opcode: 'arrayToPng',
+            opcode: "arrayToPng",
             blockType: Scratch.BlockType.REPORTER,
-            text: 'array [ARRAY] width [W] height [H] to PNG',
+            text: Scratch.translate("array [ARRAY] width [W] height [H] to PNG"),
             arguments: {
               ARRAY: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: '[16711680,65280,255]'
+                defaultValue: "[16711680,65280,255]",
               },
               W: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: 3
+                defaultValue: 3,
               },
               H: {
                 type: Scratch.ArgumentType.NUMBER,
-                defaultValue: 1
-              }
-            }
+                defaultValue: 1,
+              },
+            },
           },
 
           // Block 3 — read image dimensions
           {
-            opcode: 'pngDimensions',
+            opcode: "pngDimensions",
             blockType: Scratch.BlockType.REPORTER,
-            text: 'dimensions of PNG [URL]',
+            text: Scratch.translate("dimensions of PNG [URL]"),
             arguments: {
               URL: {
                 type: Scratch.ArgumentType.STRING,
-                defaultValue: 'data:image/png;base64,...'
-              }
-            }
-          }
-        ]
+                defaultValue: "data:image/png;base64,...",
+              },
+            },
+          },
+        ],
       };
     }
 
-    // ── Block implementations ──────────────────────────────────────────────────
-
     /**
      * Decodes a PNG Data URL and returns a JSON array of 24-bit pixel integers.
-     *
      * Output format: ["WxH", pixel0, pixel1, ...]
-     * The first element encodes the image dimensions so the array can be fed
-     * back into [arrayToPng] without specifying width/height manually.
      */
     async pngToArray({ URL }) {
+      // eslint-disable-next-line extension/check-can-fetch
+      if (!(await Scratch.canFetch(URL))) return "[]";
+
       let img;
       try {
         img = await loadImage(URL);
       } catch {
-        return '[]';
+        return "[]";
       }
 
       const { width: w, height: h } = img;
       const canvas = createCanvas(w, h);
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext("2d");
       ctx.drawImage(img, 0, 0);
 
       const { data } = ctx.getImageData(0, 0, w, h);
@@ -150,52 +148,53 @@
 
     /**
      * Encodes a JSON array of 24-bit integers into a PNG Data URL.
-     *
-     * Accepts arrays with or without the "WxH" header produced by [pngToArray].
-     * When W and H are both 0, dimensions are read from the header automatically.
+     * Accepts arrays with or without the "WxH" header produced by pngToArray.
      */
     arrayToPng(args) {
       let arr;
       try {
         arr = JSON.parse(args.ARRAY);
       } catch {
-        return '';
+        return "";
       }
-      if (!Array.isArray(arr) || arr.length === 0) return '';
+      if (!Array.isArray(arr) || arr.length === 0) return "";
 
       let w = Math.floor(Number(args.W));
       let h = Math.floor(Number(args.H));
 
       // Auto-detect the optional "WxH" header
-      if (typeof arr[0] === 'string' && /^\d+x\d+$/.test(arr[0])) {
-        const [dw, dh] = arr[0].split('x').map(Number);
+      if (typeof arr[0] === "string" && /^\d+x\d+$/.test(arr[0])) {
+        const [dw, dh] = arr[0].split("x").map(Number);
         if (w <= 0) w = dw;
         if (h <= 0) h = dh;
         arr = arr.slice(1);
       }
 
-      if (w <= 0 || h <= 0) return '';
+      if (w <= 0 || h <= 0) return "";
 
       const canvas = createCanvas(w, h);
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext("2d");
       const imgData = ctx.createImageData(w, h);
 
-      if (!int24ArrayToImageData(arr, imgData, w * h)) return '';
+      if (!int24ArrayToImageData(arr, imgData, w * h)) return "";
 
       ctx.putImageData(imgData, 0, 0);
-      return canvas.toDataURL('image/png');
+      return canvas.toDataURL("image/png");
     }
 
     /**
-     * Returns the width and height of a PNG Data URL as "width height"
-     * (space-separated). Returns "0 0" on error.
+     * Returns the width and height of a PNG Data URL as "width height".
+     * Returns "0 0" on error.
      */
     async pngDimensions({ URL }) {
+      // eslint-disable-next-line extension/check-can-fetch
+      if (!(await Scratch.canFetch(URL))) return "0 0";
+
       try {
         const img = await loadImage(URL);
         return `${img.width} ${img.height}`;
       } catch {
-        return '0 0';
+        return "0 0";
       }
     }
   }

--- a/extensions/pixelbridge.js
+++ b/extensions/pixelbridge.js
@@ -87,7 +87,9 @@
           {
             opcode: "arrayToPng",
             blockType: Scratch.BlockType.REPORTER,
-            text: Scratch.translate("array [ARRAY] width [W] height [H] to PNG"),
+            text: Scratch.translate(
+              "array [ARRAY] width [W] height [H] to PNG"
+            ),
             arguments: {
               ARRAY: {
                 type: Scratch.ArgumentType.STRING,

--- a/extensions/pixelbridge/pixelbridge.md
+++ b/extensions/pixelbridge/pixelbridge.md
@@ -1,0 +1,94 @@
+# PixelBridge
+
+Convert PNG Data URLs to pixel arrays and reconstruct images from arrays.  
+Enables **pixel-level image manipulation** directly inside Scratch/TurboWarp projects — no external tools required.
+
+---
+
+## Blocks
+
+### `PNG [URL] to pixel array`
+Decodes a PNG Data URL and returns a **JSON array** of 24-bit RGB integers.
+
+| Position | Value | Example |
+|---|---|---|
+| `[0]` | Dimensions header `"WxH"` | `"320x240"` |
+| `[1…]` | One integer per pixel `(R<<16)\|(G<<8)\|B` | `16711680` = red |
+
+**Returns** `[]` if the URL is invalid or the image cannot be loaded.
+
+---
+
+### `array [ARRAY] width [W] height [H] to PNG`
+Encodes a JSON array of 24-bit RGB integers back into a PNG Data URL.
+
+- Accepts arrays **with or without** the `"WxH"` header produced by the block above.
+- If the header is present and `W`/`H` are both `0`, dimensions are read automatically — handy for a lossless round-trip.
+- **Returns** an empty string if the array is too short or dimensions are invalid.
+
+---
+
+### `dimensions of PNG [URL]`
+Returns the width and height of a PNG Data URL as `"width height"` (space-separated).  
+**Returns** `"0 0"` on error.
+
+---
+
+## Pixel format
+
+All pixel values are **24-bit unsigned integers** (RGB, no alpha):
+
+```
+color = (R << 16) | (G << 8) | B
+```
+
+| Color | Integer | Hex |
+|---|---|---|
+| Red | `16711680` | `0xFF0000` |
+| Green | `65280` | `0x00FF00` |
+| Blue | `255` | `0x0000FF` |
+| White | `16777215` | `0xFFFFFF` |
+| Black | `0` | `0x000000` |
+
+> **Note:** The alpha channel of the source image is ignored. All reconstructed pixels are fully opaque.
+
+---
+
+## Example usage
+
+### Read pixels from a costume
+
+```
+set [dataURL v] to (costume [costume1 v] as [png data url v])  ── using the Looks extension
+set [pixels v] to (PNG (dataURL) to pixel array)
+set [width v]  to (item (1 v) of (pixels) split by [ v])       ── parse "WxH" header
+```
+
+### Modify and rebuild
+
+```
+// Change pixel at index 42 to pure red
+replace item (43 v) of [pixels v] with [16711680]              ── index 1 = header, so pixel N is at N+1
+
+set [newImage v] to (array (pixels) width [0] height [0] to PNG)
+switch costume to (newImage)
+```
+
+### Create a solid-color image from scratch
+
+```
+// Build a 4×4 red image
+set [arr v] to []
+repeat (16)
+  add [16711680] to [arr v]
+end
+set [png v] to (array (arr) width [4] height [4] to PNG)
+```
+
+---
+
+## Notes
+
+- Large images (e.g. 480×360 = 172 800 pixels) produce large JSON strings. Consider downscaling images before processing if performance matters.
+- The `"WxH"` header is only added by the **PNG to array** block. Manually built arrays do not have it — always provide `W` and `H` explicitly in that case.
+- This extension uses the browser's built-in Canvas API and requires no network access.


### PR DESCRIPTION
**Add PixelBridge extension**

This extension provides pixel-level image manipulation between PNG Data URLs and integer arrays, combining two previously separate extensions into one cohesive tool.

**Blocks:**
- `PNG [URL] to pixel array` — Decodes a PNG Data URL into a JSON array of 24-bit RGB integers (`0xRRGGBB`), prefixed with a `"WxH"` dimension header for lossless round-trips.
- `array [ARRAY] width [W] height [H] to PNG` — Reconstructs a PNG Data URL from a 24-bit integer array. Automatically reads dimensions from the header if W and H are set to 0.
- `dimensions of PNG [URL]` — Returns the width and height of a PNG as `"width height"`.

**Design decisions:**
- Unified pixel format (24-bit integers) across all blocks, making the two conversion blocks directly compatible with each other.
- The `"WxH"` header embedded in the array output allows a full PNG → array → PNG round-trip without manually tracking dimensions.
- All processing is done via the browser's Canvas API — no network requests, no dependencies.

By Claude AI.