### PR TITLE
Clay/htmlEncode: change credit to not be a website

### DIFF
--- a/extensions/Clay/htmlEncode.js
+++ b/extensions/Clay/htmlEncode.js
@@ -1,7 +1,7 @@
 // Name: HTML Encode
 // ID: clayhtmlencode
 // Description: Escape untrusted text to safely include in HTML.
-// By: clay.rip
+// By: clay-rip
 // License: MIT
 
 (function (Scratch) {


### PR DESCRIPTION
well, less obviously a website, anyway

this is a bit rather silly. just being extra safe