### PR TITLE
rixxyx, text, encoding: fix errors

### DIFF
--- a/extensions/encoding.js
+++ b/extensions/encoding.js
@@ -618,6 +618,9 @@
     }
     Randomstrings({ position }) {
       position = Scratch.Cast.toNumber(position) || 32;
+      if (!Number.isFinite(position)) {
+        return "";
+      }
       let t = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
       let a = t.length;
       let string = "";
@@ -628,6 +631,9 @@
     }
     Fontgenerationstring({ wordbank, position }) {
       position = Scratch.Cast.toNumber(position) || 32;
+      if (!Number.isFinite(position)) {
+        return "";
+      }
       let t = String(wordbank);
       let a = t.length;
       let string = "";

--- a/extensions/rixxyx.js
+++ b/extensions/rixxyx.js
@@ -248,6 +248,7 @@
             },
           },
           {
+            hideFromPalette: true,
             opcode: "returnNum",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("[NUM] as number"),

--- a/extensions/rixxyx.js
+++ b/extensions/rixxyx.js
@@ -461,7 +461,11 @@
         .join(" ");
     }
     repeatTxtTimes(args) {
-      return Scratch.Cast.toString(args.TEXT).repeat(Math.floor(args.NUM));
+      const times = Math.floor(Scratch.Cast.toNumber(args.NUM));
+      if (times < 0 || !Number.isFinite(times)) {
+        return "";
+      }
+      return Scratch.Cast.toString(args.TEXT).repeat(times);
     }
     jsonParse(args) {
       try {

--- a/extensions/text.js
+++ b/extensions/text.js
@@ -611,7 +611,10 @@
 
     repeat(args, util) {
       const string = Scratch.Cast.toString(args.STRING);
-      const repeat = Scratch.Cast.toNumber(args.REPEAT);
+      const repeat = Math.floor(Scratch.Cast.toNumber(args.REPEAT));
+      if (repeat < 0 || !Number.isFinite(repeat)) {
+        return "";
+      }
       return string.repeat(repeat);
     }
 


### PR DESCRIPTION
 - rixxyx: hide returnNum because it's not useful at all - just use the floor block - and the description is entirely ambiguous
 - rixxyx: prevent error in the repeat block on negative or infinite count
 - text: prevent error in the repeat block on negative or infinite count
 - encoding: prevent infinite loop in random string blocks on infinite count