### PR TITLE
cloudlink: hide version number block because it doesn't mean anything

### DIFF
--- a/extensions/cloudlink.js
+++ b/extensions/cloudlink.js
@@ -894,6 +894,7 @@
           "---",
 
           {
+            hideFromPalette: true,
             opcode: "returnVersionData",
             blockType: Scratch.BlockType.REPORTER,
             text: Scratch.translate("extension version"),


### PR DESCRIPTION
- It was last updated two years ago
- There's no reason for a project to care about this anyway
