### PR TITLE
Harden generated gallery/docs HTML

### DIFF
--- a/development/builder.js
+++ b/development/builder.js
@@ -11,7 +11,7 @@ import compatibilityAliases from "./compatibility-aliases.js";
 import parseMetadata from "./parse-extension-metadata.js";
 import parseTranslations from "./parse-extension-translations.js";
 import renderTemplate from "./render-template.js";
-import renderDocs from "./render-docs.js";
+import renderDocs, { validateDocsMarkdown } from "./render-docs.js";
 import { mkdirp, recursiveReadDirectory } from "./fs-utils.js";
 import {
   fetchAllDependencies,
@@ -79,6 +79,21 @@ const filterTranslationsByID = (allTranslations, idFilter) => {
   }
 
   return stringsEmpty ? null : result;
+};
+
+const isScratchUserLink = (link) => {
+  try {
+    const url = new URL(link);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "scratch.mit.edu" &&
+      /^\/users\/[A-Za-z0-9_-]+\/?$/.test(url.pathname) &&
+      url.search === "" &&
+      url.hash === ""
+    );
+  } catch {
+    return false;
+  }
 };
 
 /**
@@ -268,10 +283,7 @@ class ExtensionFile extends BuildFile {
       if (!person.name) {
         throw new Error("Person is missing name");
       }
-      if (
-        person.link &&
-        !person.link.startsWith("https://scratch.mit.edu/users/")
-      ) {
+      if (person.link && !isScratchUserLink(person.link)) {
         throw new Error(
           `Link for ${person.name} does not point to a Scratch user`
         );
@@ -591,6 +603,10 @@ class DocsFile extends BuildFile {
   async read() {
     const markdown = (await super.read()).toString("utf-8");
     return renderDocs(markdown, this.extensionSlug);
+  }
+
+  async validate() {
+    validateDocsMarkdown((await super.read()).toString("utf-8"));
   }
 
   getType() {

--- a/development/parse-extension-metadata.js
+++ b/development/parse-extension-metadata.js
@@ -1,3 +1,11 @@
+const escapeHTML = (value) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
 class Person {
   constructor(name, link) {
     /** @type {string} */
@@ -7,11 +15,11 @@ class Person {
   }
 
   toHTML() {
-    // Don't need to bother escaping here. There's no vulnerability.
+    const escapedName = escapeHTML(this.name);
     if (this.link) {
-      return `<a href="${this.link}">${this.name}</a>`;
+      return `<a href="${escapeHTML(this.link)}">${escapedName}</a>`;
     }
-    return this.name;
+    return escapedName;
   }
 }
 

--- a/development/render-docs.js
+++ b/development/render-docs.js
@@ -17,6 +17,12 @@ const md = new MarkdownIt({
   breaks: true,
 });
 
+const validationMd = new MarkdownIt({
+  html: true,
+  linkify: true,
+  breaks: true,
+});
+
 md.renderer.rules.fence = function (tokens, idx, options, env, self) {
   const token = tokens[idx];
 
@@ -101,6 +107,44 @@ md.block.ruler.before(
     return true;
   }
 );
+
+const SAFE_HTML_PATTERNS = [
+  /^<a name="[A-Za-z0-9_-]+">$/i,
+  /^<\/a>$/i,
+  /^<br\s*\/?>$/i,
+  /^<br\/><br\/>$/i,
+  /^<sup>$/i,
+  /^<\/sup>$/i,
+  /^<u>$/i,
+  /^<\/u>$/i,
+  /^<div class="alert alert-(note|tip|important|warning|caution)">$/i,
+  /^<\/div>$/i,
+];
+
+const isSafeHTML = (html) =>
+  SAFE_HTML_PATTERNS.some((pattern) => pattern.test(html.trim()));
+
+const validateTokenHTML = (tokens) => {
+  for (const token of tokens) {
+    if (
+      (token.type === "html_inline" || token.type === "html_block") &&
+      !isSafeHTML(token.content)
+    ) {
+      throw new Error(`Unsafe HTML in Markdown docs: ${token.content.trim()}`);
+    }
+    if (token.children) {
+      validateTokenHTML(token.children);
+    }
+  }
+};
+
+/**
+ * @param {string} markdownSource Markdown code
+ */
+export const validateDocsMarkdown = (markdownSource) => {
+  const env = {};
+  validateTokenHTML(validationMd.parse(markdownSource, env));
+};
 
 /**
  * @param {string} markdownSource Markdown code


### PR DESCRIPTION
# Harden generated gallery/docs HTML

## Summary

- Escape extension metadata person names and profile links before rendering them
  into the gallery homepage.
- Tighten Scratch profile link validation to accept only well-formed
  `https://scratch.mit.edu/users/<username>/` links.
- Validate raw HTML in markdown docs and allow only the small set of tags already
  used by the current documentation.

## Verification

- `npm run validate`
- `npm run lint`
- `npm run check-format`
- `npm run build`

## Disclosure Note

This PR intentionally avoids exploit details. The corresponding private report
contains the reproduction steps and impact analysis.
