### PR TITLE
TheShovel/CanvasEffects: don't scale render size block by DPI

### DIFF
--- a/extensions/TheShovel/CanvasEffects.js
+++ b/extensions/TheShovel/CanvasEffects.js
@@ -505,7 +505,7 @@
     renderscale({ X, Y }) {
       // The function normally expects a stage size and therefore scales by DPI.
       // However, this block is meant for a fixed pixel size
-      // (usually used in cojunction with the pixelated resize rendering mode).
+      // (usually used in conjunction with the pixelated resize rendering mode).
       // Therefore, scale it back according to the devicePixelRatio.
       const pixelRatio = window.devicePixelRatio || 1;
       Scratch.vm.renderer.resize(X / pixelRatio, Y / pixelRatio);

--- a/extensions/TheShovel/CanvasEffects.js
+++ b/extensions/TheShovel/CanvasEffects.js
@@ -503,7 +503,12 @@
       updateStyle();
     }
     renderscale({ X, Y }) {
-      Scratch.vm.renderer.resize(X, Y);
+      // The function normally expects a stage size and therefore scales by DPI.
+      // However, this block is meant for a fixed pixel size
+      // (usually used in cojunction with the pixelated resize rendering mode).
+      // Therefore, scale it back according to the devicePixelRatio.
+      const pixelRatio = window.devicePixelRatio || 1;
+      Scratch.vm.renderer.resize(X / pixelRatio, Y / pixelRatio);
     }
     setBorder(args) {
       borderWidth = Scratch.Cast.toNumber(args.WIDTH);


### PR DESCRIPTION
It's probably more expected behavior for the block to keep a fixed resolution than for it to scale with browser zoom and DPI.
(e.g it's probably often used for pixelated games that keep a resolution)

Before:
https://github.com/user-attachments/assets/fc01c2cf-c3c6-43d3-99e4-e1dd5f4376ca

After:
https://github.com/user-attachments/assets/d45b25a9-5e7e-4d77-953c-666866434446