### PR TITLE
NishiOwO/dectalk: a couple fixes

### DIFF
--- a/extensions/NishiOwO/dectalk.js
+++ b/extensions/NishiOwO/dectalk.js
@@ -1,8 +1,9 @@
-// Name: DECtalk
+// Name: DECtalk Text to Speech
 // ID: nishiowoDectalk
-// Description: Use DECtalk.
+// Description: Text to speech powered by DECtalk. Does not use an internet connection, so it works offline. English only.
 // By: NishiOwO
 // License: BSD-3-Clause
+// Context: Don't translate "DECtalk" - it's the name of the text-to-speech library.
 
 // Repository is at https://github.com/dectalk/tw-dectalk
 
@@ -50,7 +51,7 @@
 
       return {
         id: "nishiowoDectalk",
-        name: Scratch.translate("DECtalk"),
+        name: Scratch.translate("DECtalk Text to Speech"),
         blockIconURI: blockIconURI,
         color1: "#b3353f",
         blocks: [
@@ -61,6 +62,7 @@
             arguments: {
               WORDS: {
                 type: Scratch.ArgumentType.STRING,
+                // Don't translate - the TTS library needs English to work well
                 defaultValue: "Hello",
               },
             },

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -95,10 +95,10 @@
   "veggiecan/LongmanDictionary",
   "CubesterYT/TurboHook",
   "Alestore/nfcwarp",
+  "NishiOwO/dectalk",
   "steamworks",
   "itchio",
   "gamejolt",
   "obviousAlexC/newgroundsIO",
-  "NishiOwO/dectalk",
   "Lily/McUtils" // McUtils should always be the last item.
 ]

--- a/licenses/BSD-3-Clause.txt
+++ b/licenses/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2026 TurboWarp Extensions Contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
- rename, elaborate in description
- instruct translators to not do anything funny with "DECtalk"
- first BSD3c so we should add the license txt
