### PR TITLE
ar: fix getMatrixItem bounds check

### DIFF
--- a/extensions/ar.js
+++ b/extensions/ar.js
@@ -774,7 +774,7 @@
     }
     getMatrixItem(args) {
       let item = args.ITEM | 0;
-      if (item < 1 && item > 16) return "";
+      if (item < 1 || item > 16) return "";
       let matrix = null;
       switch (args.MATRIX) {
         case "combined":


### PR DESCRIPTION
Previously, it would return 0. Now it will return empty string, which makes more sense for out of bounds.