### PR TITLE
SamuelLouf/Geolocation: mark as not supported in desktop app

### DIFF
--- a/extensions/SamuelLouf/Geolocation.js
+++ b/extensions/SamuelLouf/Geolocation.js
@@ -95,7 +95,7 @@
    * @returns {boolean}
    */
   function isElectron() {
-    return navigator.userAgent.includes('Electron');
+    return navigator.userAgent.includes("Electron");
   }
 
   /**
@@ -134,12 +134,14 @@
         color3: "#04C825",
         menuIconURI,
         blocks: [
-          ...(isElectron() ? [
-            {
-              blockType: Scratch.BlockType.LABEL,
-              text: Scratch.translate('Not supported in desktop app'),
-            },
-          ] : []),
+          ...(isElectron()
+            ? [
+                {
+                  blockType: Scratch.BlockType.LABEL,
+                  text: Scratch.translate("Not supported in desktop app"),
+                },
+              ]
+            : []),
           {
             opcode: "isSupported",
             blockType: Scratch.BlockType.BOOLEAN,

--- a/extensions/SamuelLouf/Geolocation.js
+++ b/extensions/SamuelLouf/Geolocation.js
@@ -1,6 +1,6 @@
 // Name: Geolocation
 // ID: samuelloufgeolocation
-// Description: Get the user's current location (requires permission from browser).
+// Description: Get the user's current location (requires permission from browser). Not supported in desktop app or Electron packaged projects.
 // By: SamuelLouf <https://scratch.mit.edu/users/samuellouf/>
 // License: MIT
 
@@ -92,11 +92,24 @@
   }
 
   /**
+   * @returns {boolean}
+   */
+  function isElectron() {
+    return navigator.userAgent.includes('Electron');
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  function isSupported() {
+    return !!navigator.geolocation && !isElectron();
+  }
+
+  /**
    * @returns {Promise<boolean>}
    */
   async function canGeolocate() {
-    const supported = !!navigator.geolocation;
-    if (!supported) {
+    if (!isSupported()) {
       return false;
     }
 
@@ -121,6 +134,12 @@
         color3: "#04C825",
         menuIconURI,
         blocks: [
+          ...(isElectron() ? [
+            {
+              blockType: Scratch.BlockType.LABEL,
+              text: Scratch.translate('Not supported in desktop app'),
+            },
+          ] : []),
           {
             opcode: "isSupported",
             blockType: Scratch.BlockType.BOOLEAN,
@@ -272,7 +291,7 @@
     }
 
     isSupported() {
-      return !!navigator.geolocation;
+      return isSupported();
     }
 
     setTimeoutTo(args) {


### PR DESCRIPTION
In Electron, the geolocation APIs don't work unless we provide a GOOGLE_API_KEY with billing enabled for Google to charge per request. This key has to be embedded in plain text in every copy of the desktop app too, so it's public and anyone could start putting a lot of usage on it overnight. Don't really want to fund that, so it's just not going to work there. That'll include the desktop app and packaged Electron projects.

For the desktop app, making this work on macOS would also probably require the location services entitlement. I don't really want to try explaining to App Store Review why the app needs location services without having some good explanation of what people are doing with this thing.