### PR TITLE
Remove extension-reviewer codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # If multiple rules match, only the last one applies. File names are case sensitive.
 
 # Fallback for everything not mentioned
-* @turbowarp/admins
+* @GarboMuffin
 
 # Allow extension reviewers to approve these changes without additional codeowner
 /extensions

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,22 +3,11 @@
 # If multiple rules match, only the last one applies. File names are case sensitive.
 
 # Fallback for everything not mentioned
-* @TurboWarp/extension-reviewers
+* @turbowarp/admins
 
-# This file itself
-CODEOWNERS @GarboMuffin
-
-# I want to take a look at these
-/.github @GarboMuffin @TurboWarp/extension-reviewers
-/extension-dependencies.json @GarboMuffin @TurboWarp/extension-reviewers
-/development @GarboMuffin @TurboWarp/extension-reviewers
-/build-snippets @GarboMuffin @TurboWarp/extension-reviewers
-/website @GarboMuffin @TurboWarp/extension-reviewers
-/README.md @GarboMuffin @TurboWarp/extension-reviewers
-/CONTRIBUTING.md @GarboMuffin @TurboWarp/extension-reviewers
-/REVIEW_PROCESS.md @GarboMuffin @TurboWarp/extension-reviewers
-
-# Automated changes that don't need to request review from every reviewer
-/package.json @GarboMuffin
-/package-lock.json @GarboMuffin
-/translations @GarboMuffin
+# Allow extension reviewers to approve these changes without additional codeowner
+/extensions
+/docs
+/images
+/samples
+/translations


### PR DESCRIPTION
Apparently GitHub just sent out 147 emails because of this thing, so we're going to stop using it now